### PR TITLE
style: correctly vendor-prefix transform styles

### DIFF
--- a/src/components/HeaderBar/Progress.js
+++ b/src/components/HeaderBar/Progress.js
@@ -1,16 +1,15 @@
 import cx from 'classnames';
 import React from 'react';
 
+import transformStyle from '../../utils/transformStyle';
+
 const Progress = ({ className, percent }) => {
   const width = isFinite(percent) ? percent : 0;
   return (
     <div className={cx('Progress', className)}>
       <div
         className="Progress-fill"
-        style={{
-          transform: `scaleX(${width})`,
-          webkitTransform: `scaleX(${width})`
-        }}
+        style={transformStyle(`scaleX(${width})`)}
       />
     </div>
   );

--- a/src/components/MediaList/MediaDragPreview.js
+++ b/src/components/MediaList/MediaDragPreview.js
@@ -2,10 +2,7 @@ import assign from 'object-assign';
 import React, { Component, PropTypes } from 'react';
 import ListIcon from 'material-ui/lib/svg-icons/action/list';
 
-const transformStyle = transform => ({
-  transform,
-  WebkitTransform: transform
-});
+import transformStyle from '../../utils/transformStyle';
 
 const getItemStyles = offset => offset
   ? assign(

--- a/src/utils/transformStyle.js
+++ b/src/utils/transformStyle.js
@@ -1,0 +1,13 @@
+/**
+ * Create a vendor-prefixed inline CSS object for a "transform" property.
+ *
+ * @param {string} transform CSS transform value.
+ * @return {Object}
+ */
+
+export default function transformStyle(transform) {
+  return {
+    transform,
+    WebkitTransform: transform
+  };
+}


### PR DESCRIPTION
Fixes prefixing of `transform` properties in the media progress bar. (`webkitTransform` → `WebkitTransform`)
