### PR TITLE
chat: use localised timestamp

### DIFF
--- a/src/components/Chat/Message.js
+++ b/src/components/Chat/Message.js
@@ -7,8 +7,7 @@ import Username from '../Username';
 import Loader from '../Loader';
 import compile from './Markup/compile';
 
-const padZero = n => (n < 10 ? `0${n}` : n);
-const formatTime = date => `${padZero(date.getHours())}:${padZero(date.getMinutes())}`;
+const timeFormatOptions = { hour: 'numeric', minute: 'numeric' };
 
 const Message = ({
   user,
@@ -49,7 +48,7 @@ const Message = ({
           className="ChatMessage-timestamp"
           dateTime={date.toISOString()}
         >
-          {formatTime(date)}
+          {date.toLocaleTimeString([], timeFormatOptions)}
         </time>
         <Username className="ChatMessage-username" user={user} />
         <span className="ChatMessage-text">{children}</span>


### PR DESCRIPTION
Use browser-supplied time strings for chat timestamps. These include the seconds which is usually a bit much, but they follow local conventions, so we don't have to manually take am/pm/24-hour/more notations into account. If we want to get rid of the seconds we might have to use a bigger localised time handling library, I don't think JavaScript Dates support more extensive formatting options than these(?).
