### PR TITLE
users: wrap cardable elements in <div>s to maintain height

### DIFF
--- a/src/utils/userCardable.js
+++ b/src/utils/userCardable.js
@@ -33,7 +33,7 @@ export default function userCardable() {
       render() {
         const { open, position, user } = this.state;
         return (
-          <span ref={this.refContainer}>
+          <div ref={this.refContainer}>
             {open && (
               <UserCard
                 user={user}
@@ -46,7 +46,7 @@ export default function userCardable() {
               openUserCard={this.handleOpen}
               closeUserCard={this.handleClose}
             />
-          </span>
+          </div>
         );
       }
     }


### PR DESCRIPTION
"Cardable" elements (i.e., that get a user card attached when click) use `<span>`s which means that cardable elements with block contents (e.g. a `<div>`) would lose their height. This trips up react-list, because it looks at the height of its children to compute how many items it needs to show. With an inline `<span>` as the first child, the height of eg. the first User row appears to be 0, whereas it should be 40.

Changing it to a `<div>` ensures the cardable element takes on the size of its contents.