### PR TITLE
booth: load existing votes into store on join

### DIFF
--- a/src/actions/LoginActionCreators.js
+++ b/src/actions/LoginActionCreators.js
@@ -14,6 +14,7 @@ import {
 import { closeLoginDialog } from './DialogActionCreators';
 import { syncTimestamps } from './TickerActionCreators';
 import { setUsers } from './UserActionCreators';
+import { setVoteStats } from './VoteActionCreators';
 import { setWaitList } from './WaitlistActionCreators';
 import { currentUserSelector, tokenSelector } from '../selectors/userSelectors';
 
@@ -41,6 +42,7 @@ export function loadedState(state) {
     if (state.booth) {
       // TODO don't set this when logging in _after_ entering the page?
       dispatch(advance(state.booth));
+      dispatch(setVoteStats(state.booth.stats));
     }
     if (state.user) {
       const token = tokenSelector(getState());

--- a/src/actions/VoteActionCreators.js
+++ b/src/actions/VoteActionCreators.js
@@ -6,12 +6,20 @@ import { sendVote } from '../utils/Socket';
 
 import { OPEN_ADD_MEDIA_MENU } from '../constants/actionTypes/playlists';
 import {
+  LOAD_VOTES,
   FAVORITE, UPVOTE, DOWNVOTE,
   DO_FAVORITE_START, DO_FAVORITE_COMPLETE,
   DO_UPVOTE, DO_DOWNVOTE
 } from '../constants/actionTypes/votes';
 
 import { addMediaStart, addMediaComplete, flattenPlaylistItem } from './PlaylistActionCreators';
+
+export function setVoteStats(voteStats) {
+  return {
+    type: LOAD_VOTES,
+    payload: voteStats
+  };
+}
 
 export function favorited({ userID, historyID }) {
   return {

--- a/src/constants/actionTypes/votes.js
+++ b/src/constants/actionTypes/votes.js
@@ -1,3 +1,4 @@
+export const LOAD_VOTES = 'votes/LOAD_VOTES';
 export const UPVOTE = 'votes/UPVOTE';
 export const DOWNVOTE = 'votes/DOWNVOTE';
 export const FAVORITE = 'votes/FAVORITE';

--- a/src/reducers/votes.js
+++ b/src/reducers/votes.js
@@ -1,5 +1,6 @@
 import { ADVANCE } from '../constants/actionTypes/booth';
 import {
+  LOAD_VOTES,
   FAVORITE, UPVOTE, DOWNVOTE,
   DO_FAVORITE_START, DO_FAVORITE_COMPLETE
 } from '../constants/actionTypes/votes';
@@ -15,6 +16,13 @@ export default function reduce(state = initialState, action = {}) {
   switch (type) {
   case ADVANCE:
     return initialState;
+  case LOAD_VOTES:
+    return {
+      ...state,
+      upvotes: payload.upvotes,
+      downvotes: payload.downvotes,
+      favorites: payload.favorites
+    };
   case UPVOTE:
     return {
       ...state,


### PR DESCRIPTION
Fixes votes always displaying "0 / 0 / 0" when just joining.
