### PR TITLE
video: hide YouTube player when inactive

### DIFF
--- a/src/components/Video/YouTubePlayer/index.js
+++ b/src/components/Video/YouTubePlayer/index.js
@@ -16,21 +16,21 @@ export default class YouTubePlayer extends React.Component {
   };
 
   render() {
-    const { className, enabled, size, media } = this.props;
+    const { active, className, enabled, size, media } = this.props;
     const sizeClass = `YouTubePlayer--${size}`;
 
     let backdrop;
-    if (size === 'small') {
+    if (active && size === 'small') {
       backdrop = <VideoBackdrop url={media.thumbnail} />;
     }
     // Wrapper span so the backdrop can be full-size…
     return (
-      <span>
+      <span hidden={!active}>
         {backdrop}
         <div className={cx('YouTubePlayer', sizeClass, className)}>
           {enabled && <YouTubePlayerEmbed
             media={media}
-            active={this.props.active}
+            active={active}
             seek={this.props.seek}
             volume={this.props.volume}
           />}

--- a/src/components/Video/index.js
+++ b/src/components/Video/index.js
@@ -54,5 +54,4 @@ export default class Video extends Component {
       </div>
     );
   }
-
 }


### PR DESCRIPTION
Fixes the YouTube player showing in an errored state during not-YouTube plays:

![Screenshot](http://i.imgur.com/ImWhiTG.png)
