### PR TITLE
reselect@2.5.0 untested ⚠️

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "redux": "^3.0.4",
     "redux-logger": "^2.0.4",
     "redux-thunk": "^1.0.0",
-    "reselect": "^2.0.1",
+    "reselect": "^2.5.0",
     "router": "^1.1.4",
     "serve-static": "^1.10.2",
     "splitargs": "0.0.5",


### PR DESCRIPTION
Hello :wave:

:warning::warning::warning:

[reselect](https://www.npmjs.com/package/reselect) just published its new version 2.5.0, which **is covered by your current version range**. **No automated tests** are configured for this project.

This means it’s now **unclear whether your software still works**. Manually check if that’s still the case
and close this pull request – if it broke, use this branch to work on adaptions and fixes.

<sub>
Do you think getting a pull request for every single new version of your dependencies is too noisy?
Configure continuous integration and you will only receive them when tests fail. 
</sub>

Happy fixing and merging :palm_tree:

---

[GitHub Release](https://github.com/reactjs/reselect/releases/tag/v2.5.0)

<h2>New features</h2>


<p>Add jsnext build (<a href="http://urls.greenkeeper.io/reactjs/reselect/pull/116" class="issue-link js-issue-link" data-url="https://github.com/reactjs/reselect/issues/116" data-id="149631192" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">#116</a>)</p>

---

The new version differs by 132 commits .
- [`51d7af9`](https://github.com/reactjs/reselect/commit/51d7af9805bc1ecf3f20a258f5285a795f4ff632) `Update changelog for v2.5.0`
- [`bc1e8ff`](https://github.com/reactjs/reselect/commit/bc1e8ff0c9ea4e2c70454d442e3b3eaa406d7484) `Bump version to 2.5.0`
- [`c274361`](https://github.com/reactjs/reselect/commit/c274361686fa8405ef674763a480337b70eca7b4) `Merge pull request #116 from npbee/jsnext-main`
- [`c9c0bea`](https://github.com/reactjs/reselect/commit/c9c0bead79198cf7067ecd2f8b36a4a820082995) `Add jsnext build`
- [`760f501`](https://github.com/reactjs/reselect/commit/760f5014d1bb71bf052e1522e4a2ade8c65bc9a9) `Change README rackt urls`
- [`7815c3c`](https://github.com/reactjs/reselect/commit/7815c3c872795de9ad79ffbddf9d1edaaadbe985) `Merge pull request #113 from SimenB/babel-6`
- [`c308a45`](https://github.com/reactjs/reselect/commit/c308a45cd5b3c1e569205da88947c828e1a8d830) `Update to babel@6`
- [`c7acc62`](https://github.com/reactjs/reselect/commit/c7acc62bb6d177a454bde09abf829d361e643c7f) `Bump version to 2.4.0`
- [`1a45243`](https://github.com/reactjs/reselect/commit/1a45243b9119a469a236c858116a06b56deb69ff) `Update Changelog`
- [`98c104a`](https://github.com/reactjs/reselect/commit/98c104a1369bafa959ae5cbc68b4d66e2ee04e77) `Update Credits`
- [`70449fa`](https://github.com/reactjs/reselect/commit/70449faa48499914002f6ede1cb6e71e2231d5d6) `Update Authors`
- [`891c312`](https://github.com/reactjs/reselect/commit/891c3123286589fedcc8f81c0b621107a6d706e5) `Merge pull request #112 from npbee/umd-build`
- [`34fe421`](https://github.com/reactjs/reselect/commit/34fe4217b43017aed9bc9f1de83b3b11a613118a) `Add UMD build command`
- [`f789a53`](https://github.com/reactjs/reselect/commit/f789a5309e66d24cb7633fde4af141845ed553b7) `Merge pull request #111 from clickclickonsal/patch-1`
- [`dd6be3c`](https://github.com/reactjs/reselect/commit/dd6be3cf87f076fcecbb2ab0587a466c0488621c) `fixed typo`

There are 132 commits in total. See the [full diff](https://github.com/reactjs/reselect/compare/e9c0d651a47758e7a720a9359d399ba3ac97cd2b...51d7af9805bc1ecf3f20a258f5285a795f4ff632).

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
