### PR TITLE
build: only optimize images again when they have changed

### DIFF
--- a/tasks/assets.js
+++ b/tasks/assets.js
@@ -1,6 +1,7 @@
 const gulp = require('gulp');
 const gulpif = require('gulp-if');
 const env = require('gulp-util').env;
+const newer = require('gulp-newer');
 const optimizeImage = require('gulp-image');
 const seq = require('run-sequence');
 
@@ -11,6 +12,7 @@ gulp.task('assets:favicon', () =>
 
 gulp.task('assets:copy', () =>
   gulp.src([ 'assets/**/*', '!assets/screenshot.png' ])
+    .pipe(newer('public/assets/'))
     .pipe(gulpif(env.minify, optimizeImage()))
     .pipe(gulp.dest('public/assets/'))
 );


### PR DESCRIPTION
Takes a few seconds to optimize pngs, so this cuts 10+ seconds off of most builds.