### PR TITLE
build: remove redis & mongo options from default "serve" config

### DIFF
--- a/tasks/dev-server-config.json
+++ b/tasks/dev-server-config.json
@@ -1,8 +1,5 @@
 {
-  "server": { "port": 6041, "slave": true },
-  "mongo": { "host": "localhost" },
-  "redis": {},
-  "cert": "./tasks/dev-test-secret.txt",
+  "server": { "port": 6041 },
   "keys": {
     "youtube": "AIzaSyAlDfeXOvAM1bIYm4kCtAiXOVdeKutdx8I",
     "soundcloud": "9d883cdd4c3c54c6dddda2a5b3a11200"


### PR DESCRIPTION
The server components have good defaults for this now, and the
custom options format that is used in this file is no longer
supported.
