### PR TITLE
redbox-react@1.2.4 untested ⚠️

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "proxyquire": "^1.7.4",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.1",
-    "redbox-react": "^1.1.1",
+    "redbox-react": "^1.2.4",
     "run-sequence": "^1.1.4",
     "through2": "^2.0.0",
     "u-wave-source-soundcloud": "^1.0.0",


### PR DESCRIPTION
Hello :wave:

:warning::warning::warning:

[redbox-react](https://www.npmjs.com/package/redbox-react) just published its new version 1.2.4, which **is covered by your current version range**. **No automated tests** are configured for this project.

This means it’s now **unclear whether your software still works**. Manually check if that’s still the case
and close this pull request – if it broke, use this branch to work on adaptions and fixes.

<sub>
Do you think getting a pull request for every single new version of your dependencies is too noisy?
Configure continuous integration and you will only receive them when tests fail. 
</sub>

Happy fixing and merging :palm_tree:

---

[GitHub Release](https://github.com/KeywordBrain/redbox-react/releases/tag/v1.2.4)

<p><a name></a></p>


<h3>1.2.4 (2016-05-03)</h3>


<h4>Bug Fixes</h4>


<ul>
<li>
<strong>package:</strong> React 15 (<a href="http://urls.greenkeeper.io/KeywordBrain/redbox-react/commit/4928e0e3">4928e0e3</a>)</li>
</ul>

---

The new version differs by 13 commits (ahead by 13, behind by 1).
- [`4928e0e`](https://github.com/KeywordBrain/redbox-react/commit/4928e0e38c0660e9c0e6c67f0c1168ba348b174b) `fix(package): React 15`
- [`3d131ad`](https://github.com/KeywordBrain/redbox-react/commit/3d131ade49a59be865fb6d211752a60de796f335) `Document the style prop`
- [`6a8783d`](https://github.com/KeywordBrain/redbox-react/commit/6a8783d7163fccd5c36c1ecadc126e8cf709d4de) `fix: trigger release for latest react rc compat`
- [`33704f7`](https://github.com/KeywordBrain/redbox-react/commit/33704f7871152608f91d2e8c492f0893805006fa) `chore(package, style): allow React 15 and update styles to comply with React 15`
- [`1e134d8`](https://github.com/KeywordBrain/redbox-react/commit/1e134d81240d666f57f985c7a7019c2043221497) `chore(readme): Use react-dom instead of react for render() call`
- [`a38845b`](https://github.com/KeywordBrain/redbox-react/commit/a38845b0cca384b982235a72fbd196b036970a5d) `fix(package): Use files whitelist instead of npmignore`
- [`c2e6243`](https://github.com/KeywordBrain/redbox-react/commit/c2e624321fecb7de316b59f01f82981179cbc5c1) `fix: Guard against stack frames with an undefined filename`
- [`91945c9`](https://github.com/KeywordBrain/redbox-react/commit/91945c9b92bc1a4d06b8fc3cf3a56a620c7e9d02) `chore(readme): fix typo`
- [`c174e2e`](https://github.com/KeywordBrain/redbox-react/commit/c174e2e6d4cf8b194d8411c411dc2a29b70987c9) `chore(license): add author's name to LICENSE.md`
- [`76f0d95`](https://github.com/KeywordBrain/redbox-react/commit/76f0d957d68d21b28d5f2acd0d7ba98058c1b7da) `chore(npm): ignore examples folder`
- [`6b44f19`](https://github.com/KeywordBrain/redbox-react/commit/6b44f19fd47242eafd297c9259addd21df72eae9) `feat(links): open files in configured editor`
- [`f0229c5`](https://github.com/KeywordBrain/redbox-react/commit/f0229c5169422e2b59ffd9253b72956fdafc4dbf) `chore(readme): extend usage description`
- [`dd09896`](https://github.com/KeywordBrain/redbox-react/commit/dd098969f314d695685144b11033d717aad37147) `fix: replace Object.assign with polyfill`

See the [full diff](https://github.com/KeywordBrain/redbox-react/compare/8445b3f61069ed9224e6704c758574a7e573ac0e...4928e0e38c0660e9c0e6c67f0c1168ba348b174b).

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
