### PR TITLE
Improve themeing support

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "postcss-calc": "^5.0.0",
     "postcss-color-function": "^2.0.0",
     "postcss-import": "^8.0.2",
+    "postcss-map": "^0.8.0",
     "postcss-nested": "^1.0.0",
     "postcss-simple-vars": "^2.0.0",
     "proxyquire": "^1.7.4",

--- a/src/MuiTheme.js
+++ b/src/MuiTheme.js
@@ -2,6 +2,8 @@ import * as Colors from 'material-ui/styles/colors';
 import * as ColorManipulator from 'material-ui/utils/colorManipulator';
 import * as Spacing from 'material-ui/styles/spacing';
 
+const backgroundColor = '#151515';
+
 export default {
   spacing: Spacing,
   fontFamily: 'Open Sans, sans-serif',
@@ -13,6 +15,16 @@ export default {
     default: ''
   },
   palette: {
+    nullColor: Colors.black,
+
+    backgroundColor,
+    backgroundHighlightColor: ColorManipulator.lighten(backgroundColor, 0.1, '1.0'),
+
+    chatColor: ColorManipulator.darken(backgroundColor, 0.1),
+    chatColorAlternate: ColorManipulator.darken(backgroundColor, 0.15),
+
+    linkColor: '#c72e6c',
+
     primary1Color: '#9d2053',
     primary2Color: '#b20062',
     primary3Color: Colors.lightWhite,

--- a/src/MuiTheme.js
+++ b/src/MuiTheme.js
@@ -1,8 +1,8 @@
-import * as Colors from 'material-ui/styles/colors';
-import * as ColorManipulator from 'material-ui/utils/colorManipulator';
+import { black, darkBlack, white } from 'material-ui/styles/colors';
+import { fade } from 'material-ui/utils/colorManipulator';
 import * as Spacing from 'material-ui/styles/spacing';
 
-const backgroundColor = '#151515';
+import createPalette from './utils/createPalette';
 
 export default {
   spacing: Spacing,
@@ -14,32 +14,21 @@ export default {
     special: '#fc911d',
     default: ''
   },
-  palette: {
-    nullColor: Colors.black,
-
-    backgroundColor,
-    backgroundHighlightColor: ColorManipulator.lighten(backgroundColor, 0.1, '1.0'),
-
-    chatColor: ColorManipulator.darken(backgroundColor, 0.1),
-    chatColorAlternate: ColorManipulator.darken(backgroundColor, 0.15),
-
+  palette: createPalette({
+    nullColor: black,
+    backgroundColor: '#151515',
+    backgroundHighlightColor: '#111111',
     linkColor: '#c72e6c',
-
-    primary1Color: '#9d2053',
-    primary2Color: '#b20062',
-    primary3Color: Colors.lightWhite,
-    accent1Color: Colors.pinkA200,
-    accent2Color: Colors.grey100,
-    accent3Color: Colors.grey500,
-    textColor: Colors.white,
-    alternateTextColor: '#777777',
+    primaryColor: '#9d2053',
+    highlightColor: '#b20062',
+    textColor: white,
     canvasColor: '#303030',
-    borderColor: ColorManipulator.fade(Colors.fullWhite, 0.3),
-    disabledColor: ColorManipulator.fade(Colors.darkBlack, 0.3),
+    borderColor: fade(white, 0.3),
+    disabledColor: fade(darkBlack, 0.3),
 
     notifications: {
       errorBackgroundColor: '#9d202f',
-      errorTextColor: Colors.white
+      errorTextColor: white
     }
-  }
+  })
 };

--- a/src/components/App/index.css
+++ b/src/components/App/index.css
@@ -18,9 +18,6 @@
 a {
   color: $link-color;
 }
-a:visited {
-  color: $link-visited-color;
-}
 
 @component App {
   font-family: Open Sans, sans-serif;

--- a/src/components/Chat/Input.css
+++ b/src/components/Chat/Input.css
@@ -16,11 +16,11 @@
     padding: 0 6px;
     border: 1px solid $chat-border-color;
     background: #222222;
-    color: #fff;
+    color: $text-color;
     font-size: 10pt;
 
     @when focused {
-      border-color: #9d2053;
+      border-color: $highbright-color;
       outline: none;
     }
   }

--- a/src/components/Dialogs/Dialog.css
+++ b/src/components/Dialogs/Dialog.css
@@ -1,3 +1,3 @@
 @component Dialog {
-  color: #fff;
+  color: $text-color;
 }

--- a/src/components/FooterBar/UserInfo.js
+++ b/src/components/FooterBar/UserInfo.js
@@ -2,6 +2,7 @@ import cx from 'classnames';
 import * as React from 'react';
 import pure from 'recompose/pure';
 import SettingsIcon from 'material-ui/svg-icons/action/settings';
+import muiThemeable from 'material-ui/styles/muiThemeable';
 
 import Avatar from '../Avatar';
 
@@ -10,7 +11,7 @@ const fullSizeStyle = {
   height: '100%'
 };
 
-const UserInfo = ({ className, user, ...attrs }) => (
+const UserInfo = ({ className, user, muiTheme, ...attrs }) => (
   <div
     className={cx('UserInfo', className)}
     {...attrs}
@@ -21,7 +22,7 @@ const UserInfo = ({ className, user, ...attrs }) => (
     />
     <div className="UserInfo-settings">
       <SettingsIcon
-        color="#fff"
+        color={muiTheme.palette.textColor}
         style={fullSizeStyle}
       />
     </div>
@@ -30,7 +31,8 @@ const UserInfo = ({ className, user, ...attrs }) => (
 
 UserInfo.propTypes = {
   className: React.PropTypes.string,
+  muiTheme: React.PropTypes.object.isRequired,
   user: React.PropTypes.object.isRequired
 };
 
-export default pure(UserInfo);
+export default muiThemeable()(pure(UserInfo));

--- a/src/components/FooterBar/index.css
+++ b/src/components/FooterBar/index.css
@@ -68,7 +68,7 @@
   display: block;
   float: left;
   cursor: pointer;
-  color: #fff;
+  color: $text-color;
   font-size: 12pt;
 
   @modifier login {

--- a/src/components/Form/Button.css
+++ b/src/components/Form/Button.css
@@ -10,7 +10,7 @@
   border-bottom-color: color($highlight-color blend(white 5%));
   border-right-color: color($highlight-color blend(white 5%));
 
-  color: #fff;
+  color: $text-color;
   text-transform: uppercase;
   font-size: 12pt;
 

--- a/src/components/Form/TextField.css
+++ b/src/components/Form/TextField.css
@@ -1,10 +1,12 @@
 @import "../../vars.css";
 
+$canvas-color: map(theme, palette, canvasColor);
+
 @component TextField {
-  background: #383838;
-  border: 1px solid #2c2c2c;
-  border-top-color: #3e3e3e;
-  border-right-color: #3e3e3e;
+  background: color($canvas-color blend(white 5%));
+  border: 1px solid color($canvas-color blend(black 10%));
+  border-top-color: color($canvas-color blend(black 5%));
+  border-right-color: color($canvas-color blend(black 5%));
   height: $forms-textfield-size;
   font-size: 12pt;
 
@@ -19,10 +21,10 @@
     padding: 0 $forms-element-margin;
     padding-right: $forms-textfield-size;
     font-size: 12pt;
-    color: #fff;
+    color: $text-color;
 
     &::placeholder {
-      color: #9f9d9e;
+      color: color($text-color saturation(- 10%));
     }
   }
 

--- a/src/components/HeaderBar/HistoryButton.js
+++ b/src/components/HeaderBar/HistoryButton.js
@@ -2,10 +2,11 @@ import * as React from 'react';
 import pure from 'recompose/pure';
 import IconButton from 'material-ui/IconButton';
 import HistoryIcon from 'material-ui/svg-icons/action/history';
+import muiThemeable from 'material-ui/styles/muiThemeable';
 
 const fullSize = { width: '100%', height: '100%' };
 
-const HistoryButton = ({ onClick }) => (
+const HistoryButton = ({ onClick, muiTheme }) => (
   <IconButton
     className="HeaderHistoryButton"
     style={fullSize}
@@ -15,14 +16,15 @@ const HistoryButton = ({ onClick }) => (
   >
     <HistoryIcon
       style={fullSize}
-      color="#fff"
+      color={muiTheme.palette.textColor}
       className="HeaderHistoryButton-icon"
     />
   </IconButton>
 );
 
 HistoryButton.propTypes = {
-  onClick: React.PropTypes.func.isRequired
+  onClick: React.PropTypes.func.isRequired,
+  muiTheme: React.PropTypes.object.isRequired
 };
 
-export default pure(HistoryButton);
+export default muiThemeable()(pure(HistoryButton));

--- a/src/components/HeaderBar/Volume.js
+++ b/src/components/HeaderBar/Volume.js
@@ -1,10 +1,11 @@
 import cx from 'classnames';
-import React from 'react';
+import * as React from 'react';
 import Slider from 'material-ui/Slider';
 import VolumeDownIcon from 'material-ui/svg-icons/av/volume-down';
 import VolumeMuteIcon from 'material-ui/svg-icons/av/volume-mute';
 import VolumeOffIcon from 'material-ui/svg-icons/av/volume-off';
 import VolumeUpIcon from 'material-ui/svg-icons/av/volume-up';
+import muiThemeable from 'material-ui/styles/muiThemeable';
 
 const sliderStyle = {
   // The material-ui Slider has a 24px margin on top that we can't override,
@@ -14,6 +15,7 @@ const sliderStyle = {
   marginBottom: 3
 };
 
+@muiThemeable()
 export default class Volume extends React.Component {
   static propTypes = {
     className: React.PropTypes.string,
@@ -22,7 +24,8 @@ export default class Volume extends React.Component {
 
     onVolumeChange: React.PropTypes.func,
     onMute: React.PropTypes.func,
-    onUnmute: React.PropTypes.func
+    onUnmute: React.PropTypes.func,
+    muiTheme: React.PropTypes.object.isRequired
   };
 
   shouldComponentUpdate(nextProps) {
@@ -43,18 +46,26 @@ export default class Volume extends React.Component {
   };
 
   render() {
+    const {
+      muiTheme,
+      className,
+      muted,
+      volume
+    } = this.props;
+
     let VolumeIcon = VolumeUpIcon;
-    if (this.props.muted) {
+    if (muted) {
       VolumeIcon = VolumeOffIcon;
-    } else if (this.props.volume === 0) {
+    } else if (volume === 0) {
       VolumeIcon = VolumeMuteIcon;
-    } else if (this.props.volume < 50) {
+    } else if (volume < 50) {
       VolumeIcon = VolumeDownIcon;
     }
+
     return (
-      <div className={cx('VolumeSlider', this.props.className)}>
+      <div className={cx('VolumeSlider', className)}>
         <VolumeIcon
-          color="#fff"
+          color={muiTheme.palette.textColor}
           onClick={this.handleMuteClick}
         />
         <div className="VolumeSlider-slider">
@@ -62,7 +73,7 @@ export default class Volume extends React.Component {
             name="volume"
             min={0}
             max={100}
-            defaultValue={this.props.volume}
+            defaultValue={volume}
             style={sliderStyle}
             onChange={this.handleVolumeChange}
           />

--- a/src/components/HeaderBar/index.css
+++ b/src/components/HeaderBar/index.css
@@ -38,7 +38,7 @@
     right: 0;
     bottom: 0;
     width: $header-height;
-    background: #111;
+    background: $background-hover-color;
   }
 
   @descendent now-playing {

--- a/src/components/MediaList/Actions/AddToPlaylist.js
+++ b/src/components/MediaList/Actions/AddToPlaylist.js
@@ -1,12 +1,15 @@
 import React, { Component, PropTypes } from 'react';
 import { findDOMNode } from 'react-dom';
 import AddIcon from 'material-ui/svg-icons/content/add';
+import muiThemeable from 'material-ui/styles/muiThemeable';
 
 import Action from './Action';
 
+@muiThemeable()
 export default class AddToPlaylist extends Component {
   static propTypes = {
-    onAdd: PropTypes.func
+    onAdd: PropTypes.func,
+    muiTheme: PropTypes.object.isRequired
   };
 
   position() {
@@ -18,14 +21,14 @@ export default class AddToPlaylist extends Component {
   }
 
   render() {
-    const { onAdd, ...props } = this.props;
+    const { onAdd, muiTheme, ...props } = this.props;
     return (
       <Action
         ref="button"
         {...props}
         onAction={media => onAdd(this.position(), media)}
       >
-        <AddIcon color="#fff" />
+        <AddIcon color={muiTheme.palette.textColor} />
       </Action>
     );
   }

--- a/src/components/MediaList/Actions/EditMedia.js
+++ b/src/components/MediaList/Actions/EditMedia.js
@@ -1,16 +1,18 @@
 import * as React from 'react';
 import EditIcon from 'material-ui/svg-icons/editor/mode-edit';
+import muiThemeable from 'material-ui/styles/muiThemeable';
 
 import Action from './Action';
 
-const EditMedia = ({ onEdit, ...props }) => (
+const EditMedia = ({ onEdit, muiTheme, ...props }) => (
   <Action {...props} onAction={onEdit}>
-    <EditIcon color="#fff" />
+    <EditIcon color={muiTheme.palette.textColor} />
   </Action>
 );
 
 EditMedia.propTypes = {
-  onEdit: React.PropTypes.func.isRequired
+  onEdit: React.PropTypes.func.isRequired,
+  muiTheme: React.PropTypes.object.isRequired
 };
 
-export default EditMedia;
+export default muiThemeable()(EditMedia);

--- a/src/components/MediaList/Actions/MoveToFirst.js
+++ b/src/components/MediaList/Actions/MoveToFirst.js
@@ -1,16 +1,18 @@
 import * as React from 'react';
 import MoveToFirstIcon from 'material-ui/svg-icons/hardware/keyboard-arrow-up';
+import muiThemeable from 'material-ui/styles/muiThemeable';
 
 import Action from './Action';
 
-const MoveToFirst = ({ onFirst, ...props }) => (
+const MoveToFirst = ({ onFirst, muiTheme, ...props }) => (
   <Action {...props} onAction={onFirst}>
-    <MoveToFirstIcon color="#fff" />
+    <MoveToFirstIcon color={muiTheme.palette.textColor} />
   </Action>
 );
 
 MoveToFirst.propTypes = {
-  onFirst: React.PropTypes.func.isRequired
+  onFirst: React.PropTypes.func.isRequired,
+  muiTheme: React.PropTypes.object.isRequired
 };
 
-export default MoveToFirst;
+export default muiThemeable()(MoveToFirst);

--- a/src/components/MediaList/Actions/RemoveFromPlaylist.js
+++ b/src/components/MediaList/Actions/RemoveFromPlaylist.js
@@ -1,16 +1,18 @@
 import * as React from 'react';
 import DeleteIcon from 'material-ui/svg-icons/action/delete';
+import muiThemeable from 'material-ui/styles/muiThemeable';
 
 import Action from './Action';
 
-const RemoveFromPlaylist = ({ onRemove, ...props }) => (
+const RemoveFromPlaylist = ({ onRemove, muiTheme, ...props }) => (
   <Action {...props} onAction={onRemove}>
-    <DeleteIcon color="#fff" />
+    <DeleteIcon color={muiTheme.palette.textColor} />
   </Action>
 );
 
 RemoveFromPlaylist.propTypes = {
-  onRemove: React.PropTypes.func.isRequired
+  onRemove: React.PropTypes.func.isRequired,
+  muiTheme: React.PropTypes.object.isRequired
 };
 
-export default RemoveFromPlaylist;
+export default muiThemeable()(RemoveFromPlaylist);

--- a/src/components/Overlay/Header/Close.js
+++ b/src/components/Overlay/Header/Close.js
@@ -2,6 +2,7 @@ import cx from 'classnames';
 import * as React from 'react';
 import CloseBottomIcon from 'material-ui/svg-icons/hardware/keyboard-arrow-down';
 import CloseTopIcon from 'material-ui/svg-icons/hardware/keyboard-arrow-up';
+import muiThemeable from 'material-ui/styles/muiThemeable';
 
 const icons = {
   bottom: CloseBottomIcon,
@@ -13,7 +14,7 @@ const fullSizeStyle = {
   width: '100%'
 };
 
-const Close = ({ className, onClose, direction }) => {
+const Close = ({ className, onClose, direction, muiTheme }) => {
   const CloseIcon = icons[direction];
   return (
     <div
@@ -22,7 +23,7 @@ const Close = ({ className, onClose, direction }) => {
       onClick={onClose}
     >
       <CloseIcon
-        color="#fff"
+        color={muiTheme.palette.textColor}
         style={fullSizeStyle}
         className="OverlayHeaderClose-icon"
       />
@@ -33,7 +34,8 @@ const Close = ({ className, onClose, direction }) => {
 Close.propTypes = {
   className: React.PropTypes.string,
   direction: React.PropTypes.string.isRequired,
-  onClose: React.PropTypes.func.isRequired
+  onClose: React.PropTypes.func.isRequired,
+  muiTheme: React.PropTypes.object.isRequired
 };
 
-export default Close;
+export default muiThemeable()(Close);

--- a/src/components/PlaylistManager/Header/SearchBar.js
+++ b/src/components/PlaylistManager/Header/SearchBar.js
@@ -1,14 +1,18 @@
 import cx from 'classnames';
 import React, { Component, PropTypes } from 'react';
 import SearchIcon from 'material-ui/svg-icons/action/search';
+import muiThemeable from 'material-ui/styles/muiThemeable';
+
 import SourcePicker from './SourcePicker';
 
+@muiThemeable()
 export default class SearchBar extends Component {
   static propTypes = {
     className: PropTypes.string,
     source: PropTypes.string,
     onSubmit: PropTypes.func,
-    onSourceChange: PropTypes.func
+    onSourceChange: PropTypes.func,
+    muiTheme: PropTypes.object.isRequired
   };
 
   state = { focused: false };
@@ -28,12 +32,12 @@ export default class SearchBar extends Component {
   };
 
   render() {
-    const { source, onSourceChange } = this.props;
+    const { source, onSourceChange, muiTheme } = this.props;
     const { focused } = this.state;
     return (
       <div className={cx('SearchBar', focused ? 'is-focused' : '', this.props.className)}>
         <div className="SearchBar-icon">
-          <SearchIcon color="#fff" />
+          <SearchIcon color={muiTheme.palette.textColor} />
         </div>
         <SourcePicker
           className="SearchBar-source"

--- a/src/components/PlaylistManager/Menu/NewPlaylist.js
+++ b/src/components/PlaylistManager/Menu/NewPlaylist.js
@@ -1,11 +1,15 @@
 import cx from 'classnames';
 import * as React from 'react';
 import CreatePlaylistIcon from 'material-ui/svg-icons/content/add';
+import muiThemeable from 'material-ui/styles/muiThemeable';
 
 import PromptDialog from '../../Dialogs/PromptDialog';
 
+@muiThemeable()
 export default class NewPlaylist extends React.Component {
   static propTypes = {
+    muiTheme: React.PropTypes.object.isRequired,
+
     className: React.PropTypes.string,
     onCreatePlaylist: React.PropTypes.func.isRequired
   };
@@ -31,7 +35,11 @@ export default class NewPlaylist extends React.Component {
       .then(this.closeDialog.bind(this));
 
   render() {
-    const { className } = this.props;
+    const {
+      muiTheme,
+      className
+    } = this.props;
+
     return (
       <div
         role="menuitem"
@@ -40,7 +48,7 @@ export default class NewPlaylist extends React.Component {
       >
         <div className="PlaylistMenuRow-title">
           <div className="PlaylistMenuRow-active-icon">
-            <CreatePlaylistIcon color="#fff" />
+            <CreatePlaylistIcon color={muiTheme.palette.textColor} />
           </div>
           Create Playlist
         </div>

--- a/src/components/PlaylistManager/Menu/Row.js
+++ b/src/components/PlaylistManager/Menu/Row.js
@@ -2,6 +2,8 @@ import cx from 'classnames';
 import React, { Component, PropTypes } from 'react';
 import { DropTarget } from 'react-dnd';
 import ActiveIcon from 'material-ui/svg-icons/navigation/check';
+import muiThemeable from 'material-ui/styles/muiThemeable';
+
 import { MEDIA } from '../../../constants/DDItemTypes';
 import Loader from '../../Loader';
 
@@ -18,6 +20,7 @@ const collect = (connect, monitor) => ({
 });
 
 @DropTarget(MEDIA, playlistTarget, collect)
+@muiThemeable()
 export default class PlaylistRow extends Component {
   static propTypes = {
     className: PropTypes.string,
@@ -27,7 +30,9 @@ export default class PlaylistRow extends Component {
 
     connectDropTarget: PropTypes.func.isRequired,
     onClick: PropTypes.func,
-    onAddToPlaylist: PropTypes.func
+    onAddToPlaylist: PropTypes.func,
+
+    muiTheme: PropTypes.object.isRequired
   };
 
   render() {
@@ -39,7 +44,8 @@ export default class PlaylistRow extends Component {
       onClick,
 
       connectDropTarget,
-      isOver
+      isOver,
+      muiTheme
     } = this.props;
     const activeClass = playlist.active && 'is-active';
     const selectedClass = selected && 'is-selected';
@@ -55,7 +61,7 @@ export default class PlaylistRow extends Component {
     } else if (playlist.active) {
       icon = (
         <div className="PlaylistMenuRow-active-icon">
-          <ActiveIcon color="#fff" />
+          <ActiveIcon color={muiTheme.palette.textColor} />
         </div>
       );
     }

--- a/src/components/PlaylistManager/Menu/SearchResultsRow.js
+++ b/src/components/PlaylistManager/Menu/SearchResultsRow.js
@@ -2,17 +2,20 @@
 import cx from 'classnames';
 import React, { Component, PropTypes } from 'react';
 import SearchIcon from 'material-ui/svg-icons/action/search';
+import muiThemeable from 'material-ui/styles/muiThemeable';
 
+@muiThemeable()
 export default class SearchResultsRow extends Component {
   static propTypes = {
     className: PropTypes.string,
     query: PropTypes.string,
     size: PropTypes.number,
-    onClick: PropTypes.func
+    onClick: PropTypes.func,
+    muiTheme: PropTypes.object.isRequired
   };
 
   render() {
-    const { className, query, size, onClick } = this.props;
+    const { className, query, size, onClick, muiTheme } = this.props;
     return (
       <div
         role="menuitem"
@@ -21,7 +24,7 @@ export default class SearchResultsRow extends Component {
       >
         <div className="PlaylistMenuRow-title">
           <div className="PlaylistMenuRow-active-icon">
-            <SearchIcon color="#fff" />
+            <SearchIcon color={muiTheme.palette.textColor} />
           </div>
           "{query}"
         </div>

--- a/src/components/PlaylistManager/Panel/DeletePlaylistButton.js
+++ b/src/components/PlaylistManager/Panel/DeletePlaylistButton.js
@@ -1,12 +1,16 @@
 import * as React from 'react';
 import IconButton from 'material-ui/IconButton';
 import DeleteIcon from 'material-ui/svg-icons/action/delete';
+import muiThemeable from 'material-ui/styles/muiThemeable';
 
 import ConfirmDialog from '../../Dialogs/ConfirmDialog';
 import FormGroup from '../../Form/Group';
 
+@muiThemeable()
 export default class DeletePlaylistButton extends React.Component {
   static propTypes = {
+    muiTheme: React.PropTypes.object.isRequired,
+
     onDelete: React.PropTypes.func.isRequired,
     onNotDeletable: React.PropTypes.func.isRequired,
     active: React.PropTypes.bool
@@ -37,7 +41,12 @@ export default class DeletePlaylistButton extends React.Component {
       .then(this.closeDialog.bind(this));
 
   render() {
-    const hoverColor = this.props.active ? '#555' : '#fff';
+    const {
+      muiTheme,
+      active
+    } = this.props;
+
+    const hoverColor = active ? '#555' : muiTheme.palette.textColor;
     return (
       <IconButton
         onClick={this.handleOpen}

--- a/src/components/PlaylistManager/Panel/Meta.js
+++ b/src/components/PlaylistManager/Panel/Meta.js
@@ -10,6 +10,7 @@ import DeletePlaylistButton from './DeletePlaylistButton';
 const checkboxIconStyle = { fill: '#fff' };
 
 const PlaylistMeta = ({
+  muiTheme,
   className,
   active,
   id,
@@ -27,8 +28,8 @@ const PlaylistMeta = ({
       <Checkbox
         checked={active}
         onCheck={() => !active && onActivatePlaylist(id)}
-        checkedIcon={<ActiveIcon color="#fff" />}
-        uncheckedIcon={<ActivateIcon color="#fff" />}
+        checkedIcon={<ActiveIcon color={muiTheme.palette.textColor} />}
+        uncheckedIcon={<ActivateIcon color={muiTheme.palette.textColor} />}
         iconStyle={checkboxIconStyle}
         label={active ? 'Active' : 'Activate'}
       />
@@ -46,6 +47,7 @@ const PlaylistMeta = ({
 );
 
 PlaylistMeta.propTypes = {
+  muiTheme: React.PropTypes.object.isRequired,
   className: React.PropTypes.string,
   active: React.PropTypes.bool.isRequired,
   id: React.PropTypes.string.isRequired,
@@ -56,4 +58,4 @@ PlaylistMeta.propTypes = {
   onNotDeletable: React.PropTypes.func.isRequired
 };
 
-export default PlaylistMeta;
+export default muiThemeable()(PlaylistMeta);

--- a/src/components/PlaylistManager/Panel/Meta.js
+++ b/src/components/PlaylistManager/Panel/Meta.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 import Checkbox from 'material-ui/Checkbox';
 import ActiveIcon from 'material-ui/svg-icons/toggle/check-box';
 import ActivateIcon from 'material-ui/svg-icons/toggle/check-box-outline-blank';
+import muiThemeable from 'material-ui/styles/muiThemeable';
 
 import RenamePlaylistButton from './RenamePlaylistButton';
 import DeletePlaylistButton from './DeletePlaylistButton';

--- a/src/components/PlaylistManager/Panel/RenamePlaylistButton.js
+++ b/src/components/PlaylistManager/Panel/RenamePlaylistButton.js
@@ -1,11 +1,15 @@
 import * as React from 'react';
 import IconButton from 'material-ui/IconButton';
 import EditIcon from 'material-ui/svg-icons/editor/mode-edit';
+import muiThemeable from 'material-ui/styles/muiThemeable';
 
 import PromptDialog from '../../Dialogs/PromptDialog';
 
+@muiThemeable()
 export default class RenamePlaylistButton extends React.Component {
   static propTypes = {
+    muiTheme: React.PropTypes.object.isRequired,
+
     onRename: React.PropTypes.func.isRequired,
     initialName: React.PropTypes.string
   };
@@ -31,19 +35,24 @@ export default class RenamePlaylistButton extends React.Component {
       .then(this.closeDialog.bind(this));
 
   render() {
+    const {
+      muiTheme,
+      initialName
+    } = this.props;
+
     return (
       <IconButton
         onClick={this.handleOpen}
         tooltip="Rename"
         tooltipPosition="top-center"
       >
-        <EditIcon color="#555" hoverColor="#fff" />
+        <EditIcon color="#555" hoverColor={muiTheme.palette.textColor} />
         {this.state.renaming && (
           <PromptDialog
             title="Playlist Name"
             submitLabel="Rename"
             icon={<EditIcon color="#777" />}
-            value={this.props.initialName}
+            value={initialName}
             onSubmit={this.handleSubmit}
             onCancel={this.handleClose}
           />

--- a/src/components/SettingsManager/ChangeUsernameButton.js
+++ b/src/components/SettingsManager/ChangeUsernameButton.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import IconButton from 'material-ui/IconButton';
 import EditIcon from 'material-ui/svg-icons/editor/mode-edit';
+import muiThemeable from 'material-ui/styles/muiThemeable';
 
 import PromptDialog from '../Dialogs/PromptDialog';
 
@@ -18,8 +19,11 @@ const changeNameIconStyle = {
   padding: 2
 };
 
+@muiThemeable()
 export default class ChangeUsernameButton extends React.Component {
   static propTypes = {
+    muiTheme: React.PropTypes.object.isRequired,
+
     onChangeUsername: React.PropTypes.func.isRequired,
     initialUsername: React.PropTypes.string
   };
@@ -45,6 +49,11 @@ export default class ChangeUsernameButton extends React.Component {
       .then(this.closeDialog.bind(this));
 
   render() {
+    const {
+      muiTheme,
+      initialUsername
+    } = this.props;
+
     return (
       <IconButton
         style={changeNameButtonStyle}
@@ -53,14 +62,14 @@ export default class ChangeUsernameButton extends React.Component {
       >
         <EditIcon
           color="#777"
-          hoverColor="#fff"
+          hoverColor={muiTheme.palette.textColor}
         />
         {this.state.changingUsername && (
           <PromptDialog
             title="Change Username"
             submitLabel="Save"
             icon={<EditIcon color="#777" />}
-            value={this.props.initialUsername}
+            value={initialUsername}
             onSubmit={this.handleSubmit}
             onCancel={this.handleClose}
           />

--- a/src/components/SidePanels/index.js
+++ b/src/components/SidePanels/index.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import pure from 'recompose/pure';
 import { Tabs, Tab } from 'material-ui/Tabs';
+import muiThemeable from 'material-ui/styles/muiThemeable';
 
 import Chat from '../../containers/Chat';
 import ChatInput from '../Chat/Input';
@@ -9,35 +10,35 @@ import WaitList from '../../containers/WaitList';
 
 import PanelTemplate from './PanelTemplate';
 
-const tabItemContainerStyle = {
+const tabItemContainerStyle = ({ palette }) => ({
   height: 56,
-  backgroundColor: '#151515'
-};
+  backgroundColor: palette.backgroundColor
+});
 
-const tabStyle = {
+const tabStyle = ({ palette }) => ({
   float: 'left',
-  color: '#fff',
+  color: palette.textColor,
   fontSize: '10pt',
   height: '100%',
-  backgroundColor: '#151515'
-};
+  backgroundColor: palette.backgroundColor
+});
 
-const activeTabStyle = {
-  ...tabStyle,
-  backgroundColor: 'rgba(48, 48, 48, 0.3)'
-};
+const activeTabStyle = theme => ({
+  ...tabStyle(theme),
+  backgroundColor: '#222'
+});
 
-const inkBarStyle = {
+const inkBarStyle = ({ palette }) => ({
   height: 3,
   marginTop: -3,
-  backgroundColor: '#fff'
-};
+  backgroundColor: palette.textColor
+});
 
-const contentStyle = {
+const contentStyle = () => ({
   // This ensures that the `position:absolute`s on divs _inside_ container
   // elements align correctly.
   position: 'static'
-};
+});
 
 const subHeaderStyle = {
   fontSize: '125%'
@@ -58,6 +59,7 @@ const getWaitlistLabel = (size, position) => {
 };
 
 const SidePanels = ({
+  muiTheme,
   selected,
   isLoggedIn,
   listenerCount,
@@ -69,9 +71,9 @@ const SidePanels = ({
   <Tabs
     value={selected}
     onChange={onChange}
-    tabItemContainerStyle={tabItemContainerStyle}
-    inkBarStyle={inkBarStyle}
-    contentContainerStyle={contentStyle}
+    tabItemContainerStyle={tabItemContainerStyle(muiTheme)}
+    inkBarStyle={inkBarStyle(muiTheme)}
+    contentContainerStyle={contentStyle(muiTheme)}
     tabTemplate={PanelTemplate}
   >
     {/* Disabled touch ripples on tabs because they're offset weirdly. Also,
@@ -88,7 +90,7 @@ const SidePanels = ({
       disableTouchRipple
       label="Chat"
       value="chat"
-      style={selected === 'chat' ? activeTabStyle : tabStyle}
+      style={selected === 'chat' ? activeTabStyle(muiTheme) : tabStyle(muiTheme)}
     >
       <div className="AppRow AppRow--middle">
         <Chat />
@@ -107,7 +109,7 @@ const SidePanels = ({
         </span>
       ]}
       value="room"
-      style={selected === 'room' ? activeTabStyle : tabStyle}
+      style={selected === 'room' ? activeTabStyle(muiTheme) : tabStyle(muiTheme)}
     >
       <div className="AppRow AppRow--middle">
         <RoomUserList />
@@ -118,7 +120,7 @@ const SidePanels = ({
       disableTouchRipple
       label={getWaitlistLabel(waitlistSize, waitlistPosition)}
       value="waitlist"
-      style={selected === 'waitlist' ? activeTabStyle : tabStyle}
+      style={selected === 'waitlist' ? activeTabStyle(muiTheme) : tabStyle(muiTheme)}
     >
       <div className="AppRow AppRow--middle">
         <WaitList />
@@ -128,6 +130,7 @@ const SidePanels = ({
 );
 
 SidePanels.propTypes = {
+  muiTheme: React.PropTypes.object.isRequired,
   selected: React.PropTypes.string.isRequired,
   isLoggedIn: React.PropTypes.bool.isRequired,
   listenerCount: React.PropTypes.number.isRequired,
@@ -137,4 +140,4 @@ SidePanels.propTypes = {
   sendChatMessage: React.PropTypes.func.isRequired
 };
 
-export default pure(SidePanels);
+export default muiThemeable()(pure(SidePanels));

--- a/src/components/Video/index.css
+++ b/src/components/Video/index.css
@@ -5,5 +5,5 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
-  background: black;
+  background: map(theme, palette, nullColor);
 }

--- a/src/utils/createPalette.js
+++ b/src/utils/createPalette.js
@@ -1,0 +1,63 @@
+import * as Colors from 'material-ui/styles/colors';
+import {
+  getLuminance,
+  emphasize,
+  fade,
+  lighten,
+  darken
+} from 'material-ui/utils/colorManipulator';
+
+function deemphasize(color, coefficient = 0.15) {
+  return getLuminance(color) > 0.5 ?
+    lighten(color, coefficient) :
+    darken(color, coefficient);
+}
+
+/**
+ * Create a material-ui palette with nice-ish derived defaults. The only
+ * required parameters are `canvasColor` and `primaryColor`.
+ *
+ * The background color defaults to black, and the text color defaults to white.
+ * Every other color is derived from the given colors, but can be overridden
+ * simply by passing them in.
+ */
+export default function createPalette({
+  backgroundColor = Colors.darkBlack,
+  canvasColor,
+  primaryColor,
+  highlightColor = emphasize(primaryColor, 0.1),
+  nullColor = Colors.black,
+  textColor = Colors.white,
+  ...rest
+}) {
+  const theme = {
+    nullColor,
+
+    backgroundColor,
+    primary1Color: primaryColor,
+    primary2Color: highlightColor,
+    primary3Color: Colors.lightWhite,
+    accent1Color: Colors.pinkA200,
+    accent2Color: Colors.grey100,
+    accent3Color: Colors.grey500,
+    textColor,
+    alternateTextColor: '#777777',
+    canvasColor,
+    borderColor: Colors.grey300,
+    disabledColor: fade(Colors.darkBlack, 0.3),
+
+    ...rest
+  };
+
+  return {
+    backgroundHighlightColor: deemphasize(theme.backgroundColor, 0.1),
+
+    linkColor: theme.primaryColor,
+    linkColorVisited: darken(theme.primary1Color, 0.5),
+
+    chatColor: darken(theme.backgroundColor, 0.1),
+    chatColorAlternate: darken(theme.backgroundColor, 0.15),
+
+    ...theme
+  };
+}

--- a/src/vars.css
+++ b/src/vars.css
@@ -1,3 +1,6 @@
+/* Utilities */
+$-average-color: color(black blend(white 50%));
+
 /* Global colours */
 $text-color: map(theme, palette, textColor);
 $muted-text-color: map(theme, palette, alternateTextColor);
@@ -14,7 +17,7 @@ $header-height: 56px;
 $footer-height: 60px;
 
 /* Footer colours */
-$footer-border-color: #303036;
+$footer-border-color: color($background-color blend($-average-color 30%));
 
 /* Overlay colours & sizes */
 $overlay-header-close-size: $header-height;

--- a/src/vars.css
+++ b/src/vars.css
@@ -1,15 +1,13 @@
 /* Global colours */
-$text-color: #fff;
-$muted-text-color: #777;
-$background-color: #151515;
-$background-hover-color: #111;
-$highlight-color: #9d2053;
-$highbright-color: #b20062;
+$text-color: map(theme, palette, textColor);
+$muted-text-color: map(theme, palette, alternateTextColor);
+$background-color: map(theme, palette, backgroundColor);
+$background-hover-color: map(theme, palette, backgroundHighlightColor);
+$highlight-color: map(theme, palette, primary1Color);
+$highbright-color: map(theme, palette, primary2Color);
 $scrollbar-color: #5f5f5f;
 
-/* Link colors */
-$link-color: #c72e6c;
-$link-visited-color: $link-color;
+$link-color: map(theme, palette, linkColor);
 
 /* Sizes */
 $header-height: 56px;
@@ -22,13 +20,13 @@ $footer-border-color: #303036;
 $overlay-header-close-size: $header-height;
 
 /* Chat colours */
-$chat-background-color: #1b1b1b;
-$chat-background-color2: #222222;
+$chat-background-color: map(theme, palette, chatColor);
+$chat-background-color2: map(theme, palette, chatColorAlternate);
 $chat-border-color: $footer-border-color;
 
 /* User related colours */
-$user-list-color: #1b1b1b;
-$user-list-alternate-color: #222222;
+$user-list-color: map(theme, palette, chatColor);
+$user-list-alternate-color: map(theme, palette, chatColorAlternate);
 
 /* Playlist colours & sizing */
 $media-list-spacing: 3%;

--- a/tasks/compile-css.js
+++ b/tasks/compile-css.js
@@ -10,10 +10,16 @@ import imports from 'postcss-import';
 import nested from 'postcss-nested';
 import reduceCalc from 'postcss-calc';
 import variables from 'postcss-simple-vars';
+import map from 'postcss-map';
+
+import baseTheme from '../src/MuiTheme';
 
 export default function compileCssTask({ minify = false, 'source-maps': useSourceMaps = true }) {
   const processors = [
     imports(),
+    map({
+      maps: [ { theme: baseTheme } ]
+    }),
     variables(),
     bem(),
     nested(),


### PR DESCRIPTION
Start consistently using the theme colours everywhere, including in the CSS. This uses the theme defined in `MuiTheme.js` for the CSS, instead of duplicating the colour variables in `vars.css`.

A lot of hardcoded colours are changed to variables.

This also adds a `createPalette` helper function to generate a full material-ui theme palette based on just a few provided values.

Todo:
- Add theme to config, so instead of `import`ing `MuiTheme.js`, the client will read it from its config.
- Add build-time config file option (separate PR)
