### PR TITLE
classnames@2.2.4 untested ⚠️

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "ReconnectingWebSocket": "joewalnes/reconnecting-websocket#283894",
     "array-find": "^1.0.0",
     "array-findindex": "^0.1.0",
-    "classnames": "^2.1.3",
+    "classnames": "^2.2.4",
     "debug": "^2.2.0",
     "es6-promise": "^3.0.2",
     "escape-string-regexp": "^1.0.3",


### PR DESCRIPTION
Hello :wave:

:warning::warning::warning:

[classnames](https://www.npmjs.com/package/classnames) just published its new version 2.2.4, which **is covered by your current version range**. **No automated tests** are configured for this project.

This means it’s now **unclear whether your software still works**. Manually check if that’s still the case
and close this pull request – if it broke, use this branch to work on adaptions and fixes.

<sub>
Do you think getting a pull request for every single new version of your dependencies is too noisy?
Configure continuous integration and you will only receive them when tests fail. 
</sub>

Happy fixing and merging :palm_tree:

---

The new version differs by 73 commits .
- [`10700b4`](https://github.com/JedWatson/classnames/commit/10700b40072c1137dbf892520e655357e0e0ce33) `v2.2.4`
- [`a8fff5b`](https://github.com/JedWatson/classnames/commit/a8fff5b9c83137f4abe8fb87d5f191bf177aa29d) `Updating changelog`
- [`c3ea236`](https://github.com/JedWatson/classnames/commit/c3ea23635ae505ca01a0e0acc3b1b46677c07158) `Merge pull request #76 from barneycarroll/patch-1`
- [`0d1a68a`](https://github.com/JedWatson/classnames/commit/0d1a68abe7a9d4373be2749f15420975ed5aaa63) `Merge pull request #78 from bgoscinski/master`
- [`3c4cb02`](https://github.com/JedWatson/classnames/commit/3c4cb023b89f7e4194e7557800efe46b663e8649) `update README.md statement about dedupe perf`
- [`3615839`](https://github.com/JedWatson/classnames/commit/36158398899c2a599535f3b98f4c45af666f80a7) `avoid changing object structure in dedupe`
- [`088fb26`](https://github.com/JedWatson/classnames/commit/088fb265459c488b66665a24b2edef806be04a55) `skip hasOwnProperty check in dedupe`
- [`73a8b53`](https://github.com/JedWatson/classnames/commit/73a8b53317c8b7326e3536bbcf97d9473e46d3e8) `don't leak arguments in dedupe`
- [`34e3aaa`](https://github.com/JedWatson/classnames/commit/34e3aaa65973e948bd7f0107b2c6a4601921e229) `Fix template literal delimiters in README example`
- [`a6934cd`](https://github.com/JedWatson/classnames/commit/a6934cd623c1ea2a895575af9c83b08c8bdd3b05) `v2.2.3`
- [`5dd3fc6`](https://github.com/JedWatson/classnames/commit/5dd3fc61e8651457979baf7120bcc76dcbcc364a) `Updating changelog`
- [`61cd79d`](https://github.com/JedWatson/classnames/commit/61cd79df1077e65192ce4ae662687bb116ee1095) `Updating bind variant to also use [].join(' ')`
- [`57fb9b8`](https://github.com/JedWatson/classnames/commit/57fb9b80fbe235ec7f1841d7e18b6c929accc6a5) `v2.2.2`
- [`113a559`](https://github.com/JedWatson/classnames/commit/113a559fdc4db46d2baae581cebcdbdab76c2565) `Updating changelog`
- [`16ddaa6`](https://github.com/JedWatson/classnames/commit/16ddaa6822e3cf3a096fead3c6bb3ce96178bbcf) `Updating license & copyright for 2016`

There are 73 commits in total. See the [full diff](https://github.com/JedWatson/classnames/compare/99715cc93219198c2abb8ac488078fe336b922dd...10700b40072c1137dbf892520e655357e0e0ce33).

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
