### PR TITLE
remove bluebird-removing hacks. youtube-player uses native promises now

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react-list-lazy-load": "^1.0.3",
     "react-redux": "^4.0.0",
     "react-tap-event-plugin": "^1.0.0",
-    "react-youtube": "^7.0.0",
+    "react-youtube": "^7.2.0",
     "recompose": "^0.20.2",
     "redux": "^3.5.2",
     "redux-logger": "^2.0.4",

--- a/src/utils/Promise.js
+++ b/src/utils/Promise.js
@@ -1,7 +1,0 @@
-// This file is used instead of Bluebird by dependencies.
-// See /tasks/browserify.js for more.
-
-// Expose Promise as a default export. This module works with dependencies that
-// expect Bluebird: Bluebird exports a Promise object as "module.exports", but
-// es6-promise exports a `.Promise` property instead.
-export { Promise as default } from 'es6-promise';

--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -41,13 +41,6 @@ export default function browserifyTask({ minify = false }) {
     entries: './src/app.js'
   });
 
-  // Replace Bluebird with es6-promise.
-  // Bluebird is only used by dependencies for its most basic Promises
-  // functionality, so we can just use the es6-promise olyfill module that we
-  // already use elsewhere. This shaves some 20kb off the final minified+gzipped
-  // bundle (that's > 15%).
-  b.require('./src/utils/Promise', { expose: 'bluebird' });
-
   b.transform(yamlify);
 
   // Babelify transforms the üWave source code, which is written in JavaScript

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -92,7 +92,6 @@ export default function watchTask() {
   });
   watcher.transform(yamlify);
   watcher.transform(babelify, babelOptions);
-  watcher.require('./src/utils/Promise', { expose: 'bluebird' });
 
   // So this is where Part 1 of the magic happens. Watchify watches our
   // JavaScript files for changes, and if the files change, it emits an "update"


### PR DESCRIPTION
Simplifies the build a bit more. youtube-player v3.0.5 and on don't depend on Bluebird anymore.