### PR TITLE
reselect@2.5.1 untested ⚠️

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "redux": "^3.5.1",
     "redux-logger": "^2.0.4",
     "redux-thunk": "^2.0.1",
-    "reselect": "^2.0.1",
+    "reselect": "^2.5.1",
     "router": "^1.1.4",
     "serve-static": "^1.10.2",
     "splitargs": "0.0.7",


### PR DESCRIPTION
Hello :wave:

:warning::warning::warning:

[reselect](https://www.npmjs.com/package/reselect) just published its new version 2.5.1, which **is covered by your current version range**. **No automated tests** are configured for this project.

This means it’s now **unclear whether your software still works**. Manually check if that’s still the case
and close this pull request – if it broke, use this branch to work on adaptions and fixes.

<sub>
Do you think getting a pull request for every single new version of your dependencies is too noisy?
Configure continuous integration and you will only receive them when tests fail. 
</sub>

Happy fixing and merging :palm_tree:

---

[GitHub Release](https://github.com/reactjs/reselect/releases/tag/v2.5.1)

<h3>Bug Fixes</h3>


<p>Include es directory in package.js (<a href="http://urls.greenkeeper.io/reactjs/reselect/pull/117" class="issue-link js-issue-link" data-url="https://github.com/reactjs/reselect/issues/117" data-id="150065005" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">#117</a>)</p>

---

The new version differs by 137 commits .
- [`87e9e19`](https://github.com/reactjs/reselect/commit/87e9e193322c85f3cd88ab84c231ddac42a96afb) `Update changelog for v2.5.1`
- [`3cd08d3`](https://github.com/reactjs/reselect/commit/3cd08d36a6223d47b31c5c75f04e2b43393b509b) `Bump to version 2.5.1`
- [`236fa9b`](https://github.com/reactjs/reselect/commit/236fa9bbfec07b8e99007030a5d41b28aec97fbc) `Add mctep to CREDITS`
- [`81b4558`](https://github.com/reactjs/reselect/commit/81b45587ab80f7b16329a4ef3579c19388045ecf) `Merge pull request #117 from mctep/mctep-esnext-fix`
- [`d5c14b6`](https://github.com/reactjs/reselect/commit/d5c14b6ac4370c10c4a6f3169d5c0d56b28d5d60) `Add`es`folder to package.json`
- [`51d7af9`](https://github.com/reactjs/reselect/commit/51d7af9805bc1ecf3f20a258f5285a795f4ff632) `Update changelog for v2.5.0`
- [`bc1e8ff`](https://github.com/reactjs/reselect/commit/bc1e8ff0c9ea4e2c70454d442e3b3eaa406d7484) `Bump version to 2.5.0`
- [`c274361`](https://github.com/reactjs/reselect/commit/c274361686fa8405ef674763a480337b70eca7b4) `Merge pull request #116 from npbee/jsnext-main`
- [`c9c0bea`](https://github.com/reactjs/reselect/commit/c9c0bead79198cf7067ecd2f8b36a4a820082995) `Add jsnext build`
- [`760f501`](https://github.com/reactjs/reselect/commit/760f5014d1bb71bf052e1522e4a2ade8c65bc9a9) `Change README rackt urls`
- [`7815c3c`](https://github.com/reactjs/reselect/commit/7815c3c872795de9ad79ffbddf9d1edaaadbe985) `Merge pull request #113 from SimenB/babel-6`
- [`c308a45`](https://github.com/reactjs/reselect/commit/c308a45cd5b3c1e569205da88947c828e1a8d830) `Update to babel@6`
- [`c7acc62`](https://github.com/reactjs/reselect/commit/c7acc62bb6d177a454bde09abf829d361e643c7f) `Bump version to 2.4.0`
- [`1a45243`](https://github.com/reactjs/reselect/commit/1a45243b9119a469a236c858116a06b56deb69ff) `Update Changelog`
- [`98c104a`](https://github.com/reactjs/reselect/commit/98c104a1369bafa959ae5cbc68b4d66e2ee04e77) `Update Credits`

There are 137 commits in total. See the [full diff](https://github.com/reactjs/reselect/compare/e9c0d651a47758e7a720a9359d399ba3ac97cd2b...87e9e193322c85f3cd88ab84c231ddac42a96afb).

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
