### PR TITLE
booth: fix dealing with empty booth objects (rather than nulls)

### DIFF
--- a/src/actions/BoothActionCreators.js
+++ b/src/actions/BoothActionCreators.js
@@ -24,7 +24,7 @@ export function advanceToEmpty() {
  * Set the current song and DJ.
  */
 export function advance(nextBooth) {
-  if (!nextBooth) {
+  if (!nextBooth || !nextBooth.historyID) {
     return advanceToEmpty();
   }
   const { media, userID, historyID, playlistID, playedAt } = nextBooth;

--- a/src/actions/LoginActionCreators.js
+++ b/src/actions/LoginActionCreators.js
@@ -61,7 +61,7 @@ export function loadedState(state) {
       waitlist: state.waitlist,
       locked: state.waitlistLocked
     }));
-    if (state.booth) {
+    if (state.booth && state.booth.historyID) {
       // TODO don't set this when logging in _after_ entering the page?
       dispatch(advance(state.booth));
       dispatch(setVoteStats(state.booth.stats));


### PR DESCRIPTION
The new api response format returns an empty object instead of a `null` for empty booths, so we need to check whether the object we receive actually contains any booth data before using it.