### PR TITLE
footer: make entire vote button area clickable, fixes #154

### DIFF
--- a/src/components/FooterBar/Responses/Bar.css
+++ b/src/components/FooterBar/Responses/Bar.css
@@ -17,8 +17,16 @@
   justify-content: center;
   flex-grow: 0.334;
   padding: 0 15px;
+  position: relative;
+  cursor: pointer;
 
   &:hover {
     background-color: $background-hover-color;
+  }
+
+  @descendent icon {
+    height: 36px;
+    width: 36px;
+    padding: 6px 12px 6px 0px;
   }
 }

--- a/src/components/FooterBar/Responses/Button.js
+++ b/src/components/FooterBar/Responses/Button.js
@@ -1,34 +1,50 @@
-/* eslint-disable react/prefer-stateless-function */
-import React, { Component, PropTypes } from 'react';
-import IconButton from 'material-ui/IconButton';
+import * as React from 'react';
+import Tooltip from 'material-ui/internal/Tooltip';
+import transformStyle from '../../../utils/transformStyle';
 
-const buttonStyle = {
-  height: 36,
-  width: 36,
-  padding: '6px 12px 6px 0'
+const tooltipStyle = {
+  left: '50%',
+  ...transformStyle('translateX(-50%)')
 };
 
-export default class Button extends Component {
+export default class Button extends React.Component {
   static propTypes = {
-    onClick: PropTypes.func.isRequired,
-    children: PropTypes.element.isRequired,
-    count: PropTypes.number
+    onClick: React.PropTypes.func.isRequired,
+    children: React.PropTypes.element.isRequired,
+    count: React.PropTypes.number,
+    tooltip: React.PropTypes.string
+  };
+
+  state = { showTooltip: false };
+
+  handleMouseEnter = () => {
+    this.setState({ showTooltip: true });
+  };
+
+  handleMouseLeave = () => {
+    this.setState({ showTooltip: false });
   };
 
   render() {
-    const { count, children, ...props } = this.props;
+    const { onClick, count, children, tooltip } = this.props;
     return (
-      <div className="ResponseButton">
-        <IconButton
-          tooltipPosition="top-center"
-          style={buttonStyle}
-          {...props}
-        >
-          {children}
-        </IconButton>
+      <div
+        className="ResponseButton"
+        role="button"
+        onClick={onClick}
+        onMouseEnter={this.handleMouseEnter}
+        onMouseLeave={this.handleMouseLeave}
+      >
+        <Tooltip
+          label={tooltip}
+          verticalPosition="top"
+          horizontalPosition="center"
+          show={this.state.showTooltip}
+          style={tooltipStyle}
+        />
+        <div className="ResponseButton-icon">{children}</div>
         <span className="ResponseButton-count">{count}</span>
       </div>
     );
   }
 }
-/* eslint-enable react/prefer-stateless-function */


### PR DESCRIPTION
Material-ui buttons don't work that great here, so instead the vote buttons now implement their tooltips manually (they're the only reason we were using `<IconButton />`s in the first place, really), and the entire button area, including the current response count, is clickable as expected.
