### PR TITLE
redux@3.5.1 untested ⚠️

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react-timeago": "^2.2.1",
     "react-youtube": "^6.0.0",
     "recompose": "^0.15.1",
-    "redux": "^3.0.4",
+    "redux": "^3.5.1",
     "redux-logger": "^2.0.4",
     "redux-thunk": "^1.0.0",
     "reselect": "^2.0.1",


### PR DESCRIPTION
Hello :wave:

:warning::warning::warning:

[redux](https://www.npmjs.com/package/redux) just published its new version 3.5.1, which **is covered by your current version range**. **No automated tests** are configured for this project.

This means it’s now **unclear whether your software still works**. Manually check if that’s still the case
and close this pull request – if it broke, use this branch to work on adaptions and fixes.

<sub>
Do you think getting a pull request for every single new version of your dependencies is too noisy?
Configure continuous integration and you will only receive them when tests fail. 
</sub>

Happy fixing and merging :palm_tree:

---

[GitHub Release](https://github.com/reactjs/redux/releases/tag/v3.5.1)

<ul>
<li>Fixes a regression introduced in 3.5.0 that caused <code>dispatch</code> to not be available while middleware is initializing. (<a href="http://urls.greenkeeper.io/reactjs/redux/issues/1644" class="issue-link js-issue-link" data-url="https://github.com/reactjs/redux/issues/1644" data-id="149655244" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">#1644</a>, <a href="http://urls.greenkeeper.io/reactjs/redux/pull/1647" class="issue-link js-issue-link" data-url="https://github.com/reactjs/redux/issues/1647" data-id="149727720" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">#1647</a>)</li>
</ul>

---

The new version differs by 614 commits .
- [`843508f`](https://github.com/reactjs/redux/commit/843508f17cde5ef44b4001383a1de91e920926c8) `3.5.1`
- [`f4d80f1`](https://github.com/reactjs/redux/commit/f4d80f1889c477d5fb81256bccc453adb03a5133) `Keep dispatch available while middleware is initializing (#1647)`
- [`655fe6a`](https://github.com/reactjs/redux/commit/655fe6a8ec1f3a75e5bb6bd7abc2f9df5209b23f) `3.5.0`
- [`708d2ec`](https://github.com/reactjs/redux/commit/708d2ecbbe94554604b6ee27671d17328f30d0f0) `Style tweaks`
- [`64551cb`](https://github.com/reactjs/redux/commit/64551cb3b6e3a71b8e4e9580c7deb24d2c074aca) `feat(store): add observable proposal interop to store`
- [`f02e825`](https://github.com/reactjs/redux/commit/f02e8251212e0b90c522e4ae308cd6feb882fa0b) `replacing`(...args) => args[0]`with`arg => arg`(#1622)`
- [`7b85962`](https://github.com/reactjs/redux/commit/7b859625b727aa7f8e7fffd4481693d81b82a532) `Clarify installation instructions`
- [`24ab45f`](https://github.com/reactjs/redux/commit/24ab45f2acb8434119998e77464237041571d758) `Clarify the wording`
- [`95496d0`](https://github.com/reactjs/redux/commit/95496d0d29171e61189b933a9cc02b8273e31e23) `Actions.md: swapped the order of flux and redux examples. Redux comes first. (#1615)`
- [`1e517a3`](https://github.com/reactjs/redux/commit/1e517a3ceaa9b513672685675e9e6bcdb0ae124f) `Update Ecosystem.md`
- [`74e6892`](https://github.com/reactjs/redux/commit/74e6892fbdc5e19413bbebbc5c8a3e9f9454e44c) `Merge pull request #1609 from jory/documentation-fix`
- [`4aa1d45`](https://github.com/reactjs/redux/commit/4aa1d45ab04da35e600c1e3f7870a8899a360b96) `Change the wording around async failing`
- [`fe38181`](https://github.com/reactjs/redux/commit/fe381818fc6182f0755d11bda91eb9b6dbe60c79) `Merge pull request #1606 from sergiodxa/patch-1`
- [`38a91ab`](https://github.com/reactjs/redux/commit/38a91abbbd5edc22b7965e7ee21542074001bfd0) `Add spanish docs link to ecosystem page`
- [`ba33798`](https://github.com/reactjs/redux/commit/ba337989793a6c60076054cda9218c35088aa89b) `Add redux-actions-assertions (#1601)`

There are 250 commits in total. See the [full diff](https://github.com/reactjs/redux/compare/9b00b021dbc961fce998176a427ad1356224d914...843508f17cde5ef44b4001383a1de91e920926c8).

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
