### PR TITLE
chat: prevent chat input change from rerendering tabs

### DIFF
--- a/src/containers/SidePanels.js
+++ b/src/containers/SidePanels.js
@@ -1,4 +1,3 @@
-import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 
@@ -19,9 +18,16 @@ const mapStateToProps = createStructuredSelector({
 });
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({
-    onChange: selectPanel
-  }, dispatch);
+  return {
+    onChange: panelName => {
+      // Ensure that we're actually switching panels--otherwise change events
+      // from eg. the chat box bubble up and trigger a panel rerender on every
+      // keypress.
+      if (typeof panelName === 'string') {
+        dispatch(selectPanel(panelName));
+      }
+    }
+  };
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(SidePanels);


### PR DESCRIPTION
The material-ui Tabs component fires a change event when tabs are switched, but so does the chat input when you type in it. Rerendering the Tabs component on every keypress is super expensive, so this patch ignores the chat input events and only updates on Tabs change events.
