### PR TITLE
deps: use `router` & `serve-static` instead of forcing express

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "redux-logger": "^2.0.4",
     "redux-thunk": "^1.0.0",
     "reselect": "^2.0.1",
+    "router": "^1.1.4",
+    "serve-static": "^1.10.2",
     "soundcloud-audio": "^0.1.6",
     "truncate-url": "^0.1.2",
     "whatwg-fetch": "^0.10.0"

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,13 +1,7 @@
-function getExpress() {
-  try {
-    return require('express');
-  } catch (e) {
-    throw new Error('Could not find express');
-  }
-}
+import router from 'router';
+import serveStatic from 'serve-static';
 
 export default function uwaveWebClient(basePath = __dirname) {
-  const express = getExpress();
-  return express.Router() // eslint-disable-line new-cap
-    .use(express.static(basePath));
+  return router()
+    .use(serveStatic(basePath));
 }


### PR DESCRIPTION
Most of what express gives (templating etc.) is not really necessary for the web client, except routing and serving.
