### PR TITLE
app: ensure <App /> component is a class, not a function component

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -1,6 +1,8 @@
 /* eslint-disable react/prefer-stateless-function */
 import React from 'react';
 import { DragDropContext } from 'react-dnd';
+import compose from 'recompose/compose';
+import toClass from 'recompose/toClass';
 import HTML5Backend from 'react-dnd-html5-backend';
 
 import FooterBar from '../../containers/FooterBar';
@@ -81,4 +83,9 @@ App.propTypes = {
   sendChatMessage: React.PropTypes.func.isRequired
 };
 
-export default DragDropContext(HTML5Backend)(App);
+export default compose(
+  DragDropContext(HTML5Backend),
+  // DragDropContext needs to be able to set a ref on the component, so we can't
+  // use a stateless function directly.
+  toClass
+)(App);


### PR DESCRIPTION
react-dnd's DragDropContext attempts to add a ref to the component
it wraps, and you can't add refs to function components in React.
So, we use recompose's toClass wrapper to turn the App component
into a `class extends React.Component` before applying the
DragDropContext.
