### PR TITLE
build: remove postcss-bem

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "loud-rejection": "^1.3.0",
     "mocha": "^3.0.0",
     "npm-run-path": "^2.0.1",
-    "postcss-bem": "^0.4.0",
     "postcss-cssnext": "^2.8.0",
     "postcss-import": "8.0.2",
     "postcss-loader": "^1.1.1",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,6 @@
 module.exports = ({ env, webpack }) => ({
   plugins: {
     'postcss-import': { addDependencyTo: webpack },
-    'postcss-bem': {},
     'postcss-cssnext': {},
     cssnano: env === 'production' && {
       autoprefixer: false

--- a/src/app.css
+++ b/src/app.css
@@ -12,6 +12,7 @@ button {
   background: initial;
   border: initial;
   text-align: initial;
+  -webkit-appearance: initial;
   &:focus {
     outline: initial;
   }

--- a/src/components/App/index.css
+++ b/src/components/App/index.css
@@ -27,7 +27,7 @@ button, input, optgroup, select, textarea {
   font: inherit;
 }
 
-@component App {
+.App {
   font-family: Open Sans, sans-serif;
 
   position: absolute;
@@ -39,7 +39,7 @@ button, input, optgroup, select, textarea {
   background: var(--background-color);
   color: var(--text-color);
 
-  @descendent middle {
+  &-middle {
     position: absolute;
     top: var(--header-height);
     bottom: var(--footer-height);
@@ -48,38 +48,38 @@ button, input, optgroup, select, textarea {
   }
 }
 
-@component AppColumn {
+.AppColumn {
   position: absolute;
   height: 100%;
 
-  @modifier full {
+  &--full {
     width: 100%;
   }
-  @modifier left {
+  &--left {
     width: 75%;
     left: 0;
   }
-  @modifier right {
+  &--right {
     width: 25%;
     right: 0;
   }
 }
 
-@component AppRow {
+.AppRow {
   position: absolute;
   left: 0;
   right: 0;
   clear: both;
 
-  @modifier top {
+  &--top {
     height: var(--header-height);
     top: 0;
   }
-  @modifier middle {
+  &--middle {
     top: var(--header-height);
     bottom: var(--footer-height);
   }
-  @modifier bottom {
+  &--bottom {
     height: var(--footer-height);
     bottom: 0;
   }

--- a/src/components/Avatar/index.css
+++ b/src/components/Avatar/index.css
@@ -1,4 +1,4 @@
-@component Avatar {
+.Avatar {
   text-align: center;
   height: 24px;
   width: 24px;
@@ -6,7 +6,7 @@
   overflow: hidden;
   display: inline-block;
 
-  @descendent image {
+  &-image {
     width: 100%;
     height: 100%;
   }

--- a/src/components/Chat/Input/index.css
+++ b/src/components/Chat/Input/index.css
@@ -1,21 +1,21 @@
 @import "../../../vars.css";
 
-@component ChatInputWrapper {
+.ChatInputWrapper {
   background: var(--chat-background-color);
   border-top: 1px solid var(--chat-border-color);
 }
 
-@component ChatInput {
+.ChatInput {
   height: 100%;
   width: 100%;
 
-  @descendent suggestions {
+  &-suggestions {
     position: absolute;
     bottom: 100%;
     width: 100%;
   }
 
-  @descendent input {
+  &-input {
     margin: 15px 15px 16px 15px;
     height: 28px;
     width: calc(100% - 32px);
@@ -25,7 +25,7 @@
     color: var(--text-color);
     font-size: 10pt;
 
-    @when focused {
+    &.is-focused {
       border-color: var(--highlight-color);
       outline: none;
     }

--- a/src/components/Chat/LogMessage.css
+++ b/src/components/Chat/LogMessage.css
@@ -1,9 +1,6 @@
-@component ChatMessage {
-  @modifier log {
-    /* TODO add support for @descendent inside @modifier to postcss-bem */
-    & .ChatMessage-content {
-      padding-left: 10px;
-      color: #aaaaaa;
-    }
+.ChatMessage--log {
+  & .ChatMessage-content {
+    padding-left: 10px;
+    color: #aaaaaa;
   }
 }

--- a/src/components/Chat/Markup/Emoji.css
+++ b/src/components/Chat/Markup/Emoji.css
@@ -1,4 +1,4 @@
-@component Emoji {
+.Emoji {
   /* Same size as the surrounding text */
   height: 1.3em;
   width: 1.3em;

--- a/src/components/Chat/Message.css
+++ b/src/components/Chat/Message.css
@@ -2,23 +2,23 @@
 
 /* Message styles are still super hacky...
  * One day! */
-@component ChatMessage {
+.ChatMessage {
   background: var(--chat-background-color);
   min-height: 32px;
   position: relative;
 
-  @modifier alternate {
+  &--alternate {
     background: var(--chat-background-color2);
     & .ChatMessage-timestamp {
       background: var(--chat-background-color2);
     }
   }
 
-  @modifier mention {
+  &--mention {
     box-shadow: 5px 0px 0px var(--highlight-color) inset;
   }
 
-  @descendent timestamp {
+  &-timestamp {
     background: var(--chat-background-color);
     position: absolute;
     top: 0;
@@ -32,7 +32,7 @@
     display: block;
   }
 
-  @descendent avatar {
+  &-avatar {
     position: absolute;
     width: 24px;
     height: 24px;
@@ -41,7 +41,7 @@
     margin: 4px 0;
   }
 
-  @descendent content {
+  &-content {
     position: relative;
     padding-left: 50px;
     padding-right: 3px;
@@ -51,25 +51,25 @@
     word-wrap: break-word;
   }
 
-  @descendent cardable {
+  &-cardable {
     cursor: pointer;
     padding: 0;
   }
 
-  @descendent username {
+  &-username {
     color: #9ba0a0;
     font-weight: 600;
   }
 
-  @descendent text {
+  &-text {
     margin-left: 5px;
   }
 
-  @modifier loading {
+  &--loading {
     opacity: 0.7;
   }
 }
 
-@component ChatMention {
+.ChatMention {
   color: var(--highlight-color);
 }

--- a/src/components/Chat/Motd.css
+++ b/src/components/Chat/Motd.css
@@ -1,10 +1,7 @@
-@component ChatMessage {
-  @modifier motd {
-    /* TODO add support for @descendent inside @modifier to postcss-bem */
-    & .ChatMessage-content {
-      padding-left: 10px;
-      white-space: pre-wrap;
-      color: #eee;
-    }
+.ChatMessage--motd {
+  & .ChatMessage-content {
+    padding-left: 10px;
+    white-space: pre-wrap;
+    color: #eee;
   }
 }

--- a/src/components/Chat/index.css
+++ b/src/components/Chat/index.css
@@ -4,20 +4,20 @@
 @import "./Message.css";
 @import "./Motd.css";
 
-@component Chat {
+.Chat {
   height: 100%;
   overflow-y: scroll;
   font-size: 10pt;
 }
 
-@component ChatContainer {
-  @descendent messages {
+.ChatContainer {
+  &-messages {
     position: absolute;
     top: 0;
     bottom: var(--footer-height);
     width: 100%;
   }
-  @descendent input {
+  &-input {
     position: absolute;
     bottom: 0;
     height: var(--footer-height);

--- a/src/components/Dialogs/ConfirmDialog/index.css
+++ b/src/components/Dialogs/ConfirmDialog/index.css
@@ -1,14 +1,14 @@
-@component ConfirmDialog {
-  @descendent buttons {
+.ConfirmDialog {
+  &-buttons {
     display: flex;
     justify-content: space-between;
   }
 
-  @descendent spacer {
+  &-spacer {
     width: 40px;
   }
 
-  @descendent button {
+  &-button {
     width: 50%;
   }
 }

--- a/src/components/Dialogs/Dialog.css
+++ b/src/components/Dialogs/Dialog.css
@@ -1,5 +1,5 @@
 @import "../../vars.css";
 
-@component Dialog {
+.Dialog {
   color: var(--text-color);
 }

--- a/src/components/Dialogs/EditMediaDialog/index.css
+++ b/src/components/Dialogs/EditMediaDialog/index.css
@@ -1,28 +1,28 @@
 @import "../../../vars.css";
 
-@component EditMediaDialog {
+.EditMediaDialog {
 }
 
-@component EditMediaDialogForm {
+.EditMediaDialogForm {
   display: flex;
   justify-content: space-between;
-  @descendent column {
+  &-column {
     width: 50%;
   }
-  @descendent separator {
+  &-separator {
     /* Pushes columns to the side! */
   }
 }
 
-@component EditMediaDialogGroup {
+.EditMediaDialogGroup {
   display: flex;
   justify-content: center;
 
-  @descendent field {
+  &-field {
     flex-grow: 1;
   }
 
-  @descendent label {
+  &-label {
     line-height: 50px;
     white-space: nowrap;
     padding: 0 20px;

--- a/src/components/Dialogs/LoginDialog/LoginForm.css
+++ b/src/components/Dialogs/LoginDialog/LoginForm.css
@@ -1,5 +1,5 @@
-@component LoginForm {
-  @descendent forgot {
+.LoginForm {
+  &-forgot {
     font-size: 10pt;
   }
 }

--- a/src/components/Dialogs/PreviewMediaDialog/index.css
+++ b/src/components/Dialogs/PreviewMediaDialog/index.css
@@ -1,5 +1,5 @@
-@component PreviewMediaDialog {
-  @descendent content {
+.PreviewMediaDialog {
+  &-content {
     overflow: hidden;
     position: relative;
   }

--- a/src/components/Dialogs/index.css
+++ b/src/components/Dialogs/index.css
@@ -4,7 +4,7 @@
 @import "./LoginDialog";
 @import "./PreviewMediaDialog";
 
-@component Dialogs {
+.Dialogs {
   z-index: 100;
   position: absolute;
   width: 0;

--- a/src/components/FooterBar/NextMedia.css
+++ b/src/components/FooterBar/NextMedia.css
@@ -1,6 +1,6 @@
 @import "../../vars.css";
 
-@component NextMedia {
+.NextMedia {
   height: 100%;
   width: 100%;
   cursor: pointer;
@@ -12,7 +12,7 @@
     background-color: var(--background-hover-color);
   }
 
-  @descendent playlist {
+  &-playlist {
     color: var(--text-color);
   }
 }

--- a/src/components/FooterBar/Responses/Bar.css
+++ b/src/components/FooterBar/Responses/Bar.css
@@ -1,6 +1,6 @@
 @import "../../../vars.css";
 
-@component AudienceResponse {
+.AudienceResponse {
   height: 100%;
   width: 100%;
   display: flex;
@@ -8,7 +8,7 @@
   align-items: center;
 }
 
-@component ResponseButton {
+.ResponseButton {
   height: 100%;
   border: 0;
   background: none;
@@ -16,7 +16,7 @@
   flex-grow: 0.334;
   padding: 0;
 
-  @descendent content {
+  &-content {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -28,7 +28,7 @@
     background-color: var(--background-hover-color);
   }
 
-  @descendent icon {
+  &-icon {
     height: 36px;
     width: 36px;
     padding: 6px 12px 6px 0px;

--- a/src/components/FooterBar/UserInfo.css
+++ b/src/components/FooterBar/UserInfo.css
@@ -1,6 +1,6 @@
 @import "../../vars.css";
 
-@component UserInfo {
+.UserInfo {
   width: 100%;
   height: 100%;
   padding: 4px;
@@ -11,14 +11,14 @@
     background-color: var(--background-hover-color);
   }
 
-  @descendent avatar {
+  &-avatar {
     width: 50px;
     height: 50px;
     margin: auto;
     display: block;
   }
 
-  @descendent settings {
+  &-settings {
     position: absolute;
     bottom: 4px;
     right: 3px;

--- a/src/components/FooterBar/index.css
+++ b/src/components/FooterBar/index.css
@@ -3,14 +3,14 @@
 @import "./UserInfo.css";
 @import "./Responses";
 
-@component FooterBar {
+.FooterBar {
   display: flex;
   justify-content: space-between;
   z-index: 20; /* on top of overlays */
   border-top: 1px solid var(--chat-border-color);
   background: var(--background-color);
 
-  @descendent guest {
+  &-guest {
     font-size: 12pt;
     padding: 0 25px;
     display: flex;
@@ -20,30 +20,30 @@
     flex-grow: 1;
   }
 
-  @descendent user {
+  &-user {
     height: 100%;
     width: 75px;
   }
 
-  @descendent next {
+  &-next {
     flex-grow: 1;
     height: 100%;
     overflow: hidden;
   }
 
-  @descendent responses {
+  &-responses {
     height: 100%;
-    @modifier spaced {
+    &--spaced {
       padding-right: 1rem;
     }
   }
 
-  @descendent skip {
+  &-skip {
     height: 100%;
     padding-right: 0.5rem;
   }
 
-  @descendent join {
+  &-join {
     font-size: 12pt;
     float: right;
     display: flex;
@@ -54,13 +54,13 @@
     background: var(--highlight-color);
     cursor: pointer;
 
-    @modifier locked {
+    &--locked {
       width: 140px;
     }
   }
 }
 
-@component FooterAuthButton {
+.FooterAuthButton {
   width: 125px;
   height: 100%;
   border: 0;
@@ -72,14 +72,14 @@
   color: var(--text-color);
   font-size: 12pt;
 
-  @modifier login {
+  &--login {
     background: var(--background-color);
     &:hover {
       background: var(--background-hover-color);
     }
   }
 
-  @modifier register {
+  &--register {
     background: var(--highlight-color);
     &:hover {
       background: var(--highbright-color);

--- a/src/components/Form/Button.css
+++ b/src/components/Form/Button.css
@@ -1,6 +1,6 @@
 @import "../../vars.css";
 
-@component Button {
+.Button {
   width: 100%;
   height: var(--forms-textfield-size);
   cursor: pointer;
@@ -15,7 +15,7 @@
   text-transform: uppercase;
   font-size: 12pt;
 
-  @descendent loading {
+  &-loading {
     width: calc(var(--forms-textfield-size) * 0.8);
     height: calc(var(--forms-textfield-size) * 0.8);
     margin: auto;

--- a/src/components/Form/TextField.css
+++ b/src/components/Form/TextField.css
@@ -1,6 +1,6 @@
 @import "../../vars.css";
 
-@component TextField {
+.TextField {
   background: #383838;
   border: 1px solid #2c2c2c;
   border-top-color: #3e3e3e;
@@ -8,7 +8,7 @@
   height: var(--forms-textfield-size);
   font-size: 12pt;
 
-  @descendent input {
+  &-input {
     width: 100%;
     border: 0;
     height: 100%;
@@ -26,7 +26,7 @@
     }
   }
 
-  @descendent icon {
+  &-icon {
     width: var(--forms-textfield-size);
     height: var(--forms-textfield-size);
     margin-left: -var(--forms-textfield-size);

--- a/src/components/Form/index.css
+++ b/src/components/Form/index.css
@@ -2,7 +2,7 @@
 @import "./Button.css";
 @import "./TextField.css";
 
-@component FormGroup {
+.FormGroup {
   margin: var(--forms-element-margin) 0;
   width: 100%;
   clear: both;
@@ -11,7 +11,7 @@
     margin-top: 0;
   }
 
-  @modifier noSpacing {
+  &--noSpacing {
     margin: 0;
   }
 }

--- a/src/components/HeaderBar/HeaderHistoryButton.css
+++ b/src/components/HeaderBar/HeaderHistoryButton.css
@@ -1,4 +1,4 @@
-@component HeaderHistoryButton {
+.HeaderHistoryButton {
   /* above the progress bar, video backdrop, etc. */
   z-index: 7;
 }

--- a/src/components/HeaderBar/Progress.css
+++ b/src/components/HeaderBar/Progress.css
@@ -1,7 +1,7 @@
 @import "../../vars.css";
 
-@component Progress {
-  @descendent fill {
+.Progress {
+  &-fill {
     background: var(--highlight-color);
     height: 100%;
     width: 100%;

--- a/src/components/HeaderBar/Volume.css
+++ b/src/components/HeaderBar/Volume.css
@@ -1,5 +1,5 @@
-@component VolumeSlider {
-  @descendent slider {
+.VolumeSlider {
+  &-slider {
     height: 24px;
     display: inline-block;
     width: calc(100% - 30px);

--- a/src/components/HeaderBar/index.css
+++ b/src/components/HeaderBar/index.css
@@ -3,13 +3,13 @@
 @import "./Progress.css";
 @import "./Volume.css";
 
-@component HeaderBar {
+.HeaderBar {
   position: relative;
   height: 100%;
   width: 100%;
   z-index: 4; /* below overlays, above video */
 
-  @descendent title {
+  &-title {
     position: absolute;
     top: 0;
     left: 0;
@@ -24,7 +24,7 @@
     font-size: 0;
   }
 
-  @descendent volume {
+  &-volume {
     position: absolute;
     right: var(--header-height);
     top: 0;
@@ -32,7 +32,7 @@
     padding: 15px;
   }
 
-  @descendent history {
+  &-history {
     position: absolute;
     top: 0;
     right: 0;
@@ -41,7 +41,7 @@
     background: #111;
   }
 
-  @descendent now-playing {
+  &-now-playing {
     position: absolute;
     top: 5px;
     left: 250px;
@@ -49,7 +49,7 @@
     line-height: 25px;
   }
 
-  @descendent dj {
+  &-dj {
     position: absolute;
     top: 30px;
     left: 250px;
@@ -58,7 +58,7 @@
     color: var(--muted-text-color);
   }
 
-  @descendent progress {
+  &-progress {
     position: absolute;
     bottom: 1px;
     height: 2px;

--- a/src/components/Loader/index.css
+++ b/src/components/Loader/index.css
@@ -1,10 +1,10 @@
 @import "../../vars.css";
 
-@component Loader {
+.Loader {
   position: relative;
 }
 
-@component Spinner {
+.Spinner {
   border-style: solid;
   border-color: color(var(--text-color) alpha(0.2));
   border-left-color: var(--text-color);
@@ -13,13 +13,13 @@
   border-radius: 50%;
   width: 100%;
 
-  @modifier tiny {
+  &--tiny {
     border-width: 3px;
     /* Hack for squares! padding-bottom is computed according to
      * parent element width. */
     padding-bottom: calc(100% - 6px);
   }
-  @modifier large {
+  &--large {
     border-width: 1.1em;
     padding-bottom: calc(100% - 2.2em);
   }

--- a/src/components/LoadingScreen/index.css
+++ b/src/components/LoadingScreen/index.css
@@ -1,6 +1,6 @@
 @import "../../vars.css";
 
-@component LoadingScreen {
+.LoadingScreen {
   background: var(--background-color);
   position: fixed;
   left: 0;
@@ -13,14 +13,14 @@
   justify-content: center;
   align-items: center;
 
-  @descendent loader {
+  &-loader {
     height: 250px;
     width: 250px;
     height: 50vmin;
     width: 50vmin;
   }
 
-  @descendent notice {
+  &-notice {
     color: var(--text-color);
   }
 }

--- a/src/components/MediaList/Actions.css
+++ b/src/components/MediaList/Actions.css
@@ -1,15 +1,15 @@
 @import "../../vars.css";
 
-@component MediaActions {
+.MediaActions {
   height: 54px;
   text-align: right;
   background: var(--background-color);
 
-  @when selected {
+  &.is-selected {
     background: var(--highlight-color);
   }
 
-  @descendent action {
+  &-action {
     height: 100%;
     cursor: pointer;
     display: inline-block;

--- a/src/components/MediaList/MediaDragPreview.css
+++ b/src/components/MediaList/MediaDragPreview.css
@@ -1,6 +1,6 @@
 @import "../../vars.css";
 
-@component MediaDragPreview {
+.MediaDragPreview {
   background: var(--highbright-color);
   color: var(--text-color);
   font-weight: bold;

--- a/src/components/MediaList/MediaLoadingIndicator.css
+++ b/src/components/MediaList/MediaLoadingIndicator.css
@@ -1,4 +1,4 @@
-@component MediaLoadingIndicator {
+.MediaLoadingIndicator {
   height: 100%;
   width: 55px;
   float: left;
@@ -6,7 +6,7 @@
   align-items: center;
   justify-content: center;
 
-  @descendent spinner {
+  &-spinner {
     width: 32px;
     height: 32px;
   }

--- a/src/components/MediaList/Row.css
+++ b/src/components/MediaList/Row.css
@@ -1,28 +1,28 @@
 @import "../../vars.css";
 
-@component MediaListRow {
+.MediaListRow {
   height: 54px;
   line-height: 54px;
   position: relative;
   background: var(--media-list-color);
 
-  @modifier alternate {
+  &--alternate {
     background: var(--media-list-alternate-color);
   }
 
-  @when loading {
+  &.is-loading {
     opacity: 0.75;
   }
 
-  @when selected {
+  &.is-selected {
     background: color(var(--highlight-color) alpha(* 70%));
   }
 
-  @descendent loader {
+  &-loader {
     margin: 0 15px;
   }
 
-  @descendent thumb {
+  &-thumb {
     height: 100%;
     width: 55px;
     margin: 0 15px;
@@ -30,12 +30,12 @@
     float: left;
   }
 
-  @descendent image {
+  &-image {
     max-width: 100%;
     max-height: 100%;
   }
 
-  @descendent artist {
+  &-artist {
     height: 100%;
     float: left;
     width: calc(50% - var(--media-list-spacing) - var(--media-list-thumb-width) - var(--media-list-duration-width));
@@ -45,7 +45,7 @@
     white-space: nowrap;
   }
 
-  @descendent title {
+  &-title {
     height: 100%;
     float: left;
     width: calc(50% - var(--media-list-spacing));
@@ -55,13 +55,13 @@
     white-space: nowrap;
   }
 
-  @descendent duration {
+  &-duration {
     height: 100%;
     float: left;
     width: var(--media-list-duration-width);
   }
 
-  @descendent actions {
+  &-actions {
     height: 100%;
     position: absolute;
     right: 0;

--- a/src/components/MediaList/index.css
+++ b/src/components/MediaList/index.css
@@ -3,6 +3,6 @@
 @import "./MediaLoadingIndicator.css";
 @import "./Row.css";
 
-@component MediaList {
+.MediaList {
   overflow-y: auto;
 }

--- a/src/components/Overlay/Header/Close.css
+++ b/src/components/Overlay/Header/Close.css
@@ -1,13 +1,13 @@
 @import "../../../vars.css";
 
-@component OverlayHeaderClose {
+.OverlayHeaderClose {
   cursor: pointer;
   text-align: center;
   width: var(--overlay-header-close-size);
   height: var(--overlay-header-close-size);
   padding: 12px;
 
-  @descendent icon {
+  &-icon {
     font-size: 32px;
     line-height: var(--overlay-header-close-size);
   }

--- a/src/components/Overlay/Header/index.css
+++ b/src/components/Overlay/Header/index.css
@@ -1,11 +1,11 @@
 @import "../../../vars.css";
 @import "./Close.css";
 
-@component OverlayHeader {
+.OverlayHeader {
   background: var(--background-color);
   height: var(--header-height);
 
-  @descendent title {
+  &-title {
     float: left;
     height: 100%;
     padding-top: 17px;
@@ -19,7 +19,7 @@
     }
   }
 
-  @descendent content {
+  &-content {
     float: left;
     height: 100%;
     width: calc(100% - 33% - var(--overlay-header-close-size));
@@ -28,7 +28,7 @@
     }
   }
 
-  @descendent close {
+  &-close {
     float: left;
   }
 }

--- a/src/components/Overlay/index.css
+++ b/src/components/Overlay/index.css
@@ -1,27 +1,27 @@
 @import "./Header";
 
-@component Overlay {
+.Overlay {
   position: absolute;
   height: 100%;
   width: 100%;
   z-index: 6;
 
-  @modifier from-bottom {
+  &--from-bottom {
     top: auto;
     bottom: 0;
   }
-  @modifier from-top {
+  &--from-top {
     top: 0;
     bottom: auto;
   }
 
-  @descendent body {
+  &-body {
     height: 100%;
     height: 100vh;
   }
 
   /* Animations!.. */
-  @descendent enter {
+  &-enter {
     overflow-y: hidden;
     height: 0%;
     &-active {
@@ -29,7 +29,7 @@
       height: 100%;
     }
   }
-  @descendent leave {
+  &-leave {
     overflow-y: hidden;
     height: 100%;
     &-active {

--- a/src/components/PlaylistManager/Header/SearchBar.css
+++ b/src/components/PlaylistManager/Header/SearchBar.css
@@ -1,6 +1,6 @@
 @import "../../../vars.css";
 
-@component SearchBar {
+.SearchBar {
   cursor: text;
   background: #252727;
   border: 1px solid #252727;
@@ -9,11 +9,11 @@
   height: 38px;
   margin: 8px 0;
 
-  @when focused {
+  &.is-focused {
     border-color: var(--highlight-color);
   }
 
-  @descendent icon {
+  &-icon {
     width: 80px;
     height: 100%;
     float: left;
@@ -22,13 +22,13 @@
     line-height: 38px;
   }
 
-  @descendent query {
+  &-query {
     height: 100%;
     margin-left: 80px;
     margin-right: 100px;
   }
 
-  @descendent input {
+  &-input {
     background: transparent;
     width: 100%;
     height: 100%;
@@ -42,7 +42,7 @@
     }
   }
 
-  @descendent source {
+  &-source {
     float: right;
     margin: 0 5px;
     height: 100%;

--- a/src/components/PlaylistManager/Header/SourcePicker.css
+++ b/src/components/PlaylistManager/Header/SourcePicker.css
@@ -4,21 +4,21 @@
   --source-picker-width: calc(48px + 24px);
 }
 
-@component SourcePicker {
+.SourcePicker {
   width: var(--source-picker-width);
 
-  @descendent active {
+  &-active {
     cursor: pointer;
     width: 100%;
     height: 100%;
     padding: 0;
   }
 
-  @descendent list {
+  &-list {
     width: var(--source-picker-width);
   }
 
-  @descendent item {
+  &-item {
     cursor: pointer;
     width: 100%;
     padding: 5px;

--- a/src/components/PlaylistManager/Header/SourcePickerElement.css
+++ b/src/components/PlaylistManager/Header/SourcePickerElement.css
@@ -1,19 +1,19 @@
-@component SourcePickerElement {
+.SourcePickerElement {
   width: 100%;
   height: 36px;
   background-position: center center;
   background-repeat: no-repeat;
   background-size: contain;
 
-  @modifier active {
+  &--active {
     width: 48px;
     float: left;
   }
 
-  @modifier soundcloud {
+  &--soundcloud {
     background-image: url(/assets/img/soundcloud.png);
   }
-  @modifier youtube {
+  &--youtube {
     background-image: url(/assets/img/youtube.png);
   }
 }

--- a/src/components/PlaylistManager/Import/ImportPanel.css
+++ b/src/components/PlaylistManager/Import/ImportPanel.css
@@ -1,12 +1,12 @@
-@component ImportPanel {
+.ImportPanel {
   height: 100%;
 
-  @descendent loading {
+  &-loading {
     margin: auto;
     width: 25%;
   }
 
-  @descendent body {
+  &-body {
     height: calc(100% - 54px);
   }
 }

--- a/src/components/PlaylistManager/Import/ImportPanelHeader.css
+++ b/src/components/PlaylistManager/Import/ImportPanelHeader.css
@@ -1,11 +1,11 @@
-@component ImportPanelHeader {
+.ImportPanelHeader {
   height: 54px;
   line-height: 54px;
   font-size: 14pt;
   display: flex;
   justify-content: space-between;
 
-  @descendent content {
+  &-content {
     flex-grow: 1;
     padding-left: 15px;
   }

--- a/src/components/PlaylistManager/Import/ImportSourceBlock.css
+++ b/src/components/PlaylistManager/Import/ImportSourceBlock.css
@@ -1,5 +1,5 @@
-@component ImportSourceBlock {
-  @descendent image {
+.ImportSourceBlock {
+  &-image {
     max-width: 100%;
     max-height: 50px;
     display: block;

--- a/src/components/PlaylistManager/Import/index.css
+++ b/src/components/PlaylistManager/Import/index.css
@@ -4,11 +4,11 @@
 @import "./ImportPanelHeader.css";
 @import "./ImportSourceBlock.css";
 
-@component PlaylistImport {
+.PlaylistImport {
   height: 100%;
   background: var(--background-color);
 
-  @descendent source {
+  &-source {
     padding: 16px;
     width: 50%;
   }

--- a/src/components/PlaylistManager/Menu/Row.css
+++ b/src/components/PlaylistManager/Menu/Row.css
@@ -1,18 +1,18 @@
 @import "../../../vars.css";
 
-@component PlaylistMenuRow {
+.PlaylistMenuRow {
   height: 44px;
   line-height: 44px;
   padding: 0 10px;
   cursor: pointer;
   width: 100%;
 
-  @descendent content {
+  &-content {
     display: flex;
     justify-content: space-between;
   }
 
-  @descendent active-icon {
+  &-active-icon {
     display: block;
     float: left;
     height: 44px;
@@ -20,14 +20,14 @@
     padding-top: 5px;
   }
 
-  @descendent loading {
+  &-loading {
     width: 24px;
     height: 24px;
     float: left;
     margin: 10px 7px 10px 0;
   }
 
-  @descendent title {
+  &-title {
     align-self: flex-start;
     /* dot dot dot */
     overflow: hidden;
@@ -35,20 +35,20 @@
     white-space: nowrap;
   }
 
-  @descendent count {
+  &-count {
     align-self: flex-end;
     color: var(--highlight-color);
     margin-right: 5px;
   }
 
-  @modifier create {
+  &--create {
     background-color: var(--highlight-color);
   }
 
-  @when selected {
+  &.is-selected {
     background: var(--media-list-alternate-color);
   }
-  @when droppable {
+  &.is-droppable {
     background: var(--media-list-alternate-color);
   }
 }

--- a/src/components/PlaylistManager/Menu/index.css
+++ b/src/components/PlaylistManager/Menu/index.css
@@ -1,7 +1,7 @@
 @import "../../../vars.css";
 @import "./Row.css";
 
-@component PlaylistMenu {
+.PlaylistMenu {
   background: color(var(--background-color) alpha(* 96%));
   height: 100%;
   overflow-y: auto;

--- a/src/components/PlaylistManager/Panel/Meta.css
+++ b/src/components/PlaylistManager/Panel/Meta.css
@@ -1,11 +1,11 @@
-@component PlaylistMeta {
+.PlaylistMeta {
   height: 54px;
   line-height: 54px;
   font-size: 14pt;
   display: flex;
   justify-content: space-between;
 
-  @descendent name {
+  &-name {
     flex-grow: 1;
     padding-left: 15px;
     overflow: hidden;
@@ -13,7 +13,7 @@
     white-space: nowrap;
   }
 
-  @descendent active {
+  &-active {
     display: flex;
     justify-content: center;
     align-items: center;

--- a/src/components/PlaylistManager/Panel/PlaylistFilter.css
+++ b/src/components/PlaylistManager/Panel/PlaylistFilter.css
@@ -4,10 +4,10 @@
   --playlist-filter-input-height: 36px;
 }
 
-@component PlaylistMediaFilter {
+.PlaylistMediaFilter {
   display: flex;
 
-  @descendent input {
+  &-input {
     width: 180px;
     border-radius: 2px;
     background: #252727;
@@ -24,7 +24,7 @@
       border: 1px solid var(--highlight-color);
     }
 
-    @when open {
+    &.is-open {
       display: block;
     }
   }

--- a/src/components/PlaylistManager/Panel/PlaylistItemRow.css
+++ b/src/components/PlaylistManager/Panel/PlaylistItemRow.css
@@ -1,5 +1,5 @@
-@component PlaylistItemRow {
-  @descendent drop-indicator {
+.PlaylistItemRow {
+  &-drop-indicator {
     background: white;
     height: 3px;
     width: 100%;

--- a/src/components/PlaylistManager/Panel/SearchResults.css
+++ b/src/components/PlaylistManager/Panel/SearchResults.css
@@ -1,5 +1,5 @@
-@component SearchResults {
-  @descendent query {
+.SearchResults {
+  &-query {
     height: 54px;
     line-height: 54px;
     font-size: 14pt;

--- a/src/components/PlaylistManager/Panel/index.css
+++ b/src/components/PlaylistManager/Panel/index.css
@@ -4,20 +4,20 @@
 @import "./SearchResults.css";
 @import "./PlaylistItemRow.css";
 
-@component PlaylistPanel {
+.PlaylistPanel {
   background: color(var(--background-color) alpha(* 96%));
   height: 100%;
 
-  @descendent loading {
+  &-loading {
     margin: auto;
     width: 25%;
   }
 
-  @descendent media {
+  &-media {
     height: calc(100% - 54px);
   }
 
-  @modifier empty {
+  &--empty {
     padding: 16px;
   }
 }

--- a/src/components/PlaylistManager/index.css
+++ b/src/components/PlaylistManager/index.css
@@ -3,10 +3,10 @@
 @import "./Menu";
 @import "./Panel";
 
-@component PlaylistManager {
+.PlaylistManager {
   z-index: 10;
 
-  @descendent menu {
+  &-menu {
     width: 33%; /* 25% of total screen width */
     float: left;
 
@@ -15,7 +15,7 @@
       width: 300px;
     }
   }
-  @descendent panel {
+  &-panel {
     position: absolute;
     left: 33%;
     right: 0;

--- a/src/components/ReCaptcha/index.css
+++ b/src/components/ReCaptcha/index.css
@@ -2,8 +2,8 @@
   --recaptcha-iframe-height: 78px;
 }
 
-@component ReCaptcha {
-  @descendent spinner {
+.ReCaptcha {
+  &-spinner {
     width: var(--recaptcha-iframe-height);
     height: var(--recaptcha-iframe-height);
     margin: auto;

--- a/src/components/RoomHistory/Row.css
+++ b/src/components/RoomHistory/Row.css
@@ -14,7 +14,7 @@
   );
 }
 
-@component HistoryRow {
+.HistoryRow {
   height: 54px;
   line-height: 54px;
   position: relative;
@@ -24,11 +24,11 @@
     background: var(--media-list-alternate-color);
   }
 
-  @when selected {
+  &.is-selected {
     background: color(var(--highlight-color) alpha(* 70%));
   }
 
-  @descendent thumb {
+  &-thumb {
     height: 100%;
     width: 55px;
     margin: 0 15px;
@@ -36,12 +36,12 @@
     float: left;
   }
 
-  @descendent image {
+  &-image {
     max-width: 100%;
     max-height: 100%;
   }
 
-  @descendent song {
+  &-song {
     font-size: 1em;
     height: 100%;
     float: left;
@@ -52,13 +52,13 @@
     white-space: nowrap;
   }
 
-  @descendent votes {
+  &-votes {
     height: 100%;
     float: left;
     width: var(--history-list-votes-width);
   }
 
-  @descendent user {
+  &-user {
     height: 100%;
     float: left;
     width: var(--history-list-user-width);
@@ -68,7 +68,7 @@
     white-space: nowrap;
   }
 
-  @descendent time {
+  &-time {
     height: 100%;
     float: left;
     text-align: right;
@@ -77,7 +77,7 @@
     width: var(--history-list-time-width);
   }
 
-  @descendent actions {
+  &-actions {
     height: 100%;
     position: absolute;
     right: 0;

--- a/src/components/RoomUserList/GuestsRow.css
+++ b/src/components/RoomUserList/GuestsRow.css
@@ -1,8 +1,6 @@
-@component UserRow {
-  @modifier guests {
-    padding-left: 44px;
-    font-style: italic;
-    color: #aaaaaa;
-    background: transparent;
-  }
+.UserRow--guests {
+  padding-left: 44px;
+  font-style: italic;
+  color: #aaaaaa;
+  background: transparent;
 }

--- a/src/components/RoomUserList/Row.css
+++ b/src/components/RoomUserList/Row.css
@@ -1,5 +1,5 @@
-@component UserRow {
-  @descendent votes {
+.UserRow {
+  &-votes {
     float: right;
     display: flex;
     align-items: center;
@@ -7,7 +7,7 @@
     margin-right: 4px;
   }
 
-  @descendent voteIcon {
+  &-voteIcon {
     margin: 0 4px;
   }
 }

--- a/src/components/SettingsManager/Profile.css
+++ b/src/components/SettingsManager/Profile.css
@@ -1,9 +1,9 @@
-@component SettingsPanelProfile {
-  @descendent username {
+.SettingsPanelProfile {
+  &-username {
     font-size: 120%;
     font-weight: normal;
   }
-  @descendent avatar {
+  &-avatar {
     width: 120px;
     height: 120px;
   }

--- a/src/components/SettingsManager/SettingsPanel.css
+++ b/src/components/SettingsManager/SettingsPanel.css
@@ -1,32 +1,32 @@
 @import "../../vars.css";
 
-@component SettingsPanel {
+.SettingsPanel {
   padding: 20px 50px;
 
-  @descendent divider {
+  &-divider {
     height: 1px;
     border: none;
     background: var(--muted-text-color);
     margin: 20px 0;
   }
 
-  @descendent header {
+  &-header {
     margin: 0 0 20px 0;
     font-weight: 400;
   }
 
-  @descendent toggle {
+  &-toggle {
     margin: 0 0 20px 0;
   }
 
-  @descendent column {
+  &-column {
     width: 50%;
     float: left;
 
-    @modifier left {
+    &--left {
       padding-right: 50px;
     }
-    @modifier right {
+    &--right {
       padding-left: 50px;
     }
   }

--- a/src/components/SettingsManager/index.css
+++ b/src/components/SettingsManager/index.css
@@ -2,10 +2,10 @@
 @import "./Profile.css";
 @import "./SettingsPanel.css";
 
-@component SettingsManager {
+.SettingsManager {
   z-index: 10;
 
-  @descendent body {
+  &-body {
     overflow-y: scroll;
     background: color(var(--background-color) alpha(* 96%));
   }

--- a/src/components/SidePanels/index.css
+++ b/src/components/SidePanels/index.css
@@ -1,7 +1,7 @@
 @import "../../vars.css";
 
-@component SidePanel {
-  @descendent tab {
+.SidePanel {
+  &-tab {
     /* material-ui needs box-sizing: content-box on an element that is not
      * inline-styleable :( */
     > div {
@@ -11,14 +11,14 @@
       padding: 0 !important;
     }
 
-    @descendent guests {
+    &-guests {
       margin-left: 5px;
       font-size: 80%;
       color: #777;
     }
   }
 
-  @descendent panel {
+  &-panel {
     position: absolute;
     top: var(--header-height);
     bottom: 0;
@@ -28,7 +28,7 @@
     visibility: hidden;
     opacity: 0;
 
-    @when visible {
+    &.is-visible {
       visibility: visible;
       opacity: 1;
     }

--- a/src/components/SongTitle/index.css
+++ b/src/components/SongTitle/index.css
@@ -1,16 +1,16 @@
 @import "../../vars.css";
 
-@component SongTitle {
+.SongTitle {
   color: var(--text-color);
 
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 
-  @modifier large {
+  &--large {
     font-size: 14pt;
   }
-  @modifier mediaRow {
+  &--mediaRow {
     font-size: 1em;
   }
 }

--- a/src/components/UserCard/index.css
+++ b/src/components/UserCard/index.css
@@ -1,8 +1,8 @@
-@component UserCard {
+.UserCard {
   position: absolute;
   transform: translateX(-100%);
 
-  @descendent avatar {
+  &-avatar {
     width: 40px;
     height: 40px;
     margin-right: 16px;

--- a/src/components/UserList/UserRow.css
+++ b/src/components/UserList/UserRow.css
@@ -1,4 +1,4 @@
-@component UserRow {
+.UserRow {
   height: 40px;
   width: 100%;
   line-height: 30px;
@@ -6,11 +6,11 @@
   display: block;
   text-decoration: none;
 
-  @modifier cardable {
+  &--cardable {
     cursor: pointer;
   }
 
-  @descendent avatar {
+  &-avatar {
     float: left;
     margin: 3px 10px;
   }

--- a/src/components/UserList/index.css
+++ b/src/components/UserList/index.css
@@ -1,13 +1,13 @@
 @import "./UserRow.css";
 
-@component UserList {
+.UserList {
   width: 100%;
   height: 100%;
   overflow-y: scroll;
 
-  @descendent row {
+  &-row {
     background: var(--user-list-color);
-    @modifier alternate {
+    &--alternate {
       background: var(--user-list-alternate-color);
     }
   }

--- a/src/components/Video/VideoBackdrop.css
+++ b/src/components/Video/VideoBackdrop.css
@@ -1,4 +1,4 @@
-@component VideoBackdrop {
+.VideoBackdrop {
   position: absolute;
   z-index: 3;
   /* sorta hacky center positioning */
@@ -8,7 +8,7 @@
   min-width: 100%;
   min-height: 100%;
 
-  @modifier blurry {
+  &--blurry {
     filter: blur(1em);
   }
 }

--- a/src/components/Video/index.css
+++ b/src/components/Video/index.css
@@ -1,6 +1,6 @@
 @import "./VideoBackdrop.css";
 
-@component Video {
+.Video {
   position: relative;
   width: 100%;
   height: 100%;

--- a/src/components/WaitList/ModRow.css
+++ b/src/components/WaitList/ModRow.css
@@ -1,9 +1,9 @@
-@component WaitlistRow {
-  @modifier moderate {
+.WaitlistRow {
+  &--moderate {
     display: flex;
   }
 
-  @descendent card {
+  &-card {
     flex-grow: 2;
     cursor: pointer;
     white-space: nowrap;
@@ -11,25 +11,25 @@
     text-overflow: ellipsis;
   }
 
-  @descendent tools {
+  &-tools {
     float: right;
     height: 100%;
     padding: 5px;
     white-space: nowrap;
   }
 
-  /* TODO use `@descendent handle, remove` here when supported by postcss-bem */
-  @descendent tool {
+  /* TODO use `&-handle, &-remove` here? */
+  &-tool {
     display: inline-flex;
     align-items: center;
     height: 100%;
     padding: 0 4px;
   }
 
-  @descendent handle {
+  &-handle {
     cursor: move;
   }
-  @descendent remove {
+  &-remove {
     cursor: pointer;
   }
 }

--- a/src/components/WaitList/SimpleRow.css
+++ b/src/components/WaitList/SimpleRow.css
@@ -1,11 +1,11 @@
-@component WaitlistRow {
-  @descendent position {
+.WaitlistRow {
+  &-position {
     float: left;
     text-align: center;
     padding: 0 0 0 7px;
   }
 
-  @descendent drop-indicator {
+  &-drop-indicator {
     background: white;
     height: 3px;
     width: 100%;

--- a/src/containers/DragLayer.css
+++ b/src/containers/DragLayer.css
@@ -1,4 +1,4 @@
-@component DragLayerContainer {
+.DragLayerContainer {
   position: fixed;
   pointer-events: none;
   z-index: 100;

--- a/src/sources/soundcloud/Player.css
+++ b/src/sources/soundcloud/Player.css
@@ -4,38 +4,36 @@
   --sc-margins: 20px;
 }
 
-@component-namespace src-soundcloud {
-  @component Player {
-    width: 400px;
-    margin: auto;
-    height: 300px;
-    background: var(--background-color);
+.src-soundcloud-Player {
+  width: 400px;
+  margin: auto;
+  height: 300px;
+  background: var(--background-color);
 
-    @descendent meta {
-      background: color(var(--background-color) alpha(* 20%));
-      position: relative;
-      padding: var(--sc-margins);
-      z-index: 3;
-    }
+  &-meta {
+    background: color(var(--background-color) alpha(* 20%));
+    position: relative;
+    padding: var(--sc-margins);
+    z-index: 3;
+  }
 
-    @descendent info {
-      margin-bottom: var(--sc-margins);
-    }
+  &-info {
+    margin-bottom: var(--sc-margins);
+  }
 
-    @descendent art {
-      display: block;
-      width: 100px;
-      height: 100px;
-      margin-right: var(--sc-margins);
-      float: left;
-    }
+  &-art {
+    display: block;
+    width: 100px;
+    height: 100px;
+    margin-right: var(--sc-margins);
+    float: left;
+  }
 
-    @descendent permalink {
-      display: block;
-      font: 14pt;
-      color: var(--text-color);
-      text-align: right;
-      text-decoration: none;
-    }
+  &-permalink {
+    display: block;
+    font: 14pt;
+    color: var(--text-color);
+    text-align: right;
+    text-decoration: none;
   }
 }

--- a/src/sources/soundcloud/SongInfo.css
+++ b/src/sources/soundcloud/SongInfo.css
@@ -1,19 +1,17 @@
 @import "../../vars.css";
 
-@component-namespace src-soundcloud {
-  @component SongInfo {
-    @descendent link {
-      font: 14pt;
-      color: var(--text-color);
-      display: block;
-      height: 25px;
-      @modifier track {
-        font-weight: bold;
-      }
+.src-soundcloud-SongInfo {
+  &-link {
+    font: 14pt;
+    color: var(--text-color);
+    display: block;
+    height: 25px;
+    &--track {
+      font-weight: bold;
+    }
 
-      &:visited {
-        color: var(--text-color);
-      }
+    &:visited {
+      color: var(--text-color);
     }
   }
 }

--- a/src/sources/youtube/Player.css
+++ b/src/sources/youtube/Player.css
@@ -1,20 +1,12 @@
-@component-namespace src-youtube {
-  @component Player {
-    width: 100%;
-    height: 100%;
-    position: relative;
-    z-index: 3;
+.src-youtube-Player {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  z-index: 3;
 
-    @modifier small {
-      margin: auto;
-      width: 640px;
-      height: 360px;
-    }
-
-    @modifier preview {
-      margin: auto;
-      width: 640px;
-      height: 360px;
-    }
+  &--small, &--preview {
+    margin: auto;
+    width: 640px;
+    height: 360px;
   }
 }

--- a/src/sources/youtube/PlaylistPanel.css
+++ b/src/sources/youtube/PlaylistPanel.css
@@ -1,11 +1,9 @@
-@component-namespace src-youtube {
-  @component PlaylistPanel {
-    @descendent header {
-      display: flex;
-    }
+.src-youtube-PlaylistPanel {
+  &-header {
+    display: flex;
+  }
 
-    @descendent name {
-      flex-grow: 1;
-    }
+  &-name {
+    flex-grow: 1;
   }
 }

--- a/src/sources/youtube/PlaylistRow.css
+++ b/src/sources/youtube/PlaylistRow.css
@@ -4,34 +4,32 @@
   --yt-import-button-width: 54px;
 }
 
-@component-namespace src-youtube {
-  @component PlaylistRow {
-    @descendent info {
-      height: 100%;
-      line-height: 1.4;
-      float: left;
-      width: calc(100% - var(--media-list-thumb-width) - var(--media-list-spacing) - var(--yt-import-button-width));
-      margin-right: var(--media-list-spacing);
-    }
+.src-youtube-PlaylistRow {
+  &-info {
+    height: 100%;
+    line-height: 1.4;
+    float: left;
+    width: calc(100% - var(--media-list-thumb-width) - var(--media-list-spacing) - var(--yt-import-button-width));
+    margin-right: var(--media-list-spacing);
+  }
 
-    @descendent name {
-      margin: 5px 0 3px 0;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
+  &-name {
+    margin: 5px 0 3px 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 
-    @descendent size {
-      font-size: 85%;
-      color: #777;
-      float: left;
-    }
+  &-size {
+    font-size: 85%;
+    color: #777;
+    float: left;
+  }
 
-    @descendent import {
-      height: 100%;
-      line-height: 1; /* .MediaListRow sets this to 54px but we don't need that */
-      float: left;
-      width: var(--yt-import-button-width);
-    }
+  &-import {
+    height: 100%;
+    line-height: 1; /* .MediaListRow sets this to 54px but we don't need that */
+    float: left;
+    width: var(--yt-import-button-width);
   }
 }


### PR DESCRIPTION
The repository for postcss-bem disappeared from github so I assume
the project is abandoned. This patch replaces all uses of the plugin
with cssnext nesting.

We could look into adding postcss-bem-linter later on to enforce
BEM conventions that way:

https://github.com/postcss/postcss-bem-linter