### PR TITLE
form: make entire TextFields clickable

### DIFF
--- a/src/components/App/index.css
+++ b/src/components/App/index.css
@@ -11,6 +11,10 @@
   background: $scrollbar-color;
 }
 
+:focus {
+  outline-color: $highlight-color;
+}
+
 a {
   color: $link-color;
 }

--- a/src/components/Dialogs/EditMediaDialog/index.css
+++ b/src/components/Dialogs/EditMediaDialog/index.css
@@ -19,7 +19,7 @@
   justify-content: center;
 
   @descendent field {
-    flex-grow: 0.5;
+    flex-grow: 1;
   }
 
   @descendent label {

--- a/src/components/Form/TextField.css
+++ b/src/components/Form/TextField.css
@@ -9,7 +9,7 @@
   font-size: 12pt;
 
   @descendent input {
-    width: calc(100% - $forms-textfield-size);
+    width: 100%;
     border: 0;
     height: 100%;
     background: transparent;
@@ -17,8 +17,10 @@
     display: block;
     float: left;
     padding: 0 $forms-element-margin;
+    padding-right: $forms-textfield-size;
     font-size: 12pt;
     color: #fff;
+
     &::placeholder {
       color: #9f9d9e;
     }
@@ -27,6 +29,7 @@
   @descendent icon {
     width: $forms-textfield-size;
     height: $forms-textfield-size;
+    margin-left: -$forms-textfield-size;
     padding: 13px;
     display: block;
     float: left;


### PR DESCRIPTION
Makes TextField component icons _overlay_ the input, instead of making the input smaller so the icon fits. Bonus: the focus ring now surrounds the entire TextField and not just the input.
