### PR TITLE
youtube: fix updating volume

### DIFF
--- a/src/sources/youtube/PlayerEmbed.js
+++ b/src/sources/youtube/PlayerEmbed.js
@@ -22,9 +22,9 @@ export default class YouTubePlayerEmbed extends React.Component {
       // only set volume after the YT API is fully initialised.
       // if it fails here because the API isn't ready, the the volume will still
       // be set in onYTReady().
-      if (player._internalPlayer && this.props.volume !== nextProps.volume) {
+      if (player.internalPlayer && this.props.volume !== nextProps.volume) {
         debug('YT: setting volume', nextProps.volume);
-        player._internalPlayer.setVolume(nextProps.volume);
+        player.internalPlayer.setVolume(nextProps.volume);
       }
     }
   }


### PR DESCRIPTION
The name of the internal player property changed in react-youtube
7.0.0.

It might be a good idea to submit a PR to react-youtube to provide either a volume prop that we can use or an official way of accessing the YT player instance.
