### PR TITLE
 	sidepanels: fix lingering icons when switching tabs

### DIFF
--- a/src/components/SidePanels/PanelTemplate.js
+++ b/src/components/SidePanels/PanelTemplate.js
@@ -1,7 +1,8 @@
+import cx from 'classnames';
 import * as React from 'react';
 
 const PanelTemplate = ({ selected, children }) => (
-  <div style={{ visibility: selected ? 'visible' : 'hidden' }}>
+  <div className={cx('SidePanel-panel', selected && 'is-visible')}>
     {children}
   </div>
 );

--- a/src/components/SidePanels/index.css
+++ b/src/components/SidePanels/index.css
@@ -15,4 +15,14 @@
       color: #777;
     }
   }
+
+  @descendent panel {
+    visibility: hidden;
+    opacity: 0;
+
+    @when visible {
+      visibility: visible;
+      opacity: 1;
+    }
+  }
 }


### PR DESCRIPTION
Some elements have animated style properties, so when their panel
visibility is changed, it animates the visibility of those elements.
This patch instead changes both the 'visibility' property and the
opacity property without an animation, so that animations on their
child elements don't matter anymore and everything happens instantly.

It's a bit bandaidy but we can't just do `display: none` because then
the height calculations for progressive rendering of the user list fail.
