### PR TITLE
users: fix #339: user list not appending new users when unfocused

### DIFF
--- a/src/components/SidePanels/PanelTemplate.js
+++ b/src/components/SidePanels/PanelTemplate.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 const PanelTemplate = ({ selected, children }) => (
-  <div style={{ display: selected ? 'block' : 'none' }}>
+  <div style={{ visibility: selected ? 'visible' : 'hidden' }}>
     {children}
   </div>
 );


### PR DESCRIPTION
The user list would not update correctly earlier if the Chat or
Waitlist panels were selected, because react-list couldn't
determine the user list height. Since the user list would be
wrapped in a "display:none" element, the browser would report a
height of zero. This resulted in react-list not updating the amount
of elements to render.

This patch fixes that by using the CSS "visibility" property
instead of the "display" property. The "visibility" property can
be set to "hidden", which does not show the element and does not
allow users to interact with the element, but does maintain its
size, and thus does allow react-list to update correctly.
