### PR TITLE
css: import vars.css early, helps with #296 (but does not fix)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,5 +1,7 @@
 @import "normalize.css";
 
+@import "./vars.css";
+
 @import "./components";
 @import "./sources";
 @import "./containers/DragLayer.css";


### PR DESCRIPTION
The crash mentioned in #296 is because of a race condition, where
some other stylesheet file is loaded _before_ vars.css. vars.css
is included mostly from Component stylesheets, which are two or
three levels of @-imports deep, so we can moooostly work around the
race condition by loading vars.css immediately. It's not a real
fix, but does help.
