### PR TITLE
build: add react-inline-elements transform in production build.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -19,6 +19,7 @@
     "production": {
       "plugins": [
         "transform-react-constant-elements",
+        "transform-react-inline-elements",
         ["transform-react-remove-prop-types", { "mode": "wrap" }]
       ]
     }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-export-extensions": "^6.4.0",
     "babel-plugin-transform-react-constant-elements": "^6.4.0",
+    "babel-plugin-transform-react-inline-elements": "^6.8.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.2.11",
     "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015": "^6.3.13",


### PR DESCRIPTION
Cuts a few bytes off the prod build and is faster. inline-elements checks the syntax and switches to a faster method instead of react's own `createElement` when possible (which is almost always). Probably won't make a big difference, but why not ¯\_(ツ)_/¯