### PR TITLE
Update react-addons-css-transition-group to version 15.0.1 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "object-values": "^1.0.0",
     "object.map": "^0.2.0",
     "react": "^0.14.3",
-    "react-addons-css-transition-group": "^0.14.3",
+    "react-addons-css-transition-group": "^15.0.1",
     "react-dnd": "^2.0.2",
     "react-dnd-html5-backend": "^2.0.0",
     "react-dom": "^0.14.0",


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[react-addons-css-transition-group](https://www.npmjs.com/package/react-addons-css-transition-group) just published its new version 15.0.1, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of react-addons-css-transition-group – otherwise use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

[GitHub Release](https://github.com/facebook/react/releases/tag/v15.0.1)

<h3>React</h3>


<ul>
<li>Restore <code>React.__spread</code> API to unbreak code compiled with some tools making use of this undocumented API. It is now officially deprecated. (<a href="http://urls.greenkeeper.io/zpao">@zpao</a> in <a href="http://urls.greenkeeper.io/facebook/react/pull/6444">#6444</a>)</li>
</ul>


<h3>ReactDOM</h3>


<ul>
<li>Fixed issue resulting in loss of cursor position in controlled inputs. (<a href="http://urls.greenkeeper.io/spicyj">@spicyj</a> in <a href="http://urls.greenkeeper.io/facebook/react/pull/6449">#6449</a>)</li>
</ul>

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
