### PR TITLE
run-sequence@1.2.0 breaks build ⚠️

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.1",
     "redbox-react": "^1.1.1",
-    "run-sequence": "^1.1.4",
+    "run-sequence": "^1.2.0",
     "through2": "^2.0.1",
     "u-wave-source-soundcloud": "^1.0.0",
     "u-wave-source-youtube": "^1.0.0",


### PR DESCRIPTION
Hello :wave:

:warning::warning::warning:

[run-sequence](https://www.npmjs.com/package/run-sequence) just published its new version 1.2.0, which **is covered by your current version range**. After updating it in your project **the build kept failing**.

This means **it’s possible that your software is malfunctioning**, because of this update. Use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

The new version differs by 8 commits .
- [`603444c`](https://github.com/OverZealous/run-sequence/commit/603444c0bf33f0aaf44703c0d48da2b1078dcaac) `1.2.0`
- [`16be52a`](https://github.com/OverZealous/run-sequence/commit/16be52a89773593b36f99000dfda2a1f6f20c17b) `Merge remote-tracking branch 'origin/master'`
- [`900deab`](https://github.com/OverZealous/run-sequence/commit/900deab0a2ce104766608c6b1e81870a832261f5) `Merge pull request #69 from Cactucs/master`
- [`2ca32fd`](https://github.com/OverZealous/run-sequence/commit/2ca32fdbfc6fe75e18d457f6c42a2596a9b72f28) `Better error reporting`
- [`bbfbe74`](https://github.com/OverZealous/run-sequence/commit/bbfbe74a5c3fe17a5dcb780249f01a4d832168cd) `1.1.5`
- [`2308d7d`](https://github.com/OverZealous/run-sequence/commit/2308d7d61ada091e8e2b09052402e2abae04e805) `Cleaned up readme.  Closes #54, #56, #57`
- [`e140cea`](https://github.com/OverZealous/run-sequence/commit/e140cea71b5e52a29bfdd6438bb65ef67fc948e5) `Merge pull request #53 from lukehorvat/travis-nodejs`
- [`a8753f8`](https://github.com/OverZealous/run-sequence/commit/a8753f88ae7cc9f8550a592c5109207d321e7712) `Add Node.js v4 to Travis config`

See the [full diff](https://github.com/OverZealous/run-sequence/compare/7499ea50699f0badf5f8789434483bdcb69c7480...603444c0bf33f0aaf44703c0d48da2b1078dcaac).

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
