### PR TITLE
register: remove double object wrapper when passing recaptcha site key to dialog

### DIFF
--- a/src/selectors/dialogSelectors.js
+++ b/src/selectors/dialogSelectors.js
@@ -15,7 +15,7 @@ export const loginDialogSelector = createSelector(
   (dialogs, error, siteKey) => assign(merge(dialogs.login), {
     error,
     useReCaptcha: !!siteKey,
-    reCaptchaSiteKey: siteKey ? { key: siteKey } : null
+    reCaptchaSiteKey: siteKey || null
   })
 );
 


### PR DESCRIPTION
this was accidentally adding a `{ key: }` object wrapper, but the recaptcha component doesn't expect that.
