### PR TITLE
playlists: simplify playlists reducer

### DIFF
--- a/src/selectors/playlistSelectors.js
+++ b/src/selectors/playlistSelectors.js
@@ -11,14 +11,20 @@ export const playlistsSelector = createSelector(
   playlists => values(playlists.playlists).sort(byName)
 );
 
+const playlistItemsSelector = createSelector(
+  baseSelector,
+  playlists => playlists.playlistItems
+);
+
 export const activePlaylistIDSelector = createSelector(
   baseSelector,
   playlists => playlists.activePlaylistID
 );
 
 const activeMediaSelector = createSelector(
-  baseSelector,
-  playlists => playlists.activeMedia
+  playlistItemsSelector,
+  activePlaylistIDSelector,
+  (playlistItems, activePlaylist) => playlistItems[activePlaylist]
 );
 
 function mergePlaylistItems(playlist, playlistItems) {
@@ -45,8 +51,9 @@ export const selectedPlaylistIDSelector = createSelector(
 );
 
 const selectedMediaSelector = createSelector(
-  baseSelector,
-  playlists => playlists.selectedMedia
+  playlistItemsSelector,
+  selectedPlaylistIDSelector,
+  (playlistItems, selectedPlaylist) => playlistItems[selectedPlaylist]
 );
 
 export const selectedPlaylistSelector = createSelector(


### PR DESCRIPTION
Hopefully makes things a bit easier to understand, by pulling the trickier deep updates into a new function, and by keeping playlist items for each playlist in a single object `{ [playlistID]: items }` instead of two arrays (`activeMedia`, `selectedMedia`).

Todo, maybe: keep playlistItem objects in a separate object entirely, doing something like

```
playlistItems: { [playlistItemID]: item }
```

and then keeping the playlistItemIDs in a `media` property on playlist objects. Basically, like how it's done server-side.
