### PR TITLE
change module entry point

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/middleware');

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "author": "René Kooi <rene@kooi.me>",
   "license": "MIT",
   "repository": "u-wave/u-wave-web",
-  "main": "lib/middleware.js",
+  "main": "lib/Uwave.js",
+  "jsnext:main": "es/Uwave.js",
+  "module": "es/Uwave.js",
   "engines": {
     "node": ">= 4",
     "npm": ">= 3"


### PR DESCRIPTION
Changes the entry point so the client can be bundled with an ES
module bundler. `import Uwave from 'u-wave-web'` now imports the
main client class, while
`import createWebClient from 'u-wave-web/middleware'` imports the
server-side client-serving (lol) middleware. Previously, the
client class would have to be accessed through `u-wave-web/lib/Uwave`.