### PR TITLE
playlists: fix buttons opening AddToPlaylistMenu

### DIFF
--- a/src/components/FooterBar/Responses/Favorite.js
+++ b/src/components/FooterBar/Responses/Favorite.js
@@ -1,49 +1,42 @@
-import React, { Component, PropTypes } from 'react';
+import * as React from 'react';
 import FavoritedIcon from 'material-ui/svg-icons/action/favorite';
 import FavoriteIcon from 'material-ui/svg-icons/action/favorite-border';
+import muiThemeable from 'material-ui/styles/muiThemeable';
 
 import Button from './Button';
 
-export default class Favorite extends Component {
-  static propTypes = {
-    onFavorite: PropTypes.func.isRequired,
-    count: PropTypes.number.isRequired,
-    active: PropTypes.bool
-  };
+const handleFavorite = onFavorite => event => {
+  const pos = event.target.getBoundingClientRect();
+  onFavorite({
+    x: pos.left,
+    y: pos.top
+  });
+};
 
-  static contextTypes = {
-    muiTheme: PropTypes.object
-  };
+const Favorite = ({
+  muiTheme,
+  onFavorite,
+  count,
+  active
+}) => {
+  const CurrentIcon = active ? FavoritedIcon : FavoriteIcon;
 
-  position() {
-    const pos = this.button.getBoundingClientRect();
-    return {
-      x: pos.left,
-      y: pos.top
-    };
-  }
+  return (
+    <Button
+      tooltip="Favorite"
+      onClick={handleFavorite(onFavorite)}
+      count={count}
+    >
+      <CurrentIcon color={muiTheme.palette.primary1Color} />
+    </Button>
+  );
+};
 
-  handleFavorite = () => {
-    this.props.onFavorite(this.position());
-  };
+Favorite.propTypes = {
+  muiTheme: React.PropTypes.object.isRequired,
+  onFavorite: React.PropTypes.func.isRequired,
+  count: React.PropTypes.number.isRequired,
+  active: React.PropTypes.bool
+};
 
-  refButton = button => {
-    this.button = button;
-  };
-
-  render() {
-    const { muiTheme } = this.context;
-    const { active, count } = this.props;
-    const CurrentIcon = active ? FavoritedIcon : FavoriteIcon;
-    return (
-      <Button
-        ref={this.refButton}
-        tooltip="Favorite"
-        onClick={this.handleFavorite}
-        count={count}
-      >
-        <CurrentIcon color={muiTheme.palette.primary1Color} />
-      </Button>
-    );
-  }
-}
+export default muiThemeable()(Favorite);

--- a/src/components/MediaList/Actions/Action.js
+++ b/src/components/MediaList/Actions/Action.js
@@ -1,24 +1,19 @@
-/* eslint-disable react/prefer-stateless-function */
-import React, { Component, PropTypes } from 'react';
+import * as React from 'react';
 
-export default class Action extends Component {
-  static propTypes = {
-    children: PropTypes.element,
-    onAction: PropTypes.func
-  };
+const Action = ({ children, onAction, ...attrs }) => (
+  <div
+    role="button"
+    className="MediaActions-action"
+    onClick={onAction}
+    {...attrs}
+  >
+    {children}
+  </div>
+);
 
-  render() {
-    const { children, onAction, ...attrs } = this.props;
-    return (
-      <div
-        role="button"
-        className="MediaActions-action"
-        onClick={onAction}
-        {...attrs}
-      >
-        {children}
-      </div>
-    );
-  }
-}
-/* eslint-enable react/prefer-stateless-function */
+Action.propTypes = {
+  children: React.PropTypes.element,
+  onAction: React.PropTypes.func
+};
+
+export default Action;

--- a/src/components/MediaList/Actions/AddToPlaylist.js
+++ b/src/components/MediaList/Actions/AddToPlaylist.js
@@ -1,35 +1,27 @@
-import React, { Component, PropTypes } from 'react';
+import * as React from 'react';
 import AddIcon from 'material-ui/svg-icons/content/add';
 
 import Action from './Action';
 
-export default class AddToPlaylist extends Component {
-  static propTypes = {
-    onAdd: PropTypes.func
-  };
+const handleAdd = onAdd => event => {
+  const pos = event.target.getBoundingClientRect();
+  onAdd({
+    x: pos.left,
+    y: pos.top
+  });
+};
 
-  position() {
-    const pos = this.button.getBoundingClientRect();
-    return {
-      x: pos.left,
-      y: pos.top
-    };
-  }
+const AddToPlaylist = ({ onAdd, ...props }) => (
+  <Action
+    {...props}
+    onAction={handleAdd(onAdd)}
+  >
+    <AddIcon color="#fff" />
+  </Action>
+);
 
-  refButton = button => {
-    this.button = button;
-  };
+AddToPlaylist.propTypes = {
+  onAdd: React.PropTypes.func.isRequired
+};
 
-  render() {
-    const { onAdd, ...props } = this.props;
-    return (
-      <Action
-        ref={this.refButton}
-        {...props}
-        onAction={media => onAdd(this.position(), media)}
-      >
-        <AddIcon color="#fff" />
-      </Action>
-    );
-  }
-}
+export default AddToPlaylist;


### PR DESCRIPTION
These components used `ref`s to the Button components to find the position for the playlists menu. However Button components are not mere DOM components, so they didn't have the necessary DOM method (`getBoundingClientRect`).

This patch uses the onClick event target instead. That's basically the same as previously, but the target is always a DOM element, so it always works :muscle:.

Since these components no longer use refs, they could be converted to stateless components, too.
