### PR TITLE
youtube: use less intrusive way to prevent clicks from pausing YT player

### DIFF
--- a/src/sources/youtube/Player.css
+++ b/src/sources/youtube/Player.css
@@ -5,15 +5,10 @@
     position: relative;
     z-index: 3;
 
-    @modifier large {
-      pointer-events: none;
-    }
-
     @modifier small {
       margin: auto;
       width: 640px;
       height: 360px;
-      pointer-events: none;
     }
 
     @modifier preview {

--- a/src/sources/youtube/PlayerEmbed.js
+++ b/src/sources/youtube/PlayerEmbed.js
@@ -42,6 +42,10 @@ export default class YouTubePlayerEmbed extends React.Component {
     event.target.setPlaybackRate(1);
   };
 
+  handleYTPause = (event) => {
+    event.target.playVideo();
+  };
+
   refPlayer = (player) => {
     this.player = player;
   };
@@ -70,6 +74,7 @@ export default class YouTubePlayerEmbed extends React.Component {
         videoId={active ? media.sourceID : null}
         opts={opts}
         onReady={this.handleYTReady}
+        onPause={this.handleYTPause}
       />
     );
   }


### PR DESCRIPTION
This forces the video to play immediately when it pauses, instead of making the elements non-clickable. This way you can still right-click the video to get the URL or drag it (360° videos).