### PR TITLE
fix react warnings

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -11,4 +11,8 @@ button {
   color: inherit;
   background: initial;
   border: initial;
+  text-align: initial;
+  &:focus {
+    outline: initial;
+  }
 }

--- a/src/components/AddToPlaylistMenu/PlaylistsMenu.js
+++ b/src/components/AddToPlaylistMenu/PlaylistsMenu.js
@@ -14,6 +14,8 @@ const MENU_WIDTH = 280;
 const RANDOM_MUI_PADDING = 8;
 const SCROLLBAR_WIDTH = 7;
 
+const NEW_PLAYLIST = {};
+
 const positionInsideWindow = (position, expectedHeight) => {
   const constrained = { x: position.x, y: position.y };
   const h = Math.min(expectedHeight, MENU_HEIGHT);
@@ -52,11 +54,11 @@ export default class PlaylistsMenu extends React.Component {
   };
 
   handleSelect = (e, item) => {
-    if (item.props.isNewPlaylist) {
+    const playlistID = item.props.value;
+    if (playlistID === NEW_PLAYLIST) {
       this.props.onCreatePlaylist();
       return;
     }
-    const playlistID = item.props.value;
     this.props.onClose();
     this.props.onSelect(
       find(this.props.playlists, pl => pl._id === playlistID)
@@ -84,8 +86,8 @@ export default class PlaylistsMenu extends React.Component {
             onItemTouchTap={this.handleSelect}
           >
             <MenuItem
-              isNewPlaylist
               style={menuItemStyle}
+              value={NEW_PLAYLIST}
               leftIcon={<CreatePlaylistIcon color="#fff" />}
               primaryText={t('playlists.new')}
             />

--- a/src/components/Chat/Motd.js
+++ b/src/components/Chat/Motd.js
@@ -10,7 +10,7 @@ const Motd = ({ children, compileOptions }) => (
 );
 
 Motd.propTypes = {
-  children: React.PropTypes.node.isRequired,
+  children: React.PropTypes.array.isRequired,
   compileOptions: React.PropTypes.shape({
     availableEmoji: React.PropTypes.array,
     emojiImages: React.PropTypes.object

--- a/src/components/Chat/index.js
+++ b/src/components/Chat/index.js
@@ -7,7 +7,7 @@ import Motd from './Motd';
 export default class Chat extends Component {
   static propTypes = {
     messages: PropTypes.array,
-    motd: PropTypes.node,
+    motd: PropTypes.array,
     compileOptions: PropTypes.shape({
       availableEmoji: PropTypes.array,
       emojiImages: PropTypes.object

--- a/src/components/Dialogs/EditMediaDialog/index.js
+++ b/src/components/Dialogs/EditMediaDialog/index.js
@@ -119,7 +119,7 @@ export default class EditMediaDialog extends React.Component {
           defaultValue={media.artist}
           icon={<ArtistIcon color="#9f9d9e" />}
           tabIndex={baseTabIndex}
-          autofocus
+          autoFocus
         />
       );
       const artistTitleLabel = (

--- a/src/components/Dialogs/LoginDialog/LoginForm.js
+++ b/src/components/Dialogs/LoginDialog/LoginForm.js
@@ -53,7 +53,7 @@ export default class LoginForm extends React.Component {
             type="email"
             placeholder={t('login.email')}
             icon={<EmailIcon color="#9f9d9e" />}
-            autofocus
+            autoFocus
           />
         </FormGroup>
         <FormGroup>

--- a/src/components/Dialogs/LoginDialog/RegisterForm.js
+++ b/src/components/Dialogs/LoginDialog/RegisterForm.js
@@ -88,7 +88,7 @@ export default class RegisterForm extends React.Component {
             className="RegisterForm-field"
             placeholder={t('login.username')}
             icon={<UserIcon color="#9f9d9e" />}
-            autofocus
+            autoFocus
           />
         </FormGroup>
         <FormGroup>

--- a/src/components/Dialogs/PreviewMediaDialog/index.js
+++ b/src/components/Dialogs/PreviewMediaDialog/index.js
@@ -43,7 +43,7 @@ const PreviewMediaDialog = ({
 PreviewMediaDialog.propTypes = {
   open: React.PropTypes.bool,
   media: React.PropTypes.object,
-  volume: React.PropTypes.volume,
+  volume: React.PropTypes.number,
 
   onCloseDialog: React.PropTypes.func.isRequired
 };

--- a/src/components/Dialogs/PromptDialog/index.js
+++ b/src/components/Dialogs/PromptDialog/index.js
@@ -92,7 +92,7 @@ export default class PromptDialog extends React.Component {
           <FormGroup>
             <TextField
               ref={this.refInput}
-              autofocus
+              autoFocus
               type={inputType}
               placeholder={placeholder}
               icon={icon}

--- a/src/components/FooterBar/NextMedia.js
+++ b/src/components/FooterBar/NextMedia.js
@@ -14,12 +14,11 @@ const NextMedia = ({
   userInWaitlist,
   userIsDJ,
   baseEta,
-  mediaEndTime,
-  ...attrs
+  mediaEndTime
 }) => {
   if (!playlist) {
     return (
-      <div className={cx('NextMedia', className)} {...attrs}>
+      <div className={cx('NextMedia', className)}>
         {t('playlists.noPlaylistsCreate')}
       </div>
     );
@@ -42,7 +41,7 @@ const NextMedia = ({
     <Eta className="NextMedia-eta" base={baseEta} endTime={mediaEndTime} />
   );
   return (
-    <div className={cx('NextMedia', className)} {...attrs}>
+    <div className={cx('NextMedia', className)}>
       {mediaEl}
       <Interpolate
         i18nKey={key}

--- a/src/components/FooterBar/index.css
+++ b/src/components/FooterBar/index.css
@@ -67,6 +67,7 @@
   border-right: 1px solid $chat-border-color;
   display: block;
   float: left;
+  text-align: center;
   cursor: pointer;
   color: #fff;
   font-size: 12pt;

--- a/src/components/FooterBar/index.js
+++ b/src/components/FooterBar/index.js
@@ -18,11 +18,11 @@ export default class FooterBar extends React.Component {
     nextMedia: React.PropTypes.object,
     playlist: React.PropTypes.object,
     user: React.PropTypes.object,
-    userInWaitlist: React.PropTypes.bool,
-    userIsDJ: React.PropTypes.bool,
+    userInWaitlist: React.PropTypes.bool.isRequired,
+    userIsDJ: React.PropTypes.bool.isRequired,
     currentDJ: React.PropTypes.object,
     showSkip: React.PropTypes.bool,
-    waitlistIsLocked: React.PropTypes.bool,
+    waitlistIsLocked: React.PropTypes.bool.isRequired,
     voteStats: React.PropTypes.object,
 
     openLoginDialog: React.PropTypes.func,
@@ -100,7 +100,10 @@ export default class FooterBar extends React.Component {
               onClick={toggleSettings}
             />
           </div>
-          <div className="FooterBar-next">
+          <button
+            className="FooterBar-next"
+            onClick={togglePlaylistManager}
+          >
             <NextMedia
               playlist={playlist}
               nextMedia={nextMedia}
@@ -108,9 +111,8 @@ export default class FooterBar extends React.Component {
               userIsDJ={userIsDJ}
               baseEta={baseEta}
               mediaEndTime={mediaEndTime}
-              onClick={togglePlaylistManager}
             />
-          </div>
+          </button>
           <div
             className={cx(
               'FooterBar-responses',

--- a/src/components/Form/Button.css
+++ b/src/components/Form/Button.css
@@ -11,6 +11,7 @@
   border-right-color: color($highlight-color blend(white 5%));
 
   color: #fff;
+  text-align: center;
   text-transform: uppercase;
   font-size: 12pt;
 

--- a/src/components/Form/TextField.js
+++ b/src/components/Form/TextField.js
@@ -5,19 +5,12 @@ export default class TextField extends React.Component {
   static propTypes = {
     className: React.PropTypes.string,
     type: React.PropTypes.string,
-    icon: React.PropTypes.element,
-    autofocus: React.PropTypes.bool
+    icon: React.PropTypes.element
   };
 
   static defaultProps = {
     type: 'text'
   };
-
-  componentDidMount() {
-    if (this.props.autofocus) {
-      this.input.focus();
-    }
-  }
 
   get value() {
     return this.input.value;

--- a/src/components/MediaList/Row.js
+++ b/src/components/MediaList/Row.js
@@ -34,6 +34,7 @@ export default class Row extends React.Component {
     selection: React.PropTypes.array,
 
     onOpenPreviewMediaDialog: React.PropTypes.func,
+    onClick: React.PropTypes.func,
     makeActions: React.PropTypes.func
   };
 
@@ -80,12 +81,15 @@ export default class Row extends React.Component {
 
   render() {
     const {
-      className, media, selection, selected,
+      className,
+      media,
+      selection,
+      selected,
       connectDragSource,
       // actions
       makeActions,
       // etc
-      ...attrs
+      onClick
     } = this.props;
     const { showActions } = this.state;
     const selectedClass = selected ? 'is-selected' : '';
@@ -95,13 +99,18 @@ export default class Row extends React.Component {
       ? media.end - media.start
       // search result
       : media.duration;
+
     return connectDragSource(
+      // Bit uneasy about this, but turning the entire row into a button seems
+      // wrong as well! Since we nest media action <button>s inside it, too.
+      //
+      // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div
         className={cx('MediaListRow', className, selectedClass, loadingClass)}
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}
         onDoubleClick={this.handleDoubleClick}
-        {...attrs}
+        onClick={onClick}
       >
         {this.renderThumbnail()}
         <div className="MediaListRow-artist" title={media.artist}>

--- a/src/components/Overlay/Header/index.js
+++ b/src/components/Overlay/Header/index.js
@@ -2,7 +2,13 @@ import cx from 'classnames';
 import * as React from 'react';
 import CloseButton from './Close';
 
-const Header = ({ className, title, children, onCloseOverlay, direction = 'bottom' }) => (
+const Header = ({
+  className,
+  title,
+  children,
+  onCloseOverlay,
+  direction = 'bottom'
+}) => (
   <div className={cx('OverlayHeader', className)}>
     <div className="OverlayHeader-title">
       {title.toUpperCase()}
@@ -21,8 +27,8 @@ const Header = ({ className, title, children, onCloseOverlay, direction = 'botto
 Header.propTypes = {
   className: React.PropTypes.string,
   title: React.PropTypes.string.isRequired,
-  children: React.PropTypes.node.isRequired,
-  direction: React.PropTypes.string.isRequired,
+  children: React.PropTypes.node,
+  direction: React.PropTypes.string,
   onCloseOverlay: React.PropTypes.func.isRequired
 };
 

--- a/src/components/PlaylistManager/Header/SourcePicker.css
+++ b/src/components/PlaylistManager/Header/SourcePicker.css
@@ -3,14 +3,21 @@
 $source-picker-width: calc(48px + 24px);
 
 @component SourcePicker {
-  cursor: pointer;
   width: $source-picker-width;
+
+  @descendent active {
+    cursor: pointer;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+  }
 
   @descendent list {
     width: $source-picker-width;
   }
 
   @descendent item {
+    cursor: pointer;
     width: 100%;
     padding: 5px;
   }

--- a/src/components/PlaylistManager/Header/SourcePicker.js
+++ b/src/components/PlaylistManager/Header/SourcePicker.js
@@ -23,9 +23,8 @@ class SourcePicker extends React.Component {
   createElement(sourceName) {
     const { selected, onChange } = this.props;
     return (
-      <div className="SourcePicker-item">
+      <div className="SourcePicker-item" key={sourceName}>
         <SourcePickerElement
-          key={sourceName}
           name={sourceName}
           active={selected === sourceName}
           onSelect={() => onChange(sourceName)}

--- a/src/components/PlaylistManager/Header/SourcePicker.js
+++ b/src/components/PlaylistManager/Header/SourcePicker.js
@@ -23,13 +23,16 @@ class SourcePicker extends React.Component {
   createElement(sourceName) {
     const { selected, onChange } = this.props;
     return (
-      <div className="SourcePicker-item" key={sourceName}>
+      <button
+        className="SourcePicker-item"
+        key={sourceName}
+        onClick={() => onChange(sourceName)}
+      >
         <SourcePickerElement
           name={sourceName}
           active={selected === sourceName}
-          onSelect={() => onChange(sourceName)}
         />
-      </div>
+      </button>
     );
   }
 
@@ -62,19 +65,23 @@ class SourcePicker extends React.Component {
       .map(name => this.createElement(name));
 
     return (
-      <button
-        ref={this.refContainer}
+      <div
         className={cx('SourcePicker', className)}
-        onClick={this.handleOpen}
+        ref={this.refContainer}
       >
-        <SourcePickerElement
-          name={selected}
-          active
-        />
-        <ArrowIcon
-          color={muiTheme.palette.textColor}
-          style={{ height: '100%' }}
-        />
+        <button
+          className="SourcePicker-active"
+          onClick={this.handleOpen}
+        >
+          <SourcePickerElement
+            name={selected}
+            active
+          />
+          <ArrowIcon
+            color={muiTheme.palette.textColor}
+            style={{ height: '100%' }}
+          />
+        </button>
         <Popover
           className="SourcePicker-list"
           open={this.state.open}
@@ -83,7 +90,7 @@ class SourcePicker extends React.Component {
         >
           {sources}
         </Popover>
-      </button>
+      </div>
     );
   }
 }

--- a/src/components/PlaylistManager/Header/SourcePickerElement.css
+++ b/src/components/PlaylistManager/Header/SourcePickerElement.css
@@ -1,7 +1,6 @@
 @component SourcePickerElement {
   width: 100%;
   height: 36px;
-  cursor: pointer;
   background-position: center center;
   background-repeat: no-repeat;
   background-size: contain;

--- a/src/components/PlaylistManager/Header/SourcePickerElement.js
+++ b/src/components/PlaylistManager/Header/SourcePickerElement.js
@@ -4,25 +4,22 @@ import * as React from 'react';
 const SourcePickerElement = ({
   className,
   name,
-  active,
-  onSelect
+  active
 }) => (
-  <button
+  <div
     className={cx(
       'SourcePickerElement',
       `SourcePickerElement--${name}`,
       active && 'SourcePickerElement--active',
       className
     )}
-    onClick={onSelect}
   />
 );
 
 SourcePickerElement.propTypes = {
   className: React.PropTypes.string,
   name: React.PropTypes.string.isRequired,
-  active: React.PropTypes.bool,
-  onSelect: React.PropTypes.func
+  active: React.PropTypes.bool
 };
 
 export default SourcePickerElement;

--- a/src/components/PlaylistManager/Menu/index.js
+++ b/src/components/PlaylistManager/Menu/index.js
@@ -6,9 +6,17 @@ import SearchResultsRow from './SearchResultsRow';
 import PlaylistImportRow from './PlaylistImportRow';
 
 const Menu = ({
-  className, playlists, searchQuery, searchResults,
-  selected, showSearchResults, showImportPanel,
-  onCreatePlaylist, onSelectPlaylist, onSelectSearchResults, onAddToPlaylist,
+  className,
+  playlists,
+  selected,
+  searchQuery,
+  showSearchResults,
+  searchResults,
+  onCreatePlaylist,
+  onSelectPlaylist,
+  onSelectSearchResults,
+  onAddToPlaylist,
+  showImportPanel,
   onShowImportPanel
 }) => {
   const searchIsSelected = showSearchResults ? 'is-selected' : '';
@@ -55,8 +63,8 @@ Menu.propTypes = {
   selected: React.PropTypes.object.isRequired,
   showSearchResults: React.PropTypes.bool.isRequired,
   showImportPanel: React.PropTypes.bool.isRequired,
-  searchQuery: React.PropTypes.string.isRequired,
-  searchResults: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
+  searchQuery: React.PropTypes.string,
+  searchResults: React.PropTypes.number,
   onCreatePlaylist: React.PropTypes.func.isRequired,
   onSelectPlaylist: React.PropTypes.func.isRequired,
   onSelectSearchResults: React.PropTypes.func.isRequired,

--- a/src/components/PlaylistManager/Panel/SearchResults.js
+++ b/src/components/PlaylistManager/Panel/SearchResults.js
@@ -53,7 +53,7 @@ SearchResults.propTypes = {
   t: React.PropTypes.func.isRequired,
   className: React.PropTypes.string,
   query: React.PropTypes.string.isRequired,
-  results: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
+  results: React.PropTypes.arrayOf(React.PropTypes.object),
   loadingState: React.PropTypes.oneOf([ IDLE, LOADING, LOADED ]).isRequired,
   onOpenAddMediaMenu: React.PropTypes.func.isRequired,
   onOpenPreviewMediaDialog: React.PropTypes.func.isRequired

--- a/src/components/PlaylistManager/Panel/index.js
+++ b/src/components/PlaylistManager/Panel/index.js
@@ -105,7 +105,7 @@ const PlaylistPanel = (props) => {
 PlaylistPanel.propTypes = {
   className: React.PropTypes.string,
   playlist: React.PropTypes.object.isRequired,
-  media: React.PropTypes.object.isRequired,
+  media: React.PropTypes.array.isRequired,
   loading: React.PropTypes.bool.isRequired,
   isFiltered: React.PropTypes.bool.isRequired,
   onShufflePlaylist: React.PropTypes.func.isRequired,

--- a/src/components/PlaylistManager/index.js
+++ b/src/components/PlaylistManager/index.js
@@ -26,7 +26,7 @@ export default class PlaylistManager extends Component {
 
     searchSource: PropTypes.string,
     searchQuery: PropTypes.string,
-    searchResults: PropTypes.object,
+    searchResults: PropTypes.array,
     searchLoadingState: PropTypes.oneOf([ IDLE, LOADING, LOADED ]),
 
     onCloseOverlay: PropTypes.func,

--- a/src/components/RoomHistory/Row.js
+++ b/src/components/RoomHistory/Row.js
@@ -37,6 +37,7 @@ export default class HistoryRow extends React.Component {
     selection: React.PropTypes.array,
 
     onOpenPreviewMediaDialog: React.PropTypes.func,
+    onClick: React.PropTypes.func,
     makeActions: React.PropTypes.func
   };
 
@@ -67,12 +68,14 @@ export default class HistoryRow extends React.Component {
   render() {
     const {
       media: historyEntry,
-      className, selection, selected,
+      className,
+      selection,
+      selected,
       connectDragSource,
       // actions
       makeActions,
       // etc
-      ...attrs
+      onClick
     } = this.props;
     const { media, timestamp, user, stats } = historyEntry;
     const { showActions } = this.state;
@@ -87,12 +90,14 @@ export default class HistoryRow extends React.Component {
       </div>
     );
     return connectDragSource(
+      // See PlaylistManager/Panel/Row.js
+      // eslint-disable-next-line jsx-a11y/no-static-element-interactions
       <div
         className={cx('MediaListRow', 'HistoryRow', className, selectedClass)}
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}
         onDoubleClick={this.handleDoubleClick}
-        {...attrs}
+        onClick={onClick}
       >
         {thumbnail}
         <SongTitle

--- a/src/components/SettingsManager/LanguagePicker.js
+++ b/src/components/SettingsManager/LanguagePicker.js
@@ -20,6 +20,7 @@ const LanguagePicker = (props, { i18n }) => (
   >
     {i18n.availableLanguages.map(lang => (
       <MenuItem
+        key={lang}
         style={itemStyle}
         value={lang}
         primaryText={getResourceName(i18n, lang)}

--- a/src/components/SettingsManager/SettingsPanel.js
+++ b/src/components/SettingsManager/SettingsPanel.js
@@ -23,12 +23,10 @@ const iconStyle = { verticalAlign: 'top' };
 
 const linkProps = {
   style: linkStyle,
-  linkButton: true,
   target: '_blank',
   labelPosition: 'after',
   backgroundColor: 'transparent',
-  hoverColor: 'transparent',
-  textTransform: 'none'
+  hoverColor: 'transparent'
 };
 
 class SettingsPanel extends React.Component {

--- a/src/components/WaitList/index.js
+++ b/src/components/WaitList/index.js
@@ -43,7 +43,7 @@ const WaitList = ({
 WaitList.propTypes = {
   className: React.PropTypes.string,
   users: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
-  canMoveUsers: React.PropTypes.boolean,
+  canMoveUsers: React.PropTypes.bool.isRequired,
   onMoveUser: React.PropTypes.func.isRequired,
   onRemoveUser: React.PropTypes.func.isRequired
 };

--- a/src/containers/Chat.js
+++ b/src/containers/Chat.js
@@ -15,7 +15,7 @@ import {
 } from '../selectors/chatSelectors';
 import {
   userListSelector,
-  currentUserSelector
+  isLoggedInSelector
 } from '../selectors/userSelectors';
 
 import Chat from '../components/Chat';
@@ -25,7 +25,7 @@ const mapStateToProps = createStructuredSelector({
   motd: motdSelector,
   messages: messagesSelector,
   compileOptions: markupCompilerOptionsSelector,
-  currentUser: currentUserSelector,
+  isLoggedIn: isLoggedInSelector,
   mentionableUsers: userListSelector,
   mentionableGroups: availableGroupMentionsSelector,
   availableEmoji: emojiCompletionsSelector
@@ -39,7 +39,7 @@ const ChatContainer = ({
   mentionableUsers,
   mentionableGroups,
   availableEmoji,
-  currentUser,
+  isLoggedIn,
   onSend,
   ...props
 }) => (
@@ -48,7 +48,7 @@ const ChatContainer = ({
       <Chat {...props} />
     </div>
     <div className="AppRow AppRow--bottom ChatInputWrapper">
-      {!!currentUser && (
+      {isLoggedIn && (
         <ChatInput
           onSend={onSend}
           mentionableUsers={mentionableUsers}
@@ -64,7 +64,7 @@ ChatContainer.propTypes = {
   mentionableUsers: React.PropTypes.array.isRequired,
   mentionableGroups: React.PropTypes.array.isRequired,
   availableEmoji: React.PropTypes.array.isRequired,
-  currentUser: React.PropTypes.object.isRequired,
+  isLoggedIn: React.PropTypes.bool.isRequired,
   onSend: React.PropTypes.func.isRequired
 };
 

--- a/src/containers/EditMediaDialog.js
+++ b/src/containers/EditMediaDialog.js
@@ -2,6 +2,7 @@
 import React, { Component, PropTypes } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import TransitionGroup from 'react-addons-css-transition-group';
 import { updateMedia } from '../actions/PlaylistActionCreators';
 import { closeEditMediaDialog } from '../actions/DialogActionCreators';
 
@@ -13,22 +14,32 @@ const mapDispatchToProps = dispatch => bindActionCreators({
   onCloseDialog: closeEditMediaDialog
 }, dispatch);
 
+const DIALOG_ANIMATION_DURATION = 450; // ms
+
 @connect(editMediaDialogSelector, mapDispatchToProps)
 export default class EditMediaDialogContainer extends Component {
   static propTypes = {
-    playlistID: PropTypes.string.isRequired,
-    media: PropTypes.object.isRequired,
+    playlistID: PropTypes.string,
+    media: PropTypes.object,
     onUpdateMedia: PropTypes.func.isRequired
   };
 
   render() {
     const { onUpdateMedia, playlistID, media, ...props } = this.props;
     return (
-      <EditMediaDialog
-        {...props}
-        media={media}
-        onEditedMedia={update => onUpdateMedia(playlistID, media._id, update)}
-      />
+      <TransitionGroup
+        transitionName="Dialog"
+        transitionEnterTimeout={DIALOG_ANIMATION_DURATION}
+        transitionLeaveTimeout={DIALOG_ANIMATION_DURATION}
+      >
+        {media && (
+          <EditMediaDialog
+            {...props}
+            media={media}
+            onEditedMedia={update => onUpdateMedia(playlistID, media._id, update)}
+          />
+        )}
+      </TransitionGroup>
     );
   }
 }

--- a/src/reducers/chat.js
+++ b/src/reducers/chat.js
@@ -18,8 +18,10 @@ const initialState = {
   /**
    * Message of the Day, a message shown at the very top of the Chat box. Can be
    * used for announcements, for example, or a welcome message.
+   * Stored here as a parsed message, so an array of message tokens from the
+   * u-wave-parse-chat-markup module.
    */
-  motd: '',
+  motd: [],
   /**
    * All messages, including log messages and in-flight messages.
    */

--- a/src/selectors/boothSelectors.js
+++ b/src/selectors/boothSelectors.js
@@ -55,7 +55,9 @@ export const djSelector = createSelector(
 export const isCurrentDJSelector = createSelector(
   djSelector,
   currentUserSelector,
-  (dj, me) => dj && me && dj._id === me._id
+  (dj, me) => (
+    dj && me ? dj._id === me._id : false
+  )
 );
 
 // TODO use a permissions-based system instead of role IDs:

--- a/src/selectors/roomHistorySelectors.js
+++ b/src/selectors/roomHistorySelectors.js
@@ -18,9 +18,10 @@ const addOwnVoteProps = id => entry => ({
   ...entry,
   stats: {
     ...entry.stats,
-    isDownvote: entry.stats.downvotes.indexOf(id) > -1,
-    isFavorite: entry.stats.favorites.indexOf(id) > -1,
-    isUpvote: entry.stats.upvotes.indexOf(id) > -1
+    // No ID is provided for guest users.
+    isDownvote: !!id && entry.stats.downvotes.indexOf(id) > -1,
+    isFavorite: !!id && entry.stats.favorites.indexOf(id) > -1,
+    isUpvote: !!id && entry.stats.upvotes.indexOf(id) > -1
   }
 });
 
@@ -42,7 +43,7 @@ export const currentPlaySelector = createSelector(
       timestamp,
       stats
     };
-    return user ? addOwnVoteProps(user._id)(entry) : entry;
+    return addOwnVoteProps(user ? user._id : null)(entry);
   }
 );
 
@@ -51,7 +52,7 @@ export const roomHistoryWithVotesSelector = createSelector(
   currentUserSelector,
   currentPlaySelector,
   (history, user, current) => {
-    const roomHistory = user ? history.map(addOwnVoteProps(user._id)) : history;
+    const roomHistory = history.map(addOwnVoteProps(user ? user._id : null));
     if (current) {
       roomHistory.unshift(current);
     }

--- a/src/selectors/userSelectors.js
+++ b/src/selectors/userSelectors.js
@@ -9,6 +9,7 @@ export const usersSelector = createSelector(usersBaseSelector, base => base.user
 
 export const authErrorSelector = createSelector(authSelector, auth => auth.error);
 export const currentUserSelector = createSelector(authSelector, auth => auth.user);
+export const isLoggedInSelector = createSelector(currentUserSelector, Boolean);
 export const tokenSelector = createSelector(authSelector, auth => auth.jwt);
 
 const currentRoleSelector = createSelector(

--- a/src/selectors/voteSelectors.js
+++ b/src/selectors/voteSelectors.js
@@ -7,7 +7,7 @@ const createPropSelector = (base, prop) => createSelector(base, obj => obj[prop]
 const createIsSelector = type => createSelector(
   type,
   currentUserSelector,
-  (users, me) => me && users.indexOf(me._id) > -1
+  (users, me) => !!me && users.indexOf(me._id) > -1
 );
 const createCountSelector = type => createSelector(
   type,


### PR DESCRIPTION
Lots of miscellaneous stuff.

There's one notable change here: the EditMediaDialog now only renders when a playlist item is actually being edited. It's removed from the tree when no longer editing the item, but the animation has to complete first, so it's now wrapped in a TransitionGroup.

The bottom bar is now a real `<button />`, as it should've been, but it wasn't caught by the linter before. That's because the `onClick` handler used to be passed to the div using `{...props}` spread, which added a few too many properties. So now the `onClick` handler is added explicitly and it's all good again :muscle: 