### PR TITLE
eslint-plugin-jsx-a11y@1.0.3 untested ⚠️

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "eslint-config-airbnb": "^8.0.0",
     "eslint-config-airbnb-base": "^1.0.4",
     "eslint-plugin-import": "^1.6.1",
-    "eslint-plugin-jsx-a11y": "^1.0.2",
+    "eslint-plugin-jsx-a11y": "^1.0.3",
     "eslint-plugin-react": "^5.0.1",
     "express": "^4.13.3",
     "fetch-mock": "^4.1.1",


### PR DESCRIPTION
Hello :wave:

:warning::warning::warning:

[eslint-plugin-jsx-a11y](https://www.npmjs.com/package/eslint-plugin-jsx-a11y) just published its new version 1.0.3, which **is covered by your current version range**. **No automated tests** are configured for this project.

This means it’s now **unclear whether your software still works**. Manually check if that’s still the case
and close this pull request – if it broke, use this branch to work on adaptions and fixes.

<sub>
Do you think getting a pull request for every single new version of your dependencies is too noisy?
Configure continuous integration and you will only receive them when tests fail. 
</sub>

Happy fixing and merging :palm_tree:

---

The new version differs by 5 commits .
- [`a62360d`](https://github.com/evcohen/eslint-plugin-jsx-a11y/commit/a62360deb347333f4c92d685b90872a9d204bcdc) `Update CHANGELOG.md`
- [`90dc711`](https://github.com/evcohen/eslint-plugin-jsx-a11y/commit/90dc71150c6857f27bd1c5a57b514382e9f14132) `1.0.3`
- [`66509a3`](https://github.com/evcohen/eslint-plugin-jsx-a11y/commit/66509a31d2fcbc2328659fc383782b4aab64682d) `Fix typo in recommended config (#43)`
- [`b51dd95`](https://github.com/evcohen/eslint-plugin-jsx-a11y/commit/b51dd95a19aa9623ceb10c6959927360ffe2f6e3) `Remove maxAge from downloads link so it doesn't cache`
- [`7e42779`](https://github.com/evcohen/eslint-plugin-jsx-a11y/commit/7e427796d8a221684263d2a45144f2625aa282cb) `Update CHANGELOG.md`

See the [full diff](https://github.com/evcohen/eslint-plugin-jsx-a11y/compare/5e9200368981edea093ebf94d8bc62ea7ce8a4f6...a62360deb347333f4c92d685b90872a9d204bcdc).

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
