### PR TITLE
babel-plugin-transform-class-properties@6.6.0 untested ⚠️

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "babel-eslint": "6.0.4",
     "babel-plugin-external-helpers": "^6.4.0",
     "babel-plugin-react-transform": "^2.0.0",
-    "babel-plugin-transform-class-properties": "^6.4.0",
+    "babel-plugin-transform-class-properties": "^6.6.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-export-extensions": "^6.4.0",
     "babel-plugin-transform-function-bind": "^6.3.13",


### PR DESCRIPTION
Hello :wave:

:warning::warning::warning:

[babel-plugin-transform-class-properties](https://www.npmjs.com/package/babel-plugin-transform-class-properties) just published its new version 6.6.0, which **is covered by your current version range**. **No automated tests** are configured for this project.

This means it’s now **unclear whether your software still works**. Manually check if that’s still the case
and close this pull request – if it broke, use this branch to work on adaptions and fixes.

<sub>
Do you think getting a pull request for every single new version of your dependencies is too noisy?
Configure continuous integration and you will only receive them when tests fail. 
</sub>

Happy fixing and merging :palm_tree:

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
