### PR TITLE
playlists: fix insert position of newly favourited tracks, fix #404

### DIFF
--- a/src/actions/VoteActionCreators.js
+++ b/src/actions/VoteActionCreators.js
@@ -11,7 +11,7 @@ import {
   DO_UPVOTE, DO_DOWNVOTE
 } from '../constants/actionTypes/votes';
 
-import { addMediaStart, addMediaComplete, flattenPlaylistItem } from './PlaylistActionCreators';
+import { flattenPlaylistItem } from './PlaylistActionCreators';
 
 export function setVoteStats(voteStats) {
   return {
@@ -71,25 +71,20 @@ export function favoriteMediaStart(playlistID, historyID) {
 export function favoriteMediaComplete(playlistID, historyID, changes) {
   return {
     type: DO_FAVORITE_COMPLETE,
-    payload: changes,
-    meta: { historyID, playlistID }
+    payload: {
+      historyID,
+      playlistID,
+      added: changes.added.map(flattenPlaylistItem),
+      newSize: changes.playlistSize
+    }
   };
 }
 
 export function favoriteMedia(playlist, historyID) {
   const playlistID = playlist._id;
   return post('/booth/favorite', { historyID, playlistID }, {
-    onStart: () => dispatch => {
-      dispatch(favoriteMediaStart(playlistID, historyID));
-      dispatch(addMediaStart(playlistID, []));
-    },
-    onComplete: changes => dispatch => {
-      dispatch(favoriteMediaComplete(playlistID, historyID, changes));
-      dispatch(addMediaComplete(playlistID, changes.playlistSize, {
-        afterID: null,
-        media: changes.added.map(flattenPlaylistItem)
-      }));
-    },
+    onStart: () => favoriteMediaStart(playlistID, historyID),
+    onComplete: changes => favoriteMediaComplete(playlistID, historyID, changes),
     onError: error => ({
       type: DO_FAVORITE_COMPLETE,
       error: true,

--- a/test/reducers/playlists.js
+++ b/test/reducers/playlists.js
@@ -3,6 +3,7 @@ import fetch from 'fetch-mock';
 
 import createStore from '../../src/store/configureStore';
 import * as a from '../../src/actions/PlaylistActionCreators';
+import { favoriteMediaComplete } from '../../src/actions/VoteActionCreators';
 import * as s from '../../src/selectors/playlistSelectors';
 
 const initialiseStore = a.setPlaylists([
@@ -153,6 +154,28 @@ describe('reducers/playlists', () => {
       expect(
         s.nextMediaSelector(getState())._id
       ).to.eql(347);
+    });
+
+    it('appends favourited items to the end of the playlist', () => {
+      const { dispatch, getState } = createStore();
+      dispatch(initialiseStore);
+      const { playlistID } = dispatch(initialisePlaylist);
+
+      expect(
+        s.selectedPlaylistSelector(getState()).media
+      ).to.have.length(5);
+
+      dispatch(favoriteMediaComplete(playlistID, 36425, {
+        playlistSize: 6,
+        added: [
+          { _id: 1338, artist: 'SHINee', title: 'Odd Eye' }
+        ]
+      }));
+
+      const { size, media } = s.selectedPlaylistSelector(getState());
+      expect(size).to.eql(6);
+      expect(media).to.have.length(6);
+      expect(media[5]._id).to.eql(1338);
     });
   });
 


### PR DESCRIPTION
This adds more flexible positioning options to the _COMPLETE action,
like already present in the _START action. Favouriting now uses
`at: 'end'` to ensure that newly favourited tracks are always added
at the very end, while "normal" additions use `after: ID` to be
added after a certain item.

(We might have to revisit some of these positioning funnies, the
"insert after ID" strategy for keeping stuff in sync doesn't appear
to be helping us that much so far. Just using "add at index" might
actually be better, although advances might interfere if they
happen around the same time as adding a song…)

I'm not super happy about this because we now have a mix of
"index-based" ("at end") and after-item-based positions, but
since items aren't all loaded all the time, I'm not sure if there is a
better way.
