### PR TITLE
deps: upgrade material-ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "is-equal-shallow": "^0.1.3",
     "item-selection": "^1.0.0",
     "load-script": "^1.0.0",
-    "material-ui": "^0.15.0-beta.1",
+    "material-ui": "^0.15.0",
     "ms": "^0.7.1",
     "natural-compare": "^1.2.2",
     "normalize.css": "^4.1.1",

--- a/src/components/FooterBar/WaitlistButton.js
+++ b/src/components/FooterBar/WaitlistButton.js
@@ -10,6 +10,12 @@ const inlineIconStyle = {
   height: '1em'
 };
 
+const buttonStyle = {
+  height: '100%',
+  fontSize: '11pt',
+  textTransform: 'uppercase'
+};
+
 const WaitlistButton = ({
   muiTheme,
   userInWaitlist, isLocked, onClick
@@ -34,14 +40,7 @@ const WaitlistButton = ({
       className={cx('FooterBar-join', isLocked && 'FooterBar-join--locked')}
       disabled={isLocked && !userInWaitlist}
       onClick={onClick}
-      style={{
-        // Workaround for a React issue where `background` and
-        // `background-color` styles are applied in the incorrect order, leading
-        // the material-ui builtin "background: None" style to override the
-        // backgroundColor prop below on the initial render.
-        // https://github.com/facebook/react/issues/6524
-        background: muiTheme.palette.primary1Color
-      }}
+      style={buttonStyle}
       backgroundColor={muiTheme.palette.primary1Color}
       hoverColor={muiTheme.palette.primary2Color}
       rippleColor={muiTheme.palette.primary3Color}

--- a/src/components/HeaderBar/Volume.js
+++ b/src/components/HeaderBar/Volume.js
@@ -7,7 +7,10 @@ import VolumeOffIcon from 'material-ui/svg-icons/av/volume-off';
 import VolumeUpIcon from 'material-ui/svg-icons/av/volume-up';
 
 const sliderStyle = {
-  marginTop: 3,
+  // The material-ui Slider has a 24px margin on top that we can't override,
+  // but we can compensate for it here.
+  // TODO Do this properly when/if material-ui gets a better styling solution.
+  marginTop: -21,
   marginBottom: 3
 };
 


### PR DESCRIPTION
Breaks two things:
- Join Waitlist button size (gets `height:36px` instead of 100% for some reason)
- Volume slider position
