### PR TITLE
chat: improve message receive performance

### DIFF
--- a/src/components/Chat/LogMessage.js
+++ b/src/components/Chat/LogMessage.js
@@ -1,5 +1,6 @@
 import cx from 'classnames';
 import * as React from 'react';
+import pure from 'recompose/pure';
 
 const LogMessage = ({ alternate, text }) => (
   <div
@@ -20,4 +21,4 @@ LogMessage.propTypes = {
   text: React.PropTypes.string.isRequired
 };
 
-export default LogMessage;
+export default pure(LogMessage);

--- a/src/components/Chat/Markup/GroupMention.js
+++ b/src/components/Chat/Markup/GroupMention.js
@@ -1,8 +1,8 @@
 import cx from 'classnames';
 import * as React from 'react';
 
-const GroupMention = ({ className, group, ...props }) => (
-  <span className={cx('ChatMention', `ChatMention--${group}`, className)} {...props}>
+const GroupMention = ({ className, group }) => (
+  <span className={cx('ChatMention', `ChatMention--${group}`, className)}>
     @{group}
   </span>
 );

--- a/src/components/Chat/Message.js
+++ b/src/components/Chat/Message.js
@@ -1,6 +1,7 @@
 import cx from 'classnames';
 import * as React from 'react';
 import compose from 'recompose/compose';
+import pure from 'recompose/pure';
 import withProps from 'recompose/withProps';
 
 import userCardable from '../../utils/userCardable';
@@ -13,6 +14,7 @@ import compile from './Markup/compile';
 const timeFormatOptions = { hour: 'numeric', minute: 'numeric' };
 
 const enhance = compose(
+  pure,
   userCardable(),
   withProps(props => ({
     onUsernameClick(event) {

--- a/src/components/Chat/Motd.js
+++ b/src/components/Chat/Motd.js
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import pure from 'recompose/pure';
+
 import compile from './Markup/compile';
 
 const Motd = ({ children, compileOptions }) => (
@@ -17,4 +19,4 @@ Motd.propTypes = {
   })
 };
 
-export default Motd;
+export default pure(Motd);


### PR DESCRIPTION
Marks message components as pure so the entire contents of all old
messages aren't reconciled when a new message comes in.