### PR TITLE
build: use external source maps

### DIFF
--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -118,7 +118,7 @@ export default function browserifyTask({ minify = false, 'source-maps': useSourc
         // available, so it doesn't really matter what they're called!
         mangle: { toplevel: true }
       })))
-    .pipe(when(useSourceMaps, sourcemaps.write()))
+    .pipe(when(useSourceMaps, sourcemaps.write('./')))
     // Output to lib/out.js!
     .pipe(dest('lib/'));
 }

--- a/tasks/compile-css.js
+++ b/tasks/compile-css.js
@@ -32,6 +32,6 @@ export default function compileCssTask({ minify = false, 'source-maps': useSourc
   return src('src/app.css')
     .pipe(when(useSourceMaps, sourcemaps.init()))
       .pipe(postcss(processors))
-    .pipe(when(useSourceMaps, sourcemaps.write()))
+    .pipe(when(useSourceMaps, sourcemaps.write('./')))
     .pipe(dest('lib/'));
 }


### PR DESCRIPTION
Makes using them in deployed instances a bit friendlier, because now everyone doesn't have to download 500KB of inlined source maps.
