### PR TITLE
history: add dedicated history button, fixes #120

### DIFF
--- a/src/components/HeaderBar/HistoryButton.js
+++ b/src/components/HeaderBar/HistoryButton.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import IconButton from 'material-ui/lib/icon-button';
+import HistoryIcon from 'material-ui/lib/svg-icons/action/history';
+
+const fullSize = { width: '100%', height: '100%' };
+
+const HistoryButton = ({ onClick }) => (
+  <IconButton
+    className="HeaderHistoryButton"
+    style={fullSize}
+    tooltip="Play History"
+    tooltipPosition="bottom-center"
+    onClick={onClick}
+  >
+    <HistoryIcon
+      style={fullSize}
+      color="#fff"
+      className="HeaderHistoryButton-icon"
+    />
+  </IconButton>
+);
+
+export default HistoryButton;

--- a/src/components/HeaderBar/index.css
+++ b/src/components/HeaderBar/index.css
@@ -22,17 +22,26 @@
 
   @descendent volume {
     position: absolute;
-    right: 0;
+    right: $header-height;
     top: 0;
     width: 200px;
     padding: 15px;
+  }
+
+  @descendent history {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: $header-height;
+    background: #111;
   }
 
   @descendent now-playing {
     position: absolute;
     top: 5px;
     left: 250px;
-    right: 200px;
+    right: calc(200px + $header-height);
     line-height: 25px;
   }
 

--- a/src/components/HeaderBar/index.js
+++ b/src/components/HeaderBar/index.js
@@ -1,8 +1,10 @@
 import cx from 'classnames';
 import React, { Component, PropTypes } from 'react';
+
 import Progress from './Progress';
 import SongTitle from '../SongTitle';
 import Volume from './Volume';
+import HistoryButton from './HistoryButton';
 
 export default class HeaderBar extends Component {
   static propTypes = {
@@ -44,16 +46,14 @@ export default class HeaderBar extends Component {
         {...props}
       >
         <h1 className="HeaderBar-title">{title}</h1>
-        <div onClick={onToggleRoomHistory}>
-          <div className="HeaderBar-now-playing">
-            {nowPlaying}
-          </div>
-          {dj && (
-            <div className="HeaderBar-dj">
-              played by: {dj.username}
-            </div>
-          )}
+        <div className="HeaderBar-now-playing">
+          {nowPlaying}
         </div>
+        {dj && (
+          <div className="HeaderBar-dj">
+            played by: {dj.username}
+          </div>
+        )}
         <Progress
           className="HeaderBar-progress"
           percent={mediaProgress}
@@ -66,6 +66,9 @@ export default class HeaderBar extends Component {
             onMute={onVolumeMute}
             onUnmute={onVolumeUnmute}
           />
+        </div>
+        <div className="HeaderBar-history">
+          <HistoryButton onClick={onToggleRoomHistory} />
         </div>
       </div>
     );


### PR DESCRIPTION
Currently:

![](http://i.imgur.com/BpQotwJ.png)

Looks a bit off, because there's a "double" margin between the history icon and the volume slider.

When i add the background colour as shown in https://github.com/goto-bus-stop/u-wave-web/issues/120#issuecomment-175775321, it'll look a bit more like:

![](http://i.imgur.com/6Fbof47.png)

That's the same colour as an active chat tab, though.

Even brighter:

![](http://i.imgur.com/HTsIawz.png)

Also not great 😧

TODO:
- [x] Default background colour to #1111111
