### PR TITLE
socket: fix removing chat messages by id

### DIFF
--- a/src/store/socket.js
+++ b/src/store/socket.js
@@ -58,8 +58,8 @@ const actions = {
   chatDelete() {
     return removeAllMessages();
   },
-  chatDeleteByID({ chatID }) {
-    return removeMessage(chatID);
+  chatDeleteByID({ _id }) {
+    return removeMessage(_id);
   },
   chatDeleteByUser({ userID }) {
     return removeMessagesByUser(userID);


### PR DESCRIPTION
Property was wrongly named ¯\_(ツ)_/¯