### PR TITLE
build: do not remove all old built files by default when rebuilding

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -38,4 +38,4 @@ gulp.task('start', [ 'watch' ], () => {
 
 gulp.task('build', sequence('assets', 'js', 'css', 'html'));
 
-gulp.task('default', ['build']);
+gulp.task('default', [ 'build' ]);


### PR DESCRIPTION
Build dirs can still be cleaned up using `npm run build clean` or `rm -r lib/`
