### PR TITLE
style: use global font on buttons too (like normalize.css v4.2)

### DIFF
--- a/src/components/App/index.css
+++ b/src/components/App/index.css
@@ -22,6 +22,11 @@ a:visited {
   color: $link-visited-color;
 }
 
+/* make sure interactive elements also use our usual fonts */
+button, input, optgroup, select, textarea {
+  font: inherit;
+}
+
 @component App {
   font-family: Open Sans, sans-serif;
 


### PR DESCRIPTION
normalize.css v5 changed the default font for buttons and some other interactive elements. this reverts it to the old behaviour so inputs and buttons use Open Sans again.