### PR TITLE
Update postcss-simple-vars to version 2.0.0 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "postcss-color-function": "^2.0.0",
     "postcss-import": "^8.0.2",
     "postcss-nested": "^1.0.0",
-    "postcss-simple-vars": "^1.0.1",
+    "postcss-simple-vars": "^2.0.0",
     "proxyquire": "^1.7.4",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.1",


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[postcss-simple-vars](https://www.npmjs.com/package/postcss-simple-vars) just published its new version 2.0.0, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of postcss-simple-vars – otherwise use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

The new version differs by 22 commits .
- [`acef74f`](https://github.com/postcss/postcss-simple-vars/commit/acef74f4bfbe1fad7f481e78cae9a0fab147d4d1) `Release 2.0 version`
- [`1dd3ce9`](https://github.com/postcss/postcss-simple-vars/commit/1dd3ce9054f4b5e5924f6fd9f8aaf819ff92e8a2) `Ignore AVA tests`
- [`d208af5`](https://github.com/postcss/postcss-simple-vars/commit/d208af5bffd8b8ec4830dfb2d64f150dd0114560) `Update dependencies`
- [`17af3ed`](https://github.com/postcss/postcss-simple-vars/commit/17af3ed1da90446a331bc00c2fff4581eed85f22) `Update .npmignore`
- [`b348686`](https://github.com/postcss/postcss-simple-vars/commit/b348686058fd74347d4be66512ce25e113646707) `Update Travis CI config`
- [`060ee7a`](https://github.com/postcss/postcss-simple-vars/commit/060ee7a7e048e16cef3110b32eb2fe2bfdf18e5a) `Merge pull request #49 from VinSpee/master`
- [`3884944`](https://github.com/postcss/postcss-simple-vars/commit/388494420eb0ed008687469c794a906e8690e682) `interpolate variables in comments`
- [`f34b9e1`](https://github.com/postcss/postcss-simple-vars/commit/f34b9e1553751d9fd46137381672d998ecd3166c) `Merge pull request #46 from GitScrum/patch-2`
- [`26ab2b4`](https://github.com/postcss/postcss-simple-vars/commit/26ab2b464fe45da80f0c520f75a5702d13d2acd1) `typo`
- [`3afb0a6`](https://github.com/postcss/postcss-simple-vars/commit/3afb0a6784bf950a048c6443b33dc54d99047a2b) `Merge pull request #45 from GitScrum/patch-1`
- [`a6ccbba`](https://github.com/postcss/postcss-simple-vars/commit/a6ccbbaa5b9e39e1803b54f0a5d5ed56c270b24b) `Update README.md`
- [`c76a09c`](https://github.com/postcss/postcss-simple-vars/commit/c76a09cf6e1cdfb47a0b15a4f6dce3e9cd1fe996) `Release 1.2 version`
- [`cb2f171`](https://github.com/postcss/postcss-simple-vars/commit/cb2f17107a329f4fe4d07152fc295caca8b51ff2) `Typo`
- [`b49e2f5`](https://github.com/postcss/postcss-simple-vars/commit/b49e2f5f0f5fb5b9fe26ef4f1f5ec9cd62a185d6) `Rewrite tests to AVA`
- [`920df64`](https://github.com/postcss/postcss-simple-vars/commit/920df6477a7c574b8fe61a0c98f0e7ca73a67749) `Merge pull request #39 from duncanbeevers/export-variables`

There are 22 commits in total. See the [full diff](https://github.com/postcss/postcss-simple-vars/compare/de8c1f8194433d8f15505a186a51854965a38596...acef74f4bfbe1fad7f481e78cae9a0fab147d4d1).

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
