### PR TITLE
playlists: fix active playlist check mark size, closes #105

### DIFF
--- a/src/components/AddToPlaylistMenu/index.js
+++ b/src/components/AddToPlaylistMenu/index.js
@@ -1,6 +1,5 @@
 import find from 'array-find';
 import React, { Component, PropTypes } from 'react';
-import ActiveIcon from 'material-ui/lib/svg-icons/navigation/check';
 import Menu from 'material-ui/lib/menus/menu';
 import MenuItem from 'material-ui/lib/menus/menu-item';
 import RenderToLayer from 'material-ui/lib/render-to-layer';
@@ -68,7 +67,7 @@ export default class AddToPlaylistMenu extends Component {
               value={playlist._id}
               primaryText={playlist.name}
               secondaryText={`${playlist.size || 0}`}
-              leftIcon={playlist.active ? <ActiveIcon style={{ width: 48, height: 48 }} /> : null}
+              checked={!!playlist.active}
             />
           ))}
         </Menu>


### PR DESCRIPTION
Using `checked` property instead of `leftIcon`.
