### PR TITLE
gulp-postcss@6.1.1 untested ⚠️

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "gulp-htmlmin": "^2.0.0",
     "gulp-if": "^2.0.0",
     "gulp-insert": "^0.5.0",
-    "gulp-postcss": "^6.0.0",
+    "gulp-postcss": "^6.1.1",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.6",


### PR DESCRIPTION
Hello :wave:

:warning::warning::warning:

[gulp-postcss](https://www.npmjs.com/package/gulp-postcss) just published its new version 6.1.1, which **is covered by your current version range**. **No automated tests** are configured for this project.

This means it’s now **unclear whether your software still works**. Manually check if that’s still the case
and close this pull request – if it broke, use this branch to work on adaptions and fixes.

<sub>
Do you think getting a pull request for every single new version of your dependencies is too noisy?
Configure continuous integration and you will only receive them when tests fail. 
</sub>

Happy fixing and merging :palm_tree:

---

The new version differs by 16 commits .
- [`52e6ad9`](https://github.com/postcss/gulp-postcss/commit/52e6ad9567b80e028b429939629da9291e4315d5) `Cleanup tests and bump version`
- [`f8d4405`](https://github.com/postcss/gulp-postcss/commit/f8d440567a70a77ddf854b8c69bfb8e2d0dc6d60) `Merge pull request #81 from Termina1/patch-1`
- [`716822c`](https://github.com/postcss/gulp-postcss/commit/716822cdec4e2e4e85998cdb074fcebe75a8e01d) `add tests for passed options to gulp error`
- [`b69b793`](https://github.com/postcss/gulp-postcss/commit/b69b793d3241a97d4ac8e69e167fcf798d626999) `add show stack by default`
- [`fd0a7b8`](https://github.com/postcss/gulp-postcss/commit/fd0a7b86d6eb076bd9462f73aa0ae86637bfdff4) `forgotten options`
- [`2d4733a`](https://github.com/postcss/gulp-postcss/commit/2d4733a2c7f24a7085034655a27e8b40c7e337d4) `Merge pull request #77 from postcss/fix-readme`
- [`bd0d0d7`](https://github.com/postcss/gulp-postcss/commit/bd0d0d7d22d24c245510f5762dc27bb40d1c7773) `Update/fix examples`
- [`3031c1e`](https://github.com/postcss/gulp-postcss/commit/3031c1ed5a248908cdc2ba7a233e120c31c33173) `updated deps and bumped version`
- [`2c0a800`](https://github.com/postcss/gulp-postcss/commit/2c0a8000368281c4ab4c80285d2e85035315686b) `Merge pull request #70 from bammoo/patch-1`
- [`282444b`](https://github.com/postcss/gulp-postcss/commit/282444b72092595db28667f7f6488e4ed1c296d3) `Add test`
- [`59d2b9f`](https://github.com/postcss/gulp-postcss/commit/59d2b9f99a6b3b01b30625c0785f7bb9c57fa8a8) `Fix code style`
- [`464828f`](https://github.com/postcss/gulp-postcss/commit/464828f518aeb6cdca8730cd8b916f4cc0d03e60) `Check null before process file`
- [`8414a14`](https://github.com/postcss/gulp-postcss/commit/8414a14c95f7c76bef8546ad6383c6f7678076f5) `Updated version and published`
- [`bbf0ef5`](https://github.com/postcss/gulp-postcss/commit/bbf0ef552a618db3d064b3c154c431c1cff458d5) `Updated vinyl-sourcemaps-apply`
- [`1ba7f1d`](https://github.com/postcss/gulp-postcss/commit/1ba7f1d004caaf1d7de97e3838f2555117ec0d88) `Merge pull request #60 from postcss/56-add-syntax-options`

There are 16 commits in total. See the [full diff](https://github.com/postcss/gulp-postcss/compare/75d52ccbb6f4ba8fc498dbd06520ed9b5c71ee38...52e6ad9567b80e028b429939629da9291e4315d5).

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
