### PR TITLE
users: pass user object to UserList rows instead of ...spread

### DIFF
--- a/src/components/UserList/UserRow.js
+++ b/src/components/UserList/UserRow.js
@@ -2,7 +2,7 @@ import cx from 'classnames';
 import React from 'react';
 import Avatar from '../Avatar';
 
-const UserRow = ({ className, ...user }) => {
+const UserRow = ({ className, user }) => {
   return (
     <div className={cx('UserRow', className)}>
       <Avatar

--- a/src/components/UserList/index.js
+++ b/src/components/UserList/index.js
@@ -12,7 +12,7 @@ const UserList = ({ className, users }) => {
           <UserRow
             key={key}
             className="UserList-row"
-            {...users[index]}
+            user={users[index]}
           />
         )}
         length={users.length}


### PR DESCRIPTION
Spreading seems to cause issues with Babel 6, and just passing the object itself is also faster/cleaner.
