### PR TITLE
babel-plugin-external-helpers@6.8.0 untested ⚠️

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "autoprefixer": "^6.0.3",
     "babel-core": "^6.4.0",
     "babel-eslint": "6.0.4",
-    "babel-plugin-external-helpers": "^6.4.0",
+    "babel-plugin-external-helpers": "^6.8.0",
     "babel-plugin-react-transform": "^2.0.0",
     "babel-plugin-transform-class-properties": "^6.4.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",


### PR DESCRIPTION
Hello :wave:

:warning::warning::warning:

[babel-plugin-external-helpers](https://www.npmjs.com/package/babel-plugin-external-helpers) just published its new version 6.8.0, which **is covered by your current version range**. **No automated tests** are configured for this project.

This means it’s now **unclear whether your software still works**. Manually check if that’s still the case
and close this pull request – if it broke, use this branch to work on adaptions and fixes.

<sub>
Do you think getting a pull request for every single new version of your dependencies is too noisy?
Configure continuous integration and you will only receive them when tests fail. 
</sub>

Happy fixing and merging :palm_tree:

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
