### PR TITLE
Update whatwg-fetch to version 1.0.0 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "splitargs": "0.0.7",
     "truncate-url": "^0.1.2",
     "u-wave-parse-chat-markup": "^1.0.0",
-    "whatwg-fetch": "^0.11.0"
+    "whatwg-fetch": "^1.0.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.0.3",


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[whatwg-fetch](https://www.npmjs.com/package/whatwg-fetch) just published its new version 1.0.0, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of whatwg-fetch – otherwise use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

[GitHub Release](https://github.com/github/fetch/releases/tag/v1.0.0)

<ul>
<li>Reject promise on request timeout</li>
<li>Add support for <code>URLSearchParams</code> request body</li>
<li>Add <code>Headers</code> iterable methods: <code>keys</code>, <code>values</code>, and <code>entries</code>
</li>
</ul>

---

The new version differs by 27 commits .
- [`ad96feb`](https://github.com/github/fetch/commit/ad96feb721393590a1b79dd2646854f5cbb16186) `1.0.0`
- [`6e3aa34`](https://github.com/github/fetch/commit/6e3aa34e7ea631ab55ad463ffc3a7c9bd47bae86) `Merge pull request #317 from Xuefeng-Zhu/patch-1`
- [`65b611e`](https://github.com/github/fetch/commit/65b611eb0fe7878704df190e36dedfd0a9071c3a) `refactor Header iterator methods`
- [`7f71c9b`](https://github.com/github/fetch/commit/7f71c9bdccedaf65cf91b450b74065f8bed26d36) `Merge pull request #287 from jamonholmgren/patch-1`
- [`b259545`](https://github.com/github/fetch/commit/b2595455cc7ae45e6f5b2bd60c74d5801d8315ac) `Merge pull request #314 from github/update-mocha-phantomjs`
- [`d1ab588`](https://github.com/github/fetch/commit/d1ab5881ac14625e5e2da26ddd2b24f33a63aeaf) `Switch to`mocha-phantomjs-core`and system PhantomJS`
- [`4dbbfd0`](https://github.com/github/fetch/commit/4dbbfd0e09500ea969766edfd8289af1910ba135) `Merge pull request #306 from github/timeout-reject`
- [`619ee08`](https://github.com/github/fetch/commit/619ee08d5102f3a1540dd515a1fec766f3c01737) `Reject promise on request timeout`
- [`c23c3f9`](https://github.com/github/fetch/commit/c23c3f9b3aa3e2bcc8853cc0b1b08830068e6163) `Merge pull request #272 from jmeas/capitalization`
- [`08fc999`](https://github.com/github/fetch/commit/08fc999a6bfdfd3fd2fd12ebd65a73551e6f8f79) `Merge pull request #289 from steveluscher/patch-1`
- [`cff0ebb`](https://github.com/github/fetch/commit/cff0ebba8d9df9d6a76448f57a3220983fbb150f) `Merge pull request #304 from github/url-search-params`
- [`2ead77d`](https://github.com/github/fetch/commit/2ead77df94fa124fb24c03894bfb52f2c6c406b1) `Replace deprecated npm licenses format`
- [`d77810a`](https://github.com/github/fetch/commit/d77810a15c78bbbaf2defd4ea3af6db21c8d117f) `Support URLSearchParams POST body`
- [`57b7f98`](https://github.com/github/fetch/commit/57b7f98f639c3b7c9ca819eade75b7d5f678a629) `Merge pull request #295 from github/iterators`
- [`78b3a3b`](https://github.com/github/fetch/commit/78b3a3bd4d2bc11f4fc02df2f90269c842d56709) `Guard against`xhr.getAllResponseHeaders()`being`null``

There are 27 commits in total. See the [full diff](https://github.com/github/fetch/compare/989a1e8132e9adb4c4e973875ad043ff7219fc5a...ad96feb721393590a1b79dd2646854f5cbb16186).

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
