### PR TITLE
build: exclude unused modules from minified builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "through2": "^2.0.1",
     "u-wave-source-soundcloud": "^1.0.0",
     "u-wave-source-youtube": "^1.0.0",
+    "uglifyify": "^3.0.1",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.4.0"
   },

--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -2,6 +2,7 @@ import { dest } from 'gulp';
 import { buildExternalHelpers } from 'babel-core';
 import babelify from 'babelify';
 import browserify from 'browserify';
+import uglifyify from 'uglifyify';
 import buffer from 'gulp-buffer';
 import collapse from 'bundle-collapser/plugin';
 import envify from 'envify/custom';
@@ -63,6 +64,10 @@ export default function browserifyTask({ minify = false, 'source-maps': useSourc
   }), { global: true });
 
   if (minify) {
+    b.transform(uglifyify, {
+      global: true,
+      mangle: false
+    });
     // Browserify assigns numbers to all modules, but normally uses the full
     // module names in the compiled source. That's perfectly fine, but we can
     // shave off a bunch of bytes if it'd just use the assigned numbers instead,


### PR DESCRIPTION
Run uglify on modules before bundling them using browserify. Only the compression stuff is used because that does dead code elimination, so references to unused modules are removed and browserify doesn't even include the modules.

Doesn't save much, but does save a little (~2/3kb min/gzip).
