### PR TITLE
browser-resolve@1.11.2 breaks build 🚨

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "babel-preset-stage-2": "^6.3.13",
     "babel-register": "^6.7.2",
     "babelify": "^7.3.0",
-    "browser-resolve": "^1.11.1",
+    "browser-resolve": "^1.11.2",
     "browserify": "^13.0.0",
     "browserify-hmr": "^0.3.1",
     "bundle-collapser": "^1.2.1",


### PR DESCRIPTION
Hello :wave:

:rotating_light::rotating_light::rotating_light:

[browser-resolve](https://www.npmjs.com/package/browser-resolve) just published its new version 1.11.2, which **is covered by your current version range**. After updating it in your project **the build went from success to failure**.

This means **your software is now malfunctioning**, because of this update. Use this branch to work on adaptions and fixes.

Happy fixing and merging :palm_tree:

---

The new version differs by 4 commits .
- [`0955baf`](https://github.com/defunctzombie/node-browser-resolve/commit/0955bafbb275d2ec1e425b2d776d4d619bd72282) `1.11.2`
- [`8e6eca2`](https://github.com/defunctzombie/node-browser-resolve/commit/8e6eca288854d9d145ef01355fe76ac8ed1844e5) `Merge pull request #80 from msokk/fix-node6`
- [`97666bf`](https://github.com/defunctzombie/node-browser-resolve/commit/97666bf5082c81e26e79ad6f5af474fc619ef2d2) `Test with newer Node versions on Travis`
- [`ed39edd`](https://github.com/defunctzombie/node-browser-resolve/commit/ed39edd62c2943a8b584d11edfa4fb2c2c03f34a) `Fix path.dirname(undefined) throwing on Node v6`

See the [full diff](https://github.com/defunctzombie/node-browser-resolve/compare/a238dd1ca8db9319cdd6b6340358a09f298c9156...0955bafbb275d2ec1e425b2d776d4d619bd72282).

---

This pull request was created by [greenkeeper.io](https://greenkeeper.io/).
It keeps your software up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
