### PR TITLE
footer: disable vote buttons when current user is DJ or booth is empty, fixes #452

### DIFF
--- a/src/components/FooterBar/Responses/Bar.css
+++ b/src/components/FooterBar/Responses/Bar.css
@@ -12,9 +12,20 @@
   height: 100%;
   border: 0;
   background: none;
-  cursor: pointer;
   flex-grow: 0.334;
   padding: 0;
+
+  cursor: pointer;
+  &:hover {
+    background-color: var(--background-hover-color);
+  }
+
+  &--disabled {
+    cursor: default;
+    &:hover {
+      background-color: transparent;
+    }
+  }
 
   &-content {
     display: flex;
@@ -22,10 +33,6 @@
     justify-content: center;
     padding: 0 15px;
     position: relative;
-  }
-
-  &:hover {
-    background-color: var(--background-hover-color);
   }
 
   &-icon {

--- a/src/components/FooterBar/Responses/Bar.js
+++ b/src/components/FooterBar/Responses/Bar.js
@@ -6,22 +6,26 @@ import Upvote from './Upvote';
 import Downvote from './Downvote';
 
 const ResponseBar = ({
+  disabled = false,
   isUpvote, upvotesCount, onUpvote,
   isDownvote, downvotesCount, onDownvote,
   isFavorite, favoritesCount, onFavorite
 }) => (
   <div className="AudienceResponse">
     <Upvote
+      disabled={disabled}
       onUpvote={onUpvote}
       count={upvotesCount}
       active={isUpvote}
     />
     <Favorite
+      disabled={disabled}
       onFavorite={onFavorite}
       count={favoritesCount}
       active={isFavorite}
     />
     <Downvote
+      disabled={disabled}
       onDownvote={onDownvote}
       count={downvotesCount}
       active={isDownvote}
@@ -30,6 +34,7 @@ const ResponseBar = ({
 );
 
 ResponseBar.propTypes = {
+  disabled: React.PropTypes.bool,
   isUpvote: React.PropTypes.bool,
   isFavorite: React.PropTypes.bool,
   isDownvote: React.PropTypes.bool,

--- a/src/components/FooterBar/Responses/Button.js
+++ b/src/components/FooterBar/Responses/Button.js
@@ -1,3 +1,4 @@
+import cx from 'classnames';
 import * as React from 'react';
 import Tooltip from 'material-ui/internal/Tooltip';
 import transformStyle from '../../../utils/transformStyle';
@@ -12,6 +13,7 @@ export default class Button extends React.Component {
   static propTypes = {
     onClick: React.PropTypes.func.isRequired,
     children: React.PropTypes.element.isRequired,
+    disabled: React.PropTypes.bool,
     count: React.PropTypes.number,
     tooltip: React.PropTypes.string
   };
@@ -27,11 +29,22 @@ export default class Button extends React.Component {
   };
 
   render() {
-    const { onClick, count, children, tooltip } = this.props;
+    const {
+      onClick,
+      disabled,
+      count,
+      children,
+      tooltip
+    } = this.props;
+    // Buttons are fake-disabled because mouseleave acts inconsistently with
+    // tooltips and actually-disabled buttons, sometimes leaving the tooltip
+    // lingering. The cursor and hover effects are removed by the
+    // ResponseButton--disabled classname, and the click handler is simply not
+    // added.
     return (
       <button
-        className="ResponseButton"
-        onClick={onClick}
+        className={cx('ResponseButton', disabled && 'ResponseButton--disabled')}
+        onClick={disabled ? null : onClick}
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}
       >

--- a/src/components/FooterBar/Responses/Downvote.js
+++ b/src/components/FooterBar/Responses/Downvote.js
@@ -6,11 +6,13 @@ import Button from './Button';
 
 const Downvote = ({
   t,
+  disabled,
   active,
   count,
   onDownvote
 }) => (
   <Button
+    disabled={disabled}
     tooltip={t('votes.downvote')}
     onClick={onDownvote}
     count={count}
@@ -23,6 +25,7 @@ Downvote.propTypes = {
   t: React.PropTypes.func.isRequired,
   onDownvote: React.PropTypes.func.isRequired,
   count: React.PropTypes.number.isRequired,
+  disabled: React.PropTypes.bool,
   active: React.PropTypes.bool
 };
 

--- a/src/components/FooterBar/Responses/Favorite.js
+++ b/src/components/FooterBar/Responses/Favorite.js
@@ -20,12 +20,14 @@ const Favorite = ({
   muiTheme,
   onFavorite,
   count,
+  disabled,
   active
 }) => {
   const CurrentIcon = active ? FavoritedIcon : FavoriteIcon;
 
   return (
     <Button
+      disabled={disabled}
       tooltip={t('votes.favorite')}
       onClick={handleFavorite(onFavorite)}
       count={count}
@@ -40,6 +42,7 @@ Favorite.propTypes = {
   muiTheme: React.PropTypes.object.isRequired,
   onFavorite: React.PropTypes.func.isRequired,
   count: React.PropTypes.number.isRequired,
+  disabled: React.PropTypes.bool,
   active: React.PropTypes.bool
 };
 

--- a/src/components/FooterBar/Responses/Upvote.js
+++ b/src/components/FooterBar/Responses/Upvote.js
@@ -6,11 +6,13 @@ import Button from './Button';
 
 const Upvote = ({
   t,
+  disabled,
   active,
   count,
   onUpvote
 }) => (
   <Button
+    disabled={disabled}
     tooltip={t('votes.upvote')}
     onClick={onUpvote}
     count={count}
@@ -23,6 +25,7 @@ Upvote.propTypes = {
   t: React.PropTypes.func.isRequired,
   onUpvote: React.PropTypes.func.isRequired,
   count: React.PropTypes.number.isRequired,
+  disabled: React.PropTypes.bool,
   active: React.PropTypes.bool
 };
 

--- a/src/components/FooterBar/index.js
+++ b/src/components/FooterBar/index.js
@@ -92,6 +92,7 @@ export default class FooterBar extends React.Component {
     const className = cx('FooterBar', this.props.className);
 
     if (user && !user.isGuest) {
+      const canVote = !userIsDJ && !!this.props.currentDJ;
       return (
         <div className={className}>
           <div className="FooterBar-user">
@@ -120,6 +121,7 @@ export default class FooterBar extends React.Component {
             )}
           >
             <ResponseBar
+              disabled={!canVote}
               onFavorite={onFavorite}
               onUpvote={onUpvote}
               onDownvote={onDownvote}


### PR DESCRIPTION
Makes things not-clickable.

[WIP] because this breaks tooltips somewhat, the `onMouseLeave` event that's used to hide tooltips isn't always fired correctly. Not sure if that's on our end or on React's :scream: 
