### PR TITLE
media-list: fix items showing the wrong thumbnails while scrolling

### DIFF
--- a/src/components/MediaList/Row.js
+++ b/src/components/MediaList/Row.js
@@ -78,6 +78,7 @@ export default class Row extends React.Component {
       : <div className="MediaListRow-thumb">
           <img
             className="MediaListRow-image"
+            key={media._id}
             src={media.thumbnail}
             alt=""
           />


### PR DESCRIPTION
Adds a `key={}` property to the thumbnail images to force them to be recreated, instead of allowing React to only change the `src={}` property, which keeps showing the old thumbnail until the new one has loaded in.
