### PR TITLE
deps: upgrade react-youtube

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-redux": "^4.0.0",
     "react-tap-event-plugin": "^0.2.1",
     "react-timeago": "^2.2.1",
-    "react-youtube": "goto-bus-stop/troybetz-react-youtube#u-wave-temp",
+    "react-youtube": "^6.0.0",
     "recompose": "^0.15.1",
     "redux": "^3.0.4",
     "redux-logger": "^2.0.4",


### PR DESCRIPTION
v6 was just released so we don't need to depend on a branch in a forked github repo anymore :tada:
