### PR TITLE
build: inject config to html in watch mode

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import * as fs from 'fs';
+import * as defaultFs from 'fs';
 import trumpet from 'trumpet';
 import router from 'router';
 import serveStatic from 'serve-static';
@@ -25,6 +25,7 @@ export default function uwaveWebClient(uw, options = {}) {
     pluginsScriptFile = null,
     pluginsStyle = null,
     pluginsStyleFile = null,
+    fs = defaultFs, // Should only be used by the dev server.
     ...clientOptions
   } = options;
 

--- a/tasks/serve.js
+++ b/tasks/serve.js
@@ -1,3 +1,5 @@
+'use strict'; // eslint-disable-line strict, lines-around-directive
+
 require('loud-rejection/register');
 const gulp = require('gulp');
 const env = require('gulp-util').env;

--- a/tasks/serve.js
+++ b/tasks/serve.js
@@ -55,6 +55,9 @@ gulp.task('serve', () => {
     }))
     .use('/assets/emoji/', emojione.middleware());
 
+  let fs = require('fs');
+  let publicPath;
+
   if (watch) {
     wpConfig.entry.app = [
       'react-hot-loader/patch',
@@ -64,19 +67,30 @@ gulp.task('serve', () => {
       new webpack.HotModuleReplacementPlugin()
     );
     const compiler = webpack(wpConfig);
-    app.use(webpackDevMiddleware(compiler, {
+    const dev = webpackDevMiddleware(compiler, {
       noInfo: true,
-      publicPath: '/'
-    }));
+      publicPath: '/',
+      serverSideRender: true,
+      // Specify a nonexistent file so webpack-dev-middleware doesn't attempt to
+      // serve it. It'll be served by the u-wave-web middleware instead below.
+      index: '-dummy-'
+    });
+    app.use(dev);
     app.use(webpackHotMiddleware(compiler, {
       log: require('gulp-util').log,
       path: '/__webpack_hmr'
     }));
+
+    // Point u-wave-web middleware to the virtual webpack filesystem.
+    fs = dev.fileSystem;
+    publicPath = '/';
   }
 
   app.use(createWebClient(uw, {
     apiUrl,
-    emoji: emojione.emoji
+    emoji: emojione.emoji,
+    publicPath,
+    fs
   }));
 
   uw.on('stopped', () => {


### PR DESCRIPTION
Pulls a trick on webpack-dev-middleware to allow our middleware to serve the HTML file instead. Fixes emoji in dev mode.