### PR TITLE
booth: fix progress bar when booth is empty

### DIFF
--- a/src/components/HeaderBar/Progress.js
+++ b/src/components/HeaderBar/Progress.js
@@ -1,10 +1,8 @@
 import cx from 'classnames';
 import React from 'react';
 
-const Progress = ({ className, duration, startTime, currentTime }) => {
-  const elapsed = Math.round((currentTime - startTime) / 1000);
-  const percent = elapsed / duration;
-  const width = isNaN(percent) ? '0%' : `${percent * 100}%`;
+const Progress = ({ className, percent }) => {
+  const width = isFinite(percent) ? `${percent * 100}%` : '0%';
   return (
     <div className={cx('Progress', className)}>
       <div className="Progress-fill" style={{ width: width }} />

--- a/src/components/HeaderBar/index.js
+++ b/src/components/HeaderBar/index.js
@@ -8,12 +8,10 @@ export default class HeaderBar extends Component {
   static propTypes = {
     className: PropTypes.string,
     title: PropTypes.string,
-    currentTime: PropTypes.number,
 
     dj: PropTypes.object,
     media: PropTypes.object,
-    mediaDuration: PropTypes.number,
-    mediaStartTime: PropTypes.number,
+    mediaProgress: PropTypes.number,
     volume: PropTypes.number,
     muted: PropTypes.bool,
 
@@ -24,8 +22,8 @@ export default class HeaderBar extends Component {
 
   render() {
     const {
-      className, title, currentTime,
-      dj, media, mediaDuration, mediaStartTime,
+      className, title,
+      dj, media, mediaProgress,
       volume, muted,
       onVolumeChange, onVolumeMute, onVolumeUnmute,
       ...props
@@ -54,9 +52,7 @@ export default class HeaderBar extends Component {
         )}
         <Progress
           className="HeaderBar-progress"
-          duration={mediaDuration}
-          startTime={mediaStartTime}
-          currentTime={currentTime}
+          percent={mediaProgress}
         />
         <div className="HeaderBar-volume">
           <Volume

--- a/src/containers/HeaderBar.js
+++ b/src/containers/HeaderBar.js
@@ -4,17 +4,14 @@ import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { setVolume, mute, unmute } from '../actions/PlaybackActionCreators';
 
-import { djSelector, startTimeSelector, mediaSelector, mediaDurationSelector } from '../selectors/boothSelectors';
-import { currentTimeSelector } from '../selectors/timeSelectors';
+import { djSelector, mediaSelector, mediaProgressSelector } from '../selectors/boothSelectors';
 import { volumeSelector, isMutedSelector } from '../selectors/settingSelectors';
 import HeaderBar from '../components/HeaderBar';
 
 const mapStateToProps = createStructuredSelector({
-  mediaStartTime: startTimeSelector,
-  mediaDuration: mediaDurationSelector,
+  mediaProgress: mediaProgressSelector,
   media: mediaSelector,
   dj: djSelector,
-  currentTime: currentTimeSelector,
   volume: volumeSelector,
   muted: isMutedSelector
 });

--- a/src/selectors/boothSelectors.js
+++ b/src/selectors/boothSelectors.js
@@ -6,7 +6,7 @@ const baseSelector = state => state.booth;
 
 const historyIDSelector = createSelector(baseSelector, booth => booth.historyID);
 export const mediaSelector = createSelector(baseSelector, booth => booth.media);
-export const startTimeSelector = createSelector(baseSelector, booth => booth.startTime);
+export const startTimeSelector = createSelector(baseSelector, booth => booth.startTime || 0);
 
 export const mediaDurationSelector = createSelector(
   mediaSelector,
@@ -24,6 +24,12 @@ export const timeRemainingSelector = createSelector(
   mediaDurationSelector,
   timeElapsedSelector,
   (duration, elapsed) => duration > 0 ? duration - elapsed : 0
+);
+
+export const mediaProgressSelector = createSelector(
+  mediaDurationSelector,
+  timeElapsedSelector,
+  (duration, elapsed) => duration ? elapsed / duration : 0
 );
 
 export const djSelector = createSelector(


### PR DESCRIPTION
Previously, an empty booth would set the progress bar size
to "Infinity%", which caused browsers to keep it at its previous
position.

This patch moves the progress computation to a selector, which is
where computations are supposed to happen in the first place. It
also deals with media durations of 0 (and thus empty booths) by
defaulting the progress bar width to "0%".
