### PR TITLE
about: add about page overlay

### DIFF
--- a/src/Uwave.js
+++ b/src/Uwave.js
@@ -25,7 +25,7 @@ export default class Uwave {
   sources = {};
   jwt = null;
   renderTarget = null;
-  aboutPageComponent = () => null;
+  aboutPageComponent = null;
 
   constructor(options = {}, session = readSession()) {
     this.options = options;

--- a/src/Uwave.js
+++ b/src/Uwave.js
@@ -25,6 +25,7 @@ export default class Uwave {
   sources = {};
   jwt = null;
   renderTarget = null;
+  aboutPageComponent = () => null;
 
   constructor(options = {}, session = readSession()) {
     this.options = options;
@@ -70,6 +71,13 @@ export default class Uwave {
     return source;
   }
 
+  setAboutPageComponent(AboutPageComponent) {
+    this.aboutPageComponent = AboutPageComponent;
+  }
+  getAboutPageComponent() {
+    return this.aboutPageComponent;
+  }
+
   build() {
     this.store = configureStore(
       { config: this.options },
@@ -88,7 +96,10 @@ export default class Uwave {
   getComponent() {
     return (
       <Provider store={this.store}>
-        <AppContainer mediaSources={this.sources} />
+        <AppContainer
+          mediaSources={this.sources}
+          uwave={this}
+        />
       </Provider>
     );
   }

--- a/src/actions/OverlayActionCreators.js
+++ b/src/actions/OverlayActionCreators.js
@@ -26,6 +26,10 @@ export function toggleSettings() {
   return toggleOverlay('settings');
 }
 
+export function toggleAbout() {
+  return toggleOverlay('about');
+}
+
 export function closeAll() {
   return { type: CLOSE_OVERLAY };
 }

--- a/src/components/About/index.css
+++ b/src/components/About/index.css
@@ -1,0 +1,6 @@
+@import "../../vars.css";
+
+.AboutPanel {
+  background-color: var(--background-color);
+  overflow-y: auto;
+}

--- a/src/components/About/index.js
+++ b/src/components/About/index.js
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import Overlay from '../Overlay';
+import OverlayHeader from '../Overlay/Header';
+
+const About = ({
+  onCloseOverlay,
+  render: AboutPanel
+}) => (
+  <Overlay className="AppColumn AppColumn--full" direction="top">
+    <OverlayHeader
+      title="About"
+      onCloseOverlay={onCloseOverlay}
+      direction="top"
+    />
+    <div className="AppRow AppRow--middle AboutPanel">
+      <AboutPanel />
+    </div>
+  </Overlay>
+);
+
+About.propTypes = {
+  onCloseOverlay: React.PropTypes.func.isRequired,
+  render: React.PropTypes.func.isRequired
+};
+
+export default About;

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -13,6 +13,7 @@ import Overlays from './Overlays';
 import PlaylistManager from '../../containers/PlaylistManager';
 import RoomHistory from '../../containers/RoomHistory';
 import SettingsManager from '../../containers/SettingsManager';
+import About from '../../containers/About';
 
 import SidePanels from '../../containers/SidePanels';
 import Dialogs from '../Dialogs';
@@ -22,6 +23,7 @@ import DragLayer from '../../containers/DragLayer';
 const App = ({
   activeOverlay,
   settings,
+  hasAboutPage,
   onCloseOverlay
 }) => (
   <div className="App">
@@ -42,6 +44,10 @@ const App = ({
         <ErrorArea />
       </div>
       <Overlays transitionName="Overlay" active={activeOverlay}>
+        {hasAboutPage && <About
+          key="about"
+          onCloseOverlay={onCloseOverlay}
+        />}
         <PlaylistManager
           key="playlistManager"
           onCloseOverlay={onCloseOverlay}
@@ -72,6 +78,7 @@ const App = ({
 App.propTypes = {
   activeOverlay: React.PropTypes.string,
   settings: React.PropTypes.object.isRequired,
+  hasAboutPage: React.PropTypes.bool,
 
   onCloseOverlay: React.PropTypes.func.isRequired
 };

--- a/src/components/HeaderBar/AppTitle.css
+++ b/src/components/HeaderBar/AppTitle.css
@@ -1,0 +1,20 @@
+@import "../../vars.css";
+
+.AppTitle {
+  display: flex;
+  align-items: center;
+
+  &-logo {
+    line-height: var(--header-height);
+    height: var(--header-height);
+    background-image: url(/assets/img/logo-white.png);
+    background-repeat: no-repeat;
+    background-position: center center;
+    background-size: contain;
+    margin-left: 10px;
+    font-size: 0;
+    flex-grow: 2;
+  }
+
+  &-button {}
+}

--- a/src/components/HeaderBar/AppTitle.css
+++ b/src/components/HeaderBar/AppTitle.css
@@ -3,6 +3,7 @@
 .AppTitle {
   display: flex;
   align-items: center;
+  padding-right: 20px;
 
   &-logo {
     line-height: var(--header-height);
@@ -17,4 +18,8 @@
   }
 
   &-button {}
+
+  &--hasAboutPage {
+    padding-right: 0;
+  }
 }

--- a/src/components/HeaderBar/AppTitle.js
+++ b/src/components/HeaderBar/AppTitle.js
@@ -5,19 +5,23 @@ import AboutIcon from 'material-ui/svg-icons/navigation/arrow-drop-down';
 
 const AppTitle = ({
   className,
+  hasAboutPage,
   children,
   onClick
 }) => (
-  <div className={cx('AppTitle', className)}>
+  <div className={cx('AppTitle', className, hasAboutPage && 'AppTitle--hasAboutPage')}>
     <h1 className="AppTitle-logo">{children}</h1>
-    <IconButton className="AppTitle-button" onClick={onClick}>
-      <AboutIcon />
-    </IconButton>
+    {hasAboutPage && (
+      <IconButton className="AppTitle-button" onClick={onClick}>
+        <AboutIcon />
+      </IconButton>
+    )}
   </div>
 );
 
 AppTitle.propTypes = {
   className: React.PropTypes.string,
+  hasAboutPage: React.PropTypes.bool.isRequired,
   children: React.PropTypes.string.isRequired,
   onClick: React.PropTypes.func.isRequired
 };

--- a/src/components/HeaderBar/AppTitle.js
+++ b/src/components/HeaderBar/AppTitle.js
@@ -1,0 +1,25 @@
+import cx from 'classnames';
+import * as React from 'react';
+import IconButton from 'material-ui/IconButton';
+import AboutIcon from 'material-ui/svg-icons/navigation/arrow-drop-down';
+
+const AppTitle = ({
+  className,
+  children,
+  onClick
+}) => (
+  <div className={cx('AppTitle', className)}>
+    <h1 className="AppTitle-logo">{children}</h1>
+    <IconButton className="AppTitle-button" onClick={onClick}>
+      <AboutIcon />
+    </IconButton>
+  </div>
+);
+
+AppTitle.propTypes = {
+  className: React.PropTypes.string,
+  children: React.PropTypes.string.isRequired,
+  onClick: React.PropTypes.func.isRequired
+};
+
+export default AppTitle;

--- a/src/components/HeaderBar/index.css
+++ b/src/components/HeaderBar/index.css
@@ -1,4 +1,5 @@
 @import "../../vars.css";
+@import "./AppTitle.css";
 @import "./HeaderHistoryButton.css";
 @import "./Progress.css";
 @import "./Volume.css";
@@ -13,15 +14,8 @@
     position: absolute;
     top: 0;
     left: 0;
-    width: 210px;
+    width: 240px;
     margin: 0;
-    line-height: var(--header-height);
-    height: var(--header-height);
-    background-image: url(/assets/img/logo-white.png);
-    background-repeat: no-repeat;
-    background-position: 10px center;
-    background-size: auto 36px;
-    font-size: 0;
   }
 
   &-volume {

--- a/src/components/HeaderBar/index.js
+++ b/src/components/HeaderBar/index.js
@@ -16,6 +16,7 @@ const HeaderBar = ({
   mediaStartTime,
   volume,
   muted,
+  hasAboutPage,
   onVolumeChange,
   onVolumeMute,
   onVolumeUnmute,
@@ -27,7 +28,13 @@ const HeaderBar = ({
     className={cx('HeaderBar', className)}
     {...attrs}
   >
-    <AppTitle className="HeaderBar-title" onClick={onToggleAboutOverlay}>{title}</AppTitle>
+    <AppTitle
+      className="HeaderBar-title"
+      hasAboutPage={hasAboutPage}
+      onClick={onToggleAboutOverlay}
+    >
+      {title}
+    </AppTitle>
     <CurrentMedia className="HeaderBar-now-playing" media={media} />
     {dj && <CurrentDJ className="HeaderBar-dj" dj={dj} />}
     <Progress
@@ -59,6 +66,7 @@ HeaderBar.propTypes = {
   mediaStartTime: React.PropTypes.number,
   volume: React.PropTypes.number,
   muted: React.PropTypes.bool,
+  hasAboutPage: React.PropTypes.bool.isRequired,
 
   onVolumeChange: React.PropTypes.func,
   onVolumeMute: React.PropTypes.func,

--- a/src/components/HeaderBar/index.js
+++ b/src/components/HeaderBar/index.js
@@ -1,6 +1,7 @@
 import cx from 'classnames';
 import * as React from 'react';
 
+import AppTitle from './AppTitle';
 import Progress from './Progress';
 import CurrentMedia from './CurrentMedia';
 import Volume from './Volume';
@@ -19,13 +20,14 @@ const HeaderBar = ({
   onVolumeMute,
   onVolumeUnmute,
   onToggleRoomHistory,
+  onToggleAboutOverlay,
   ...attrs
 }) => (
   <div
     className={cx('HeaderBar', className)}
     {...attrs}
   >
-    <h1 className="HeaderBar-title">{title}</h1>
+    <AppTitle className="HeaderBar-title" onClick={onToggleAboutOverlay}>{title}</AppTitle>
     <CurrentMedia className="HeaderBar-now-playing" media={media} />
     {dj && <CurrentDJ className="HeaderBar-dj" dj={dj} />}
     <Progress
@@ -61,7 +63,8 @@ HeaderBar.propTypes = {
   onVolumeChange: React.PropTypes.func,
   onVolumeMute: React.PropTypes.func,
   onVolumeUnmute: React.PropTypes.func,
-  onToggleRoomHistory: React.PropTypes.func
+  onToggleRoomHistory: React.PropTypes.func,
+  onToggleAboutOverlay: React.PropTypes.func
 };
 
 export default HeaderBar;

--- a/src/components/index.css
+++ b/src/components/index.css
@@ -1,3 +1,4 @@
+@import "./About";
 @import "./App";
 @import "./Avatar";
 @import "./Chat";

--- a/src/containers/About.js
+++ b/src/containers/About.js
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import About from '../components/About';
+
+export default class AboutContainer extends React.Component {
+  static contextTypes = {
+    uwave: React.PropTypes.object
+  };
+
+  getAboutPageComponent() {
+    const uw = this.context.uwave;
+    if (uw) {
+      return uw.getAboutPageComponent();
+    }
+    return () => null;
+  }
+
+  render() {
+    return (
+      <About
+        {...this.props}
+        render={this.getAboutPageComponent()}
+      />
+    );
+  }
+}

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -21,21 +21,23 @@ const mapStateToProps = createStructuredSelector({
   activeOverlay: state => state.activeOverlay,
   settings: settingsSelector,
   language: languageSelector,
-  muiTheme: muiThemeSelector
+  muiTheme: muiThemeSelector,
+  hasAboutPage: (state, props) => (
+    props.uwave.getAboutPageComponent() !== null
+  )
 });
 
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators({
-    createTimer,
-    stopTimer,
-    onCloseOverlay: closeAll
-  }, dispatch);
-}
+const mapDispatchToProps = dispatch => bindActionCreators({
+  createTimer,
+  stopTimer,
+  onCloseOverlay: closeAll
+}, dispatch);
 
 @connect(mapStateToProps, mapDispatchToProps)
 export default class AppContainer extends React.Component {
   static propTypes = {
     mediaSources: React.PropTypes.object.isRequired,
+    uwave: React.PropTypes.object,
     language: React.PropTypes.string,
     muiTheme: React.PropTypes.object,
     createTimer: React.PropTypes.func.isRequired,
@@ -44,13 +46,15 @@ export default class AppContainer extends React.Component {
 
   static childContextTypes = {
     timerCallbacks: React.PropTypes.arrayOf(React.PropTypes.func),
-    mediaSources: React.PropTypes.object
+    mediaSources: React.PropTypes.object,
+    uwave: React.PropTypes.object
   };
 
   getChildContext() {
     return {
       timerCallbacks: this.timerCallbacks,
-      mediaSources: this.props.mediaSources
+      mediaSources: this.props.mediaSources,
+      uwave: this.props.uwave
     };
   }
 

--- a/src/containers/HeaderBar.js
+++ b/src/containers/HeaderBar.js
@@ -1,5 +1,8 @@
+import * as React from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import compose from 'recompose/compose';
+import getContext from 'recompose/getContext';
 import { createStructuredSelector } from 'reselect';
 import { setVolume, mute, unmute } from '../actions/PlaybackActionCreators';
 import { toggleRoomHistory, toggleAbout } from '../actions/OverlayActionCreators';
@@ -13,7 +16,10 @@ const mapStateToProps = createStructuredSelector({
   media: mediaSelector,
   dj: djSelector,
   volume: volumeSelector,
-  muted: isMutedSelector
+  muted: isMutedSelector,
+  hasAboutPage: (state, props) => (
+    props.uwave.getAboutPageComponent() !== null
+  )
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({
@@ -24,4 +30,7 @@ const mapDispatchToProps = dispatch => bindActionCreators({
   onToggleAboutOverlay: toggleAbout
 }, dispatch);
 
-export default connect(mapStateToProps, mapDispatchToProps)(HeaderBar);
+export default compose(
+  getContext({ uwave: React.PropTypes.object }),
+  connect(mapStateToProps, mapDispatchToProps)
+)(HeaderBar);

--- a/src/containers/HeaderBar.js
+++ b/src/containers/HeaderBar.js
@@ -2,7 +2,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { setVolume, mute, unmute } from '../actions/PlaybackActionCreators';
-import { toggleRoomHistory } from '../actions/OverlayActionCreators';
+import { toggleRoomHistory, toggleAbout } from '../actions/OverlayActionCreators';
 
 import { djSelector, mediaSelector, startTimeSelector } from '../selectors/boothSelectors';
 import { volumeSelector, isMutedSelector } from '../selectors/settingSelectors';
@@ -20,7 +20,8 @@ const mapDispatchToProps = dispatch => bindActionCreators({
   onVolumeChange: setVolume,
   onVolumeMute: mute,
   onVolumeUnmute: unmute,
-  onToggleRoomHistory: toggleRoomHistory
+  onToggleRoomHistory: toggleRoomHistory,
+  onToggleAboutOverlay: toggleAbout
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(HeaderBar);


### PR DESCRIPTION
Adds a user-fillable overlay, to be accessed by:

![this button](http://i.imgur.com/9jicwR6.png)

Server hosts can register a React component that will be rendered in the overlay using a plugin script.

```js
import * as React from 'react';

uw.setAboutPageComponent(
  class MyAboutPage extends React.Component {
    render() {
      return 'hoi';
    }
  }
);
```