### PR TITLE
video: speed up loading the first youtube video

### DIFF
--- a/src/components/Video/YouTubePlayer/Embed.js
+++ b/src/components/Video/YouTubePlayer/Embed.js
@@ -38,6 +38,7 @@ export default class YouTubePlayerEmbed extends React.Component {
     const { media, seek } = this.props;
 
     const opts = {
+      videoId: media.sourceID,
       width: '100%',
       height: '100%',
       playerVars: {


### PR DESCRIPTION
Instead of first loading the YT API and initialising the iframe,
and _then_ queueing the first video, this queues the video
instantly before initialising the iframe. The YT API will then
initialise the iframe with the video preloaded, saving about 2 or
3 seconds of loading time.
