### PR TITLE
eslint-plugin-import@1.6.0 untested ⚠️

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "envify": "^3.4.0",
     "eslint-config-airbnb": "^8.0.0",
     "eslint-config-airbnb-base": "^1.0.3",
-    "eslint-plugin-import": "^1.5.0",
+    "eslint-plugin-import": "^1.6.0",
     "eslint-plugin-jsx-a11y": "^1.0.2",
     "eslint-plugin-react": "^5.0.1",
     "express": "^4.13.3",


### PR DESCRIPTION
Hello :wave:

:warning::warning::warning:

[eslint-plugin-import](https://www.npmjs.com/package/eslint-plugin-import) just published its new version 1.6.0, which **is covered by your current version range**. **No automated tests** are configured for this project.

This means it’s now **unclear whether your software still works**. Manually check if that’s still the case
and close this pull request – if it broke, use this branch to work on adaptions and fixes.

<sub>
Do you think getting a pull request for every single new version of your dependencies is too noisy?
Configure continuous integration and you will only receive them when tests fail. 
</sub>

Happy fixing and merging :palm_tree:

---

The new version differs by 32 commits .
- [`ea1b0e3`](https://github.com/benmosher/eslint-plugin-import/commit/ea1b0e3d2d0c58287d8513a71e79100b48feed38) `resolvers/webpack/v0.2.1`
- [`4195d4a`](https://github.com/benmosher/eslint-plugin-import/commit/4195d4a20d1affca8808d96208cf0461610c72bd) `1.6.0 + fixed a bunch of changelog link issues`
- [`62ed940`](https://github.com/benmosher/eslint-plugin-import/commit/62ed940155dc4a13430f86d2be484fe1a684bde3) `named: should ignore ignored modules for re-exported names (#269)`
- [`950899d`](https://github.com/benmosher/eslint-plugin-import/commit/950899daad3bd97e633559dff866d51b6789e61b) `allow destructuring without init (fixes #249) (#264)`
- [`055201e`](https://github.com/benmosher/eslint-plugin-import/commit/055201e32072de18250603f64befd5e292c2b7bc) `Merge pull request #247 from jfmengels/import-order`
- [`38f3935`](https://github.com/benmosher/eslint-plugin-import/commit/38f39351193ad1593d64838c9e549efd53d4231b) `order`: enforce `import`s being before `require`
- [`039a77b`](https://github.com/benmosher/eslint-plugin-import/commit/039a77bd600289807bcc7f32a8f274fd9d9aa15a) `Add support for scoped packages in`importType``
- [`6c3fe44`](https://github.com/benmosher/eslint-plugin-import/commit/6c3fe44dbb4de73b72768e3c74789fb75dfc9174) `Rename`import-order`to`order`, and param`order`to`groups``
- [`03de513`](https://github.com/benmosher/eslint-plugin-import/commit/03de513a3ab4a289aab483f60922784f9b26f613) `Allow grouping in`import-order`, rename`project`type to`internal``
- [`ee951cd`](https://github.com/benmosher/eslint-plugin-import/commit/ee951cd9a683b0a2d6b11e5619b33b98e5452ff2) `Add`import-order`rule`
- [`9e5ea9b`](https://github.com/benmosher/eslint-plugin-import/commit/9e5ea9b285e321863d99dec180c88461e0b143fe) `Update doctrine to version 1.2.1 🚀`
- [`624848a`](https://github.com/benmosher/eslint-plugin-import/commit/624848a395ddbfe4c9c1d39ecd9a1a76a76ce937) `Add`no-nodejs-modules`rule (fixes #158)`
- [`052ea18`](https://github.com/benmosher/eslint-plugin-import/commit/052ea18f45545c692ad771a24f36603dd5ab81e5) `Merge branch 'extensions' (#250)`
- [`866ea65`](https://github.com/benmosher/eslint-plugin-import/commit/866ea654e998ef878d35803c1c3c00774db17ba2) `added a note on directives to imports-first doc`
- [`b1a957c`](https://github.com/benmosher/eslint-plugin-import/commit/b1a957c2c6c71148f29762ea658e5f9bb33009b0) `Merge branch 'imports-first-allow-directives'`

There are 32 commits in total. See the [full diff](https://github.com/benmosher/eslint-plugin-import/compare/1ea16f67f98fccc76f232bc5c52296d53a0faf8b...ea1b0e3d2d0c58287d8513a71e79100b48feed38).

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
