### PR TITLE
overlays: force overlay bodies to be full-size while animating, fixes #419

### DIFF
--- a/src/components/Overlay/index.css
+++ b/src/components/Overlay/index.css
@@ -2,7 +2,6 @@
 
 @component Overlay {
   position: absolute;
-  height: 100vh;
   height: 100%;
   width: 100%;
   z-index: 6;
@@ -15,6 +14,11 @@
   @modifier from-top {
     top: 0;
     bottom: auto;
+  }
+
+  @descendent body {
+    height: 100%;
+    height: 100vh;
   }
 
   /* Animations!.. */

--- a/src/components/Overlay/index.js
+++ b/src/components/Overlay/index.js
@@ -1,14 +1,14 @@
 import cx from 'classnames';
 import * as React from 'react';
 
-const Overlay = ({ direction = 'bottom', children, ...props }) => (
+const Overlay = ({ direction = 'bottom', children, className, ...props }) => (
   <div
     className={cx(
       'Overlay',
       `Overlay--from-${direction}`
     )}
   >
-    <div {...props}>
+    <div className={cx('Overlay-body', className)} {...props}>
       {children}
     </div>
   </div>
@@ -16,6 +16,7 @@ const Overlay = ({ direction = 'bottom', children, ...props }) => (
 
 Overlay.propTypes = {
   children: React.PropTypes.node.isRequired,
+  className: React.PropTypes.string,
   direction: React.PropTypes.string
 };
 


### PR DESCRIPTION
The `react-list` instances managing History and Playlists weren't rendering fully, because their initial render happened during an animation. So they'd render while having eg. 60% of total space available, thus leaving a bunch of elements out. This fix ensures that stuff inside animating Overlay elements is still always the full height of the page by adding `height: 100vh`.

Overlay bodies were already in a container div, but last time I tried fixing this issue I added the `height: 100vh` declaration to the wrong classname. :')

This time it's added to the correct element!
