### PR TITLE
eslint-plugin-import@1.6.1 untested ⚠️

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "envify": "^3.4.0",
     "eslint-config-airbnb": "^8.0.0",
     "eslint-config-airbnb-base": "^1.0.4",
-    "eslint-plugin-import": "^1.6.0",
+    "eslint-plugin-import": "^1.6.1",
     "eslint-plugin-jsx-a11y": "^1.0.2",
     "eslint-plugin-react": "^5.0.1",
     "express": "^4.13.3",


### PR DESCRIPTION
Hello :wave:

:warning::warning::warning:

[eslint-plugin-import](https://www.npmjs.com/package/eslint-plugin-import) just published its new version 1.6.1, which **is covered by your current version range**. **No automated tests** are configured for this project.

This means it’s now **unclear whether your software still works**. Manually check if that’s still the case
and close this pull request – if it broke, use this branch to work on adaptions and fixes.

<sub>
Do you think getting a pull request for every single new version of your dependencies is too noisy?
Configure continuous integration and you will only receive them when tests fail. 
</sub>

Happy fixing and merging :palm_tree:

---

The new version differs by 18 commits .
- [`e69561c`](https://github.com/benmosher/eslint-plugin-import/commit/e69561c027e2e2906e8c6cedfbef94837ad0067b) `1.6.1`
- [`7a562ac`](https://github.com/benmosher/eslint-plugin-import/commit/7a562ac1534b372d520a31a390c37f171b38590a) `added changelog note`
- [`0ead6b8`](https://github.com/benmosher/eslint-plugin-import/commit/0ead6b869fe42ed4012c5e835864973eb4ed02cf) `cleanup long predicate`
- [`27513b6`](https://github.com/benmosher/eslint-plugin-import/commit/27513b656c19601ecb8184ab590cdf53cfad75e9) `build: run Travis against Linux and OS X`
- [`bb372cc`](https://github.com/benmosher/eslint-plugin-import/commit/bb372ccb264be5294f4c6220fc9a001d7be298e5) `don't check for existence of of builtins on case-insensitive FS`
- [`e9e6ba7`](https://github.com/benmosher/eslint-plugin-import/commit/e9e6ba7c3f5d97120f832e1d1402cc8ecf97b758) `yaml schema fail`
- [`7f7a727`](https://github.com/benmosher/eslint-plugin-import/commit/7f7a727bacdee17604f4b2ef5de367e3dec6145b) `build with v6 on windows?`
- [`a2d8231`](https://github.com/benmosher/eslint-plugin-import/commit/a2d823195b7589c9de565f707c2d2637e4a86418) `Attempt build on node 6`
- [`c6740d0`](https://github.com/benmosher/eslint-plugin-import/commit/c6740d0f50201d22c44471e281897f79b647fa51) `added syntax battery to test utils for future use + fixed #281`
- [`2539fb3`](https://github.com/benmosher/eslint-plugin-import/commit/2539fb32db621be1ba842704f74a22d69e801d70) `changelog: fix some links`
- [`ddea58c`](https://github.com/benmosher/eslint-plugin-import/commit/ddea58cab6bd5006ef410c83a7f628a430e52e95) `changelogg'd #287`
- [`97f8f55`](https://github.com/benmosher/eslint-plugin-import/commit/97f8f553ca13e73f268dba07ec7ac30137e3b99a) `Automatically find webpack.config.babel.js`
- [`403a000`](https://github.com/benmosher/eslint-plugin-import/commit/403a000976d2c9ce454ac8dd41b1f5945cb00ee4) `changelog + package bump for interpret issue (#286, #289)`
- [`e4184ab`](https://github.com/benmosher/eslint-plugin-import/commit/e4184abc782a674fc7349fff281bffec179e9a41) `Move 'interpret' to webpack loader's package.json.`
- [`06e005d`](https://github.com/benmosher/eslint-plugin-import/commit/06e005d70454b076be223e930e71f033c81167a8) `Merge branch 'webpack-configs'`

There are 18 commits in total. See the [full diff](https://github.com/benmosher/eslint-plugin-import/compare/ea1b0e3d2d0c58287d8513a71e79100b48feed38...e69561c027e2e2906e8c6cedfbef94837ad0067b).

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
