### PR TITLE
chat: add timestamps to chat messages on hover, fixes #63

### DIFF
--- a/src/components/Chat/Message.css
+++ b/src/components/Chat/Message.css
@@ -9,10 +9,27 @@
 
   &:nth-child(2n + 1) {
     background: $chat-background-color2;
+    .ChatMessage-timestamp {
+      background: $chat-background-color2;
+    }
   }
 
   @modifier mention {
     box-shadow: 5px 0px 0px $highlight-color inset;
+  }
+
+  @descendent timestamp {
+    background: $chat-background-color;
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 0 6px;
+    display: none;
+    font-size: 80%;
+    color: color($text-color blend(#777777 33%));
+  }
+  &:hover .ChatMessage-timestamp {
+    display: block;
   }
 
   @descendent avatar {

--- a/src/components/Chat/Message.js
+++ b/src/components/Chat/Message.js
@@ -7,7 +7,18 @@ import Username from '../Username';
 import Loader from '../Loader';
 import compile from './Markup/compile';
 
-const Message = ({ user, text, parsedText, inFlight, isMention, compileOptions }) => {
+const padZero = n => (n < 10 ? `0${n}` : n);
+const formatTime = date => `${padZero(date.getHours())}:${padZero(date.getMinutes())}`;
+
+const Message = ({
+  user,
+  text,
+  parsedText,
+  inFlight,
+  isMention,
+  timestamp,
+  compileOptions
+}) => {
   let avatar;
   if (inFlight) {
     avatar = (
@@ -26,12 +37,20 @@ const Message = ({ user, text, parsedText, inFlight, isMention, compileOptions }
 
   const children = parsedText ? compile(parsedText, compileOptions) : text;
 
+  const date = new Date(timestamp);
+
   const inFlightClass = inFlight ? 'ChatMessage--loading' : '';
   const mentionClass = isMention ? 'ChatMessage--mention' : '';
   return (
     <div className={cx('ChatMessage', inFlightClass, mentionClass)}>
       {avatar}
       <div className="ChatMessage-content">
+        <time
+          className="ChatMessage-timestamp"
+          dateTime={date.toISOString()}
+        >
+          {formatTime(date)}
+        </time>
         <Username className="ChatMessage-username" user={user} />
         <span className="ChatMessage-text">{children}</span>
       </div>
@@ -44,6 +63,7 @@ Message.propTypes = {
   text: React.PropTypes.string.isRequired,
   parsedText: React.PropTypes.array.isRequired,
   inFlight: React.PropTypes.bool,
+  timestamp: React.PropTypes.number.isRequired,
   isMention: React.PropTypes.bool.isRequired,
   compileOptions: React.PropTypes.shape({
     availableEmoji: React.PropTypes.array,


### PR DESCRIPTION
Shown only on hover right now.

![Screen](http://i.imgur.com/DnD2BTw.png)

(The time text colour is a bit weird, it should probably be a slightly darker shade(?))
