### PR TITLE
chat: fix MOTD not wrapping around at the end of each line

### DIFF
--- a/src/components/Chat/Motd.css
+++ b/src/components/Chat/Motd.css
@@ -3,7 +3,7 @@
     /* TODO add support for @descendent inside @modifier to postcss-bem */
     .ChatMessage-content {
       padding-left: 10px;
-      white-space: pre;
+      white-space: pre-wrap;
       color: #eee;
     }
   }


### PR DESCRIPTION
long messages overflow to the right with just `white-space: pre`
