### PR TITLE
u-wave-source-youtube@1.0.1 breaks build 🚨

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "run-sequence": "^1.1.4",
     "through2": "^2.0.1",
     "u-wave-source-soundcloud": "^1.0.0",
-    "u-wave-source-youtube": "^1.0.0",
+    "u-wave-source-youtube": "^1.0.1",
     "uglifyify": "^3.0.1",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.4.0"


### PR DESCRIPTION
Hello :wave:

:rotating_light::rotating_light::rotating_light:

[u-wave-source-youtube](https://www.npmjs.com/package/u-wave-source-youtube) just published its new version 1.0.1, which **is covered by your current version range**. After updating it in your project **the build went from success to failure**.

This means **your software is now malfunctioning**, because of this update. Use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

The new version differs by 6 commits .
- [`00ae977`](https://github.com/u-wave/u-wave-source-youtube/commit/00ae977734ae2ffad68073b1ed47f90f617b90d2) `1.0.1`
- [`5ce795f`](https://github.com/u-wave/u-wave-source-youtube/commit/5ce795feb6286c45168179f9a369d8403a5c8798) `improve playlist item import error message, fixes #2`
- [`af24b80`](https://github.com/u-wave/u-wave-source-youtube/commit/af24b80c3681a811dd35597027fb9d6b627b0963) `chore(package): update googleapis to version 6.1.0 (#5)`
- [`ded7679`](https://github.com/u-wave/u-wave-source-youtube/commit/ded7679999997d5430c2539b5e5fec0cf45d7535) `chore(package): update eslint-config-airbnb-base to version 3.0.0 (#3)`
- [`f4191f0`](https://github.com/u-wave/u-wave-source-youtube/commit/f4191f089900a5f66206f4dd0a8639334ebfa621) `Merge pull request #1 from u-wave/greenkeeper-eslint-config-airbnb-base-2.0.0`
- [`040ecb2`](https://github.com/u-wave/u-wave-source-youtube/commit/040ecb2aeb467d9c2a08e59be33459eec4a98c1d) `chore(package): update eslint-config-airbnb-base to version 2.0.0`

See the [full diff](https://github.com/u-wave/u-wave-source-youtube/compare/0f42ba6ac5b55cb246af878a8661b87461c8c6f6...00ae977734ae2ffad68073b1ed47f90f617b90d2).

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
