### PR TITLE
Prevent relayouts in progress bar animation

### DIFF
--- a/src/components/HeaderBar/Progress.css
+++ b/src/components/HeaderBar/Progress.css
@@ -4,6 +4,9 @@
   @descendent fill {
     background: $highlight-color;
     height: 100%;
-    transition: width 1s linear;
+    width: 100%;
+    transform: scaleX(0);
+    transform-origin: top left;
+    transition: transform 1s linear;
   }
 }

--- a/src/components/HeaderBar/Progress.js
+++ b/src/components/HeaderBar/Progress.js
@@ -2,10 +2,16 @@ import cx from 'classnames';
 import React from 'react';
 
 const Progress = ({ className, percent }) => {
-  const width = isFinite(percent) ? `${percent * 100}%` : '0%';
+  const width = isFinite(percent) ? percent : 0;
   return (
     <div className={cx('Progress', className)}>
-      <div className="Progress-fill" style={{ width }} />
+      <div
+        className="Progress-fill"
+        style={{
+          transform: `scaleX(${width})`,
+          webkitTransform: `scaleX(${width})`
+        }}
+      />
     </div>
   );
 };


### PR DESCRIPTION
Animating the `width` property causes browsers to recalculate layouts all the time, and the `transform` property does not.
