### PR TITLE
deps: remove unused "browser-resolve" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "babel-preset-stage-2": "^6.3.13",
     "babel-register": "^6.7.2",
     "babelify": "^7.3.0",
-    "browser-resolve": "^1.11.1",
     "browserify": "^13.0.0",
     "browserify-hmr": "^0.3.1",
     "bundle-collapser": "^1.2.1",


### PR DESCRIPTION
The code that used this was removed in #333.
