### PR TITLE
Update gulp-htmlmin to version 2.0.0 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "gulp-babel": "^6.1.1",
     "gulp-buffer": "0.0.2",
     "gulp-eslint": "^2.0.0",
-    "gulp-htmlmin": "^1.3.0",
+    "gulp-htmlmin": "^2.0.0",
     "gulp-if": "^2.0.0",
     "gulp-insert": "^0.5.0",
     "gulp-postcss": "^6.0.0",


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[gulp-htmlmin](https://www.npmjs.com/package/gulp-htmlmin) just published its new version 2.0.0, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of gulp-htmlmin – otherwise use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

The new version differs by 7 commits .
- [`ebdefba`](https://github.com/jonschlinkert/gulp-htmlmin/commit/ebdefba695c9cad0e40297eb3a4950074e44187e) `2.0.0`
- [`406a5bf`](https://github.com/jonschlinkert/gulp-htmlmin/commit/406a5bf1918d7cc906cc523164154f8fd2b5378d) `update html-minifier from v1.x to v2.x`
- [`02e984e`](https://github.com/jonschlinkert/gulp-htmlmin/commit/02e984e75932e89556aa7f9334d4b364944470de) `update expected output for html-minifier v1.3.1`
- [`a69cc25`](https://github.com/jonschlinkert/gulp-htmlmin/commit/a69cc25076c16dda636a3b7e7b850c96cbf8dc87) `clarify where we should report minified issues`
- [`fa3c2ab`](https://github.com/jonschlinkert/gulp-htmlmin/commit/fa3c2abf3cfb3444029a2708edd3ec8316265021) `update html-minifier version`
- [`a318460`](https://github.com/jonschlinkert/gulp-htmlmin/commit/a318460306b36e59a98a3bbb563441bf55ee1fdd) `upgrade to ESLint v2.x`
- [`b9aac9f`](https://github.com/jonschlinkert/gulp-htmlmin/commit/b9aac9fbda82a7ad75dd5a0ac1dfc2bdea7585e2) `update expected output`

See the [full diff](https://github.com/jonschlinkert/gulp-htmlmin/compare/69891209c91682beb8a2a05231103ef031c36792...ebdefba695c9cad0e40297eb3a4950074e44187e).

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
