### PR TITLE
Revert "video: speed up loading the first youtube video"

### DIFF
--- a/src/components/Video/YouTubePlayer/Embed.js
+++ b/src/components/Video/YouTubePlayer/Embed.js
@@ -38,7 +38,6 @@ export default class YouTubePlayerEmbed extends React.Component {
     const { media, seek } = this.props;
 
     const opts = {
-      videoId: media.sourceID,
       width: '100%',
       height: '100%',
       playerVars: {


### PR DESCRIPTION
This was causing the YouTube iframe to rerender on every advance, breaking loading on Chrome.
