### PR TITLE
build: put compiled & bundled files in public/ instead of lib/

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 lib/
+public/

--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,7 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+/public
 /lib
 .eslintcache

--- a/src/index.html
+++ b/src/index.html
@@ -15,7 +15,7 @@
       <!-- Loading screen -->
     </div>
     <script id="u-wave-config" type="application/json">{}</script>
-    <script src="out.js"></script>
+    <script src="app.js"></script>
     <script id="u-wave-plugins"></script>
     <script>
       uw.renderToDOM(document.querySelector('#app'));

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -20,7 +20,7 @@ function injectConfig(config, { pluginsScript, pluginsStyle } = {}) {
 
 export default function uwaveWebClient(uw, options = {}) {
   const {
-    basePath = __dirname,
+    basePath = path.join(__dirname, '../public'),
     pluginsScript = null,
     pluginsScriptFile = null,
     pluginsStyle = null,

--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -117,7 +117,7 @@ export default function browserifyTask({ minify = false }) {
     .on('transform', maybeAddExternalHelpersHandler)
     .bundle()
     // Assign a file name to the generated bundle.
-    .pipe(source('out.js'))
+    .pipe(source('app.js'))
     // The generated bundle is a stream, but Uglify.js doesn't work on streams,
     // so we convert it to a Buffer instead.
     .pipe(buffer())
@@ -138,6 +138,6 @@ export default function browserifyTask({ minify = false }) {
         mangle: { toplevel: true }
       })))
     .pipe(sourcemaps.write('./'))
-    // Output to lib/out.js!
-    .pipe(gulp.dest('lib/'));
+    // Output to public/app.js!
+    .pipe(gulp.dest('public/'));
 }

--- a/tasks/clean-css.js
+++ b/tasks/clean-css.js
@@ -1,5 +1,5 @@
 import del from 'del';
 
 export default function cleanCssTask() {
-  return del([ 'lib/css', 'lib/app.css' ]);
+  return del([ 'public/app.css' ]);
 }

--- a/tasks/clean-js.js
+++ b/tasks/clean-js.js
@@ -1,5 +1,5 @@
 import del from 'del';
 
 export default function cleanJsTask() {
-  return del([ 'lib/js', 'lib/out.js' ]);
+  return del([ 'public/app.js' ]);
 }

--- a/tasks/compile-css.js
+++ b/tasks/compile-css.js
@@ -32,5 +32,5 @@ export default function compileCssTask({ minify = false }) {
     .pipe(sourcemaps.init())
       .pipe(postcss(processors))
     .pipe(sourcemaps.write('./'))
-    .pipe(dest('lib/'));
+    .pipe(dest('public/'));
 }

--- a/tasks/copy-assets.js
+++ b/tasks/copy-assets.js
@@ -3,12 +3,12 @@ import seq from 'run-sequence';
 
 gulp.task('assets:favicon', () =>
   gulp.src('assets/favicon.ico')
-    .pipe(gulp.dest('lib/'))
+    .pipe(gulp.dest('public/'))
 );
 
 gulp.task('assets:copy', () =>
   gulp.src('assets/**/*')
-    .pipe(gulp.dest('lib/assets/'))
+    .pipe(gulp.dest('public/assets/'))
 );
 
 export default function copyAssetsTask() {

--- a/tasks/copy-html.js
+++ b/tasks/copy-html.js
@@ -15,7 +15,7 @@ import renderApp from './utils/renderApp';
 // time. Both of those will make it feel like üWave loads incredibly fast, even
 // though it won't do much until the JavaScript is loaded as well.
 
-const COMPILED_CSS_PATH = joinPath(__dirname, '../lib/app.css');
+const COMPILED_CSS_PATH = joinPath(__dirname, '../public/app.css');
 
 // Used to apply a function to a DOM element identified by `selector`.
 const apply = (selector, fn) =>
@@ -57,5 +57,5 @@ export default function copyHtmlTask({ minify = false, prerender = false }) {
     ))))
     // minifyHtml makes HTML really, really compact.
     .pipe(when(minify, minifyHtml(minifierOptions)))
-    .pipe(dest('lib/'));
+    .pipe(dest('public/'));
 }

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -45,9 +45,9 @@ function bundle() {
     log('watchify error:', e.stack || e.message);
   });
   return stream
-    // Assign a name and save in lib/out.js.
-    .pipe(source('out.js'))
-    .pipe(gulp.dest('lib/'));
+    // Assign a name and save in public/app.js.
+    .pipe(source('app.js'))
+    .pipe(gulp.dest('public/'));
 }
 
 // Define a separate Gulp task for the Browserify bundling. This will be run


### PR DESCRIPTION
Only files that should be accessible in the browser go in public/. Babelified JS files still go in lib/. This prevents eg. https://welovekpop.club/middleware.js