### PR TITLE
redux@3.5.2 untested ⚠️

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-timeago": "^3.0.0",
     "react-youtube": "^6.0.0",
     "recompose": "^0.17.0",
-    "redux": "^3.5.1",
+    "redux": "^3.5.2",
     "redux-logger": "^2.0.4",
     "redux-thunk": "^2.0.1",
     "reselect": "^2.5.1",


### PR DESCRIPTION
Hello :wave:

:warning::warning::warning:

[redux](https://www.npmjs.com/package/redux) just published its new version 3.5.2, which **is covered by your current version range**. **No automated tests** are configured for this project.

This means it’s now **unclear whether your software still works**. Manually check if that’s still the case
and close this pull request – if it broke, use this branch to work on adaptions and fixes.

<sub>
Do you think getting a pull request for every single new version of your dependencies is too noisy?
Configure continuous integration and you will only receive them when tests fail. 
</sub>

Happy fixing and merging :palm_tree:

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
