### PR TITLE
babel-register@6.8.0 untested ⚠️

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-2": "^6.3.13",
-    "babel-register": "^6.7.2",
+    "babel-register": "^6.8.0",
     "babelify": "^7.3.0",
     "browser-resolve": "^1.11.1",
     "browserify": "^13.0.0",


### PR DESCRIPTION
Hello :wave:

:warning::warning::warning:

[babel-register](https://www.npmjs.com/package/babel-register) just published its new version 6.8.0, which **is covered by your current version range**. **No automated tests** are configured for this project.

This means it’s now **unclear whether your software still works**. Manually check if that’s still the case
and close this pull request – if it broke, use this branch to work on adaptions and fixes.

<sub>
Do you think getting a pull request for every single new version of your dependencies is too noisy?
Configure continuous integration and you will only receive them when tests fail. 
</sub>

Happy fixing and merging :palm_tree:

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
