### PR TITLE
tooltips: add repositioning tooltip wrapper, fix overflow bug in emoji tooltips

### DIFF
--- a/src/components/Chat/Markup/Emoji.js
+++ b/src/components/Chat/Markup/Emoji.js
@@ -1,33 +1,31 @@
 import * as React from 'react';
+import compose from 'recompose/compose';
 import withState from 'recompose/withState';
-import Tooltip from 'material-ui/internal/Tooltip';
-import transformStyle from '../../../utils/transformStyle';
-
-const MUI_TOOLTIP_HEIGHT = 22;
+import withProps from 'recompose/withProps';
+import Tooltip from '../../Tooltip';
 
 const tooltipStyle = {
-  left: '50%',
-  textIndent: 'initial',
-  // Put tooltips directly above the emoji. material-ui has them slightly
-  // overlaying the emoji by default, which is a bit ugly since emoji are very
-  // small to begin with.
-  top: -MUI_TOOLTIP_HEIGHT,
-  ...transformStyle('translateX(-50%)')
+  textIndent: 'initial'
 };
 
-const enhance = withState('showTooltip', 'setShowTooltip', false);
+const enhance = compose(
+  withState('showTooltip', 'setShowTooltip', false),
+  withProps(props => ({
+    onShowTooltip() { props.setShowTooltip(true); },
+    onHideTooltip() { props.setShowTooltip(false); }
+  }))
+);
 
 const Emoji = ({
   name,
   image,
   showTooltip,
-  setShowTooltip,
-  ...props
+  onShowTooltip,
+  onHideTooltip
 }) => (
   <span
-    {...props}
-    onMouseEnter={() => setShowTooltip(true)}
-    onMouseLeave={() => setShowTooltip(false)}
+    onMouseEnter={onShowTooltip}
+    onMouseLeave={onHideTooltip}
     className="Emoji"
     style={{ backgroundImage: `url(/assets/emoji/${image})` }}
     data-emoji={name}
@@ -45,7 +43,8 @@ const Emoji = ({
 
 Emoji.propTypes = {
   showTooltip: React.PropTypes.bool.isRequired,
-  setShowTooltip: React.PropTypes.func.isRequired,
+  onShowTooltip: React.PropTypes.func.isRequired,
+  onHideTooltip: React.PropTypes.func.isRequired,
   name: React.PropTypes.string.isRequired,
   image: React.PropTypes.string.isRequired
 };

--- a/src/components/Chat/index.css
+++ b/src/components/Chat/index.css
@@ -8,6 +8,12 @@
   height: 100%;
   overflow-y: scroll;
   font-size: 10pt;
+  /* Fix for tooltips close to the edge. The tooltips themselves work fine,
+   * but the element that's used to position the tooltips correctly can overflow
+   * by a few pixels.
+   * TODO fix that^ in src/components/Tooltip. Should resize(?) the positioning
+   * wrapper if it's close to the edge of the screen. */
+  overflow-x: hidden;
 }
 
 .ChatContainer {

--- a/src/components/FooterBar/Responses/Button.js
+++ b/src/components/FooterBar/Responses/Button.js
@@ -1,13 +1,6 @@
 import cx from 'classnames';
 import * as React from 'react';
-import Tooltip from 'material-ui/internal/Tooltip';
-import transformStyle from '../../../utils/transformStyle';
-
-const tooltipStyle = {
-  top: -36,
-  left: '50%',
-  ...transformStyle('translateX(-50%)')
-};
+import Tooltip from '../../Tooltip';
 
 export default class Button extends React.Component {
   static propTypes = {
@@ -54,7 +47,7 @@ export default class Button extends React.Component {
             verticalPosition="top"
             horizontalPosition="center"
             show={this.state.showTooltip}
-            style={tooltipStyle}
+            style={{ top: -22 }}
           />
           <div className="ResponseButton-icon">{children}</div>
           <span className="ResponseButton-count">{count}</span>

--- a/src/components/Tooltip/index.css
+++ b/src/components/Tooltip/index.css
@@ -1,0 +1,13 @@
+/* material-ui tooltips always uses a 48px reference frame, for some reason.
+ * These styles fake a 48px element for material-ui. */
+
+:root {
+  --mui-tooltip-reference-width: 48px;
+}
+
+.u-TooltipFix {
+  position: absolute;
+  width: var(--mui-tooltip-reference-width);
+  left: calc(50% - (var(--mui-tooltip-reference-width) / 2));
+  top: 0;
+}

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -1,0 +1,136 @@
+import * as React from 'react';
+import { findDOMNode } from 'react-dom';
+import MuiTooltip from 'material-ui/internal/Tooltip';
+
+/**
+ * Wrapper for material-ui Tooltips with better center-alignment on things that
+ * are not IconButtons, and auto-realignment when close to the window border in
+ * order to prevent overflow.
+ */
+
+class Tooltip extends React.Component {
+  static propTypes = {
+    style: React.PropTypes.object,
+    show: React.PropTypes.bool,
+    /**
+     * Desired horizontal position of the tooltip.
+     */
+    horizontalPosition: React.PropTypes.oneOf([ 'left', 'center', 'right' ])
+  };
+
+  state = {
+    /**
+     * Overflow-prevented horizontal position of the tooltip.
+     */
+    horizontalPosition: this.props.horizontalPosition,
+    /**
+     * Whether the tooltip element is currently in the DOM.
+     */
+    insert: this.props.show,
+    /**
+     * Whether the tooltip element is currently visible.
+     */
+    show: this.props.show
+  };
+
+  componentWillReceiveProps(nextProps) {
+    if (!this.props.show && nextProps.show) {
+      this.show();
+    }
+
+    if (this.props.show && !nextProps.show) {
+      this.hide();
+    }
+  }
+
+  /**
+   * Clear the fade-out animation timeout.
+   */
+  clearTimeout() {
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+      this.timeout = null;
+    }
+  }
+
+  /**
+   * Show the tooltip.
+   */
+  show() {
+    this.clearTimeout();
+    this.setState({ insert: true }, () => {
+      this.position();
+      this.setState({ show: true });
+    });
+  }
+
+  /**
+   * Hide the tooltip.
+   */
+  hide() {
+    if (this.timeout) {
+      return;
+    }
+
+    // First hide it,
+    this.setState({ show: false }, () => {
+      // Then wait for the fade-out animation,
+      this.timeout = setTimeout(() => {
+        // And finally remove the element.
+        this.setState({
+          insert: false,
+          // The horizontal position is reset here, so that the next time the
+          // tooltip is shown, the positioning checks run on the original
+          // position. Otherwise, it might getBoundingClientRect() from an
+          // already-repositioned element, discover that it is fits, and go back
+          // to the initial state even if it did not fit.
+          horizontalPosition: this.props.horizontalPosition
+        });
+      }, 450);
+    });
+  }
+
+  /**
+   * Reposition the tooltip if it is close to the window border.
+   */
+  position() {
+    if (!this.tooltip) {
+      return;
+    }
+
+    // eslint-disable-next-line react/no-find-dom-node
+    const rect = findDOMNode(this.tooltip).getBoundingClientRect();
+    this.setState({
+      horizontalPosition: rect.right > window.innerWidth ? 'left' :
+        this.props.horizontalPosition
+    });
+  }
+
+  refTooltip = (tooltip) => {
+    this.tooltip = tooltip;
+  };
+
+  render() {
+    const { insert, show } = this.state;
+    return (
+      <div className="u-TooltipFix">
+        {insert && (
+          <MuiTooltip
+            ref={this.refTooltip}
+            {...this.props}
+            show={show}
+            horizontalPosition={this.state.horizontalPosition}
+            style={{
+              // "pointer-events: none" avoids interference with tooltips  that
+              // are very close to or overlay other elements that have tooltips.
+              pointerEvents: 'none',
+              ...this.props.style
+            }}
+          />
+        )}
+      </div>
+    );
+  }
+}
+
+export default Tooltip;

--- a/src/components/index.css
+++ b/src/components/index.css
@@ -16,6 +16,7 @@
 @import "./SettingsManager";
 @import "./SidePanels";
 @import "./SongTitle";
+@import "./Tooltip";
 @import "./UserCard";
 @import "./Video";
 @import "./UserList";


### PR DESCRIPTION
Moves the somewhat hacky manual tooltip positioning from emoji and vote buttons into a separate component. The new component also repositions the tooltip if it is very close to the window border. I.e., if a `center`-aligned tooltips appears near the right edge of the screen, it'll become a `left`-aligned one instead.

![Screencap](http://i.imgur.com/0oFPQig.gif)