### PR TITLE
overlays: use vh units to always size relative to viewport

### DIFF
--- a/src/components/Overlay/index.css
+++ b/src/components/Overlay/index.css
@@ -2,6 +2,7 @@
 
 @component Overlay {
   position: absolute;
+  height: 100vh;
   height: 100%;
   width: 100%;
   z-index: 6;


### PR DESCRIPTION
Prevents overlay content collapsing weirdly during open/close animations. Earlier the height of the content would also animate, scrollbars included. This keeps the content elements at a constant height. 
