### PR TITLE
emoji: fix crash when no emoji are configured

### DIFF
--- a/src/selectors/configSelectors.js
+++ b/src/selectors/configSelectors.js
@@ -15,7 +15,7 @@ export const requestOptionsSelector = createSelector(
 
 export const availableEmojiImagesSelector = createSelector(
   configSelector,
-  config => config.emoji
+  config => config.emoji || {}
 );
 
 export const availableEmojiNamesSelector = createSelector(


### PR DESCRIPTION
can't call `Object.keys` on null/undefined
