### PR TITLE
Split up PlaylistManager into smaller containers, fixes #349

### DIFF
--- a/src/components/PlaylistManager/Header/SearchBar.js
+++ b/src/components/PlaylistManager/Header/SearchBar.js
@@ -4,8 +4,9 @@ import { translate } from 'react-i18next';
 import SearchIcon from 'material-ui/svg-icons/action/search';
 import SourcePicker from './SourcePicker';
 
-@translate()
-export default class SearchBar extends React.Component {
+const enhance = translate();
+
+class SearchBar extends React.Component {
   static propTypes = {
     className: React.PropTypes.string,
     source: React.PropTypes.string,
@@ -62,3 +63,5 @@ export default class SearchBar extends React.Component {
     );
   }
 }
+
+export default enhance(SearchBar);

--- a/src/components/PlaylistManager/Header/index.js
+++ b/src/components/PlaylistManager/Header/index.js
@@ -2,37 +2,28 @@ import cx from 'classnames';
 import * as React from 'react';
 import { translate } from 'react-i18next';
 import OverlayHeader from '../../Overlay/Header';
-import SearchBar from './SearchBar';
+import SearchBar from '../../../containers/MediaSearchBar';
+
+const enhance = translate();
 
 const PlaylistManagerHeader = ({
   t,
   className,
-  searchSource,
-  onCloseOverlay,
-  onSearchSubmit,
-  onSearchSourceChange
+  onCloseOverlay
 }) => (
   <OverlayHeader
     className={cx('PlaylistHeader', className)}
     title={t('playlists.title')}
     onCloseOverlay={onCloseOverlay}
   >
-    <SearchBar
-      className="PlaylistHeader-search"
-      source={searchSource}
-      onSubmit={onSearchSubmit}
-      onSourceChange={onSearchSourceChange}
-    />
+    <SearchBar className="PlaylistHeader-search" />
   </OverlayHeader>
 );
 
 PlaylistManagerHeader.propTypes = {
   className: React.PropTypes.string,
-  searchSource: React.PropTypes.string.isRequired,
   t: React.PropTypes.func.isRequired,
-  onCloseOverlay: React.PropTypes.func.isRequired,
-  onSearchSubmit: React.PropTypes.func.isRequired,
-  onSearchSourceChange: React.PropTypes.func.isRequired
+  onCloseOverlay: React.PropTypes.func.isRequired
 };
 
-export default translate()(PlaylistManagerHeader);
+export default enhance(PlaylistManagerHeader);

--- a/src/components/PlaylistManager/Import/index.css
+++ b/src/components/PlaylistManager/Import/index.css
@@ -7,6 +7,7 @@
 .PlaylistImport {
   height: 100%;
   background: var(--background-color);
+  overflow: auto;
 
   &-source {
     padding: 16px;

--- a/src/components/PlaylistManager/Menu/index.js
+++ b/src/components/PlaylistManager/Menu/index.js
@@ -45,7 +45,7 @@ const Menu = ({
           className="PlaylistMenu-row"
           playlist={pl}
           selected={isSelectingPlaylist && selected._id === pl._id}
-          onClick={() => onSelectPlaylist(pl)}
+          onClick={() => onSelectPlaylist(pl._id)}
           onAddToPlaylist={onAddToPlaylist}
         />
       ))}

--- a/src/components/PlaylistManager/Menu/index.js
+++ b/src/components/PlaylistManager/Menu/index.js
@@ -60,7 +60,7 @@ const Menu = ({
 Menu.propTypes = {
   className: React.PropTypes.string,
   playlists: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
-  selected: React.PropTypes.object.isRequired,
+  selected: React.PropTypes.object,
   showSearchResults: React.PropTypes.bool.isRequired,
   showImportPanel: React.PropTypes.bool.isRequired,
   searchQuery: React.PropTypes.string,

--- a/src/components/PlaylistManager/Panel/index.css
+++ b/src/components/PlaylistManager/Panel/index.css
@@ -7,6 +7,7 @@
 .PlaylistPanel {
   background: color(var(--background-color) alpha(* 96%));
   height: 100%;
+  width: 100%;
 
   &-loading {
     margin: auto;

--- a/src/components/PlaylistManager/index.css
+++ b/src/components/PlaylistManager/index.css
@@ -19,6 +19,7 @@
     position: absolute;
     left: 33%;
     right: 0;
+    height: 100%;
 
     /* menu would be larger than 300px */
     @media (min-width: 1200px) {

--- a/src/components/PlaylistManager/index.js
+++ b/src/components/PlaylistManager/index.js
@@ -4,7 +4,7 @@ import React, { Component, PropTypes } from 'react';
 import { IDLE, LOADING, LOADED } from '../../constants/LoadingStates';
 import Overlay from '../Overlay';
 
-import PlaylistMenu from './Menu';
+import PlaylistMenu from '../../containers/PlaylistManagerMenu';
 import PlaylistHeader from './Header';
 import PlaylistPanel from './Panel';
 import PlaylistPanelEmpty from './Panel/Empty';
@@ -15,8 +15,6 @@ export default class PlaylistManager extends Component {
   static propTypes = {
     className: PropTypes.string,
 
-    playlists: PropTypes.array,
-    activePlaylist: PropTypes.object,
     selectedPlaylist: PropTypes.object,
     selectedMedia: PropTypes.array,
     currentFilter: PropTypes.string,
@@ -30,19 +28,14 @@ export default class PlaylistManager extends Component {
     searchLoadingState: PropTypes.oneOf([ IDLE, LOADING, LOADED ]),
 
     onCloseOverlay: PropTypes.func,
-    onCreatePlaylist: PropTypes.func,
     onRenamePlaylist: PropTypes.func,
     onDeletePlaylist: PropTypes.func,
     onNotDeletable: PropTypes.func,
     onShufflePlaylist: PropTypes.func,
     onActivatePlaylist: PropTypes.func,
     onFilterPlaylistItems: PropTypes.func,
-    onSelectPlaylist: PropTypes.func,
-    onSelectSearchResults: PropTypes.func,
     onSearchSubmit: PropTypes.func,
     onSearchSourceChange: PropTypes.func,
-    onShowImportPanel: PropTypes.func,
-    onAddToPlaylist: PropTypes.func,
     onOpenAddMediaMenu: PropTypes.func,
     onMoveToFirst: PropTypes.func,
     onEditMedia: PropTypes.func,
@@ -104,14 +97,8 @@ export default class PlaylistManager extends Component {
     );
   };
 
-  handleSelectPlaylist = (playlist) => {
-    this.props.onSelectPlaylist(playlist._id);
-  };
-
   render() {
     const {
-      playlists,
-      activePlaylist,
       selectedPlaylist,
       selectedMedia,
       currentFilter,
@@ -125,16 +112,12 @@ export default class PlaylistManager extends Component {
       searchLoadingState,
 
       onCloseOverlay,
-      onCreatePlaylist,
       onDeletePlaylist,
       onNotDeletable,
-      onAddToPlaylist,
       onActivatePlaylist,
       onRenamePlaylist,
-      onSelectSearchResults,
       onSearchSubmit,
       onSearchSourceChange,
-      onShowImportPanel,
 
       onOpenPreviewMediaDialog,
       onOpenAddMediaMenu
@@ -204,21 +187,7 @@ export default class PlaylistManager extends Component {
         />
 
         <div className="AppRow AppRow--middle">
-          <PlaylistMenu
-            className="PlaylistManager-menu"
-            playlists={playlists}
-            active={activePlaylist}
-            selected={selectedPlaylist}
-            showSearchResults={showSearchResults}
-            showImportPanel={showImportPanel}
-            searchQuery={searchQuery}
-            searchResults={searchResults ? searchResults.length : 0}
-            onCreatePlaylist={onCreatePlaylist}
-            onAddToPlaylist={onAddToPlaylist}
-            onSelectPlaylist={this.handleSelectPlaylist}
-            onSelectSearchResults={onSelectSearchResults}
-            onShowImportPanel={onShowImportPanel}
-          />
+          <PlaylistMenu className="PlaylistManager-menu" />
 
           {panel}
         </div>

--- a/src/components/PlaylistManager/index.js
+++ b/src/components/PlaylistManager/index.js
@@ -1,15 +1,14 @@
 import cx from 'classnames';
 import * as React from 'react';
 
-import { IDLE, LOADING, LOADED } from '../../constants/LoadingStates';
 import Overlay from '../Overlay';
 
 import PlaylistMenu from '../../containers/PlaylistManagerMenu';
-import PlaylistHeader from './Header';
 import PlaylistPanel from '../../containers/PlaylistManagerPanel';
-import PlaylistPanelEmpty from './Panel/Empty';
 import PlaylistImport from '../../containers/PlaylistImportManager';
-import SearchResults from './Panel/SearchResults';
+import SearchResults from '../../containers/SearchResultsPanel';
+import PlaylistHeader from './Header';
+import PlaylistPanelEmpty from './Panel/Empty';
 
 // eslint-disable-next-line react/prefer-stateless-function
 export default class PlaylistManager extends React.Component {
@@ -22,15 +21,10 @@ export default class PlaylistManager extends React.Component {
     showImportPanel: React.PropTypes.bool.isRequired,
 
     searchSource: React.PropTypes.string,
-    searchQuery: React.PropTypes.string,
-    searchResults: React.PropTypes.array,
-    searchLoadingState: React.PropTypes.oneOf([ IDLE, LOADING, LOADED ]),
 
     onCloseOverlay: React.PropTypes.func,
     onSearchSubmit: React.PropTypes.func,
-    onSearchSourceChange: React.PropTypes.func,
-    onOpenAddMediaMenu: React.PropTypes.func,
-    onOpenPreviewMediaDialog: React.PropTypes.func
+    onSearchSourceChange: React.PropTypes.func
   };
 
   render() {
@@ -41,16 +35,10 @@ export default class PlaylistManager extends React.Component {
       showImportPanel,
 
       searchSource,
-      searchQuery,
-      searchResults,
-      searchLoadingState,
 
       onCloseOverlay,
       onSearchSubmit,
-      onSearchSourceChange,
-
-      onOpenPreviewMediaDialog,
-      onOpenAddMediaMenu
+      onSearchSourceChange
     } = this.props;
 
     let panel;
@@ -61,15 +49,7 @@ export default class PlaylistManager extends React.Component {
         </div>
       );
     } else if (showSearchResults) {
-      panel = (
-        <SearchResults
-          query={searchQuery}
-          results={searchResults}
-          loadingState={searchLoadingState}
-          onOpenPreviewMediaDialog={onOpenPreviewMediaDialog}
-          onOpenAddMediaMenu={onOpenAddMediaMenu}
-        />
-      );
+      panel = <SearchResults />;
     } else if (selectedPlaylist) {
       panel = <PlaylistPanel />;
     } else {

--- a/src/components/PlaylistManager/index.js
+++ b/src/components/PlaylistManager/index.js
@@ -6,18 +6,17 @@ import Overlay from '../Overlay';
 
 import PlaylistMenu from '../../containers/PlaylistManagerMenu';
 import PlaylistHeader from './Header';
-import PlaylistPanel from './Panel';
+import PlaylistPanel from '../../containers/PlaylistManagerPanel';
 import PlaylistPanelEmpty from './Panel/Empty';
 import PlaylistImport from '../../containers/PlaylistImportManager';
 import SearchResults from './Panel/SearchResults';
 
+// eslint-disable-next-line react/prefer-stateless-function
 export default class PlaylistManager extends Component {
   static propTypes = {
     className: PropTypes.string,
 
     selectedPlaylist: PropTypes.object,
-    selectedMedia: PropTypes.array,
-    currentFilter: PropTypes.string,
 
     showSearchResults: PropTypes.bool.isRequired,
     showImportPanel: PropTypes.bool.isRequired,
@@ -28,80 +27,15 @@ export default class PlaylistManager extends Component {
     searchLoadingState: PropTypes.oneOf([ IDLE, LOADING, LOADED ]),
 
     onCloseOverlay: PropTypes.func,
-    onRenamePlaylist: PropTypes.func,
-    onDeletePlaylist: PropTypes.func,
-    onNotDeletable: PropTypes.func,
-    onShufflePlaylist: PropTypes.func,
-    onActivatePlaylist: PropTypes.func,
-    onFilterPlaylistItems: PropTypes.func,
     onSearchSubmit: PropTypes.func,
     onSearchSourceChange: PropTypes.func,
     onOpenAddMediaMenu: PropTypes.func,
-    onMoveToFirst: PropTypes.func,
-    onEditMedia: PropTypes.func,
-    onMoveMedia: PropTypes.func,
-    onRemoveFromPlaylist: PropTypes.func,
-    onOpenPreviewMediaDialog: PropTypes.func,
-    onLoadPlaylistPage: PropTypes.func,
-    onLoadFilteredPlaylistPage: PropTypes.func
-  };
-
-  withSelected(fn) {
-    const selectedPlaylist = this.props.selectedPlaylist;
-    if (selectedPlaylist) {
-      fn(selectedPlaylist);
-    }
-  }
-
-  handleShufflePlaylist = () => {
-    this.withSelected(selectedPlaylist =>
-      this.props.onShufflePlaylist(selectedPlaylist._id)
-    );
-  };
-
-  handleMoveToFirst = (media, selection) => {
-    this.withSelected(selectedPlaylist =>
-      this.props.onMoveToFirst(selectedPlaylist._id, media, selection)
-    );
-  };
-
-  handleEditMedia = (media) => {
-    this.withSelected(selectedPlaylist =>
-      this.props.onEditMedia(selectedPlaylist._id, media)
-    );
-  };
-
-  handleMoveMedia = (media, opts) => {
-    this.withSelected(selectedPlaylist =>
-      this.props.onMoveMedia(selectedPlaylist._id, media, opts)
-    );
-  };
-
-  handleRemoveFromPlaylist = (media, selection) => {
-    this.withSelected(selectedPlaylist =>
-      this.props.onRemoveFromPlaylist(selectedPlaylist._id, media, selection)
-    );
-  };
-
-  handleLoadPlaylistPage = (page) => {
-    const loadPlaylistPage = this.props.currentFilter ?
-      this.props.onLoadFilteredPlaylistPage : this.props.onLoadPlaylistPage;
-    this.withSelected(selectedPlaylist =>
-      loadPlaylistPage(selectedPlaylist._id, page)
-    );
-  };
-
-  handleFilterPlaylistItems = (filter) => {
-    this.withSelected(selectedPlaylist =>
-      this.props.onFilterPlaylistItems(selectedPlaylist._id, filter)
-    );
+    onOpenPreviewMediaDialog: PropTypes.func
   };
 
   render() {
     const {
       selectedPlaylist,
-      selectedMedia,
-      currentFilter,
 
       showSearchResults,
       showImportPanel,
@@ -112,10 +46,6 @@ export default class PlaylistManager extends Component {
       searchLoadingState,
 
       onCloseOverlay,
-      onDeletePlaylist,
-      onNotDeletable,
-      onActivatePlaylist,
-      onRenamePlaylist,
       onSearchSubmit,
       onSearchSourceChange,
 
@@ -143,26 +73,9 @@ export default class PlaylistManager extends Component {
       );
     } else if (selectedPlaylist) {
       panel = (
-        <PlaylistPanel
-          className="PlaylistManager-panel"
-          playlist={selectedPlaylist}
-          media={selectedMedia}
-          loading={!!selectedPlaylist.loading}
-          isFiltered={!!currentFilter}
-          onShufflePlaylist={this.handleShufflePlaylist}
-          onActivatePlaylist={onActivatePlaylist}
-          onRenamePlaylist={onRenamePlaylist}
-          onDeletePlaylist={onDeletePlaylist}
-          onNotDeletable={onNotDeletable}
-          onOpenPreviewMediaDialog={onOpenPreviewMediaDialog}
-          onOpenAddMediaMenu={onOpenAddMediaMenu}
-          onMoveToFirst={this.handleMoveToFirst}
-          onMoveMedia={this.handleMoveMedia}
-          onEditMedia={this.handleEditMedia}
-          onRemoveFromPlaylist={this.handleRemoveFromPlaylist}
-          onLoadPlaylistPage={this.handleLoadPlaylistPage}
-          onFilterPlaylistItems={this.handleFilterPlaylistItems}
-        />
+        <div className="PlaylistManager-panel">
+          <PlaylistPanel />
+        </div>
       );
     } else {
       panel = <PlaylistPanelEmpty className="PlaylistManager-panel" />;

--- a/src/components/PlaylistManager/index.js
+++ b/src/components/PlaylistManager/index.js
@@ -1,5 +1,5 @@
 import cx from 'classnames';
-import React, { Component, PropTypes } from 'react';
+import * as React from 'react';
 
 import { IDLE, LOADING, LOADED } from '../../constants/LoadingStates';
 import Overlay from '../Overlay';
@@ -12,25 +12,25 @@ import PlaylistImport from '../../containers/PlaylistImportManager';
 import SearchResults from './Panel/SearchResults';
 
 // eslint-disable-next-line react/prefer-stateless-function
-export default class PlaylistManager extends Component {
+export default class PlaylistManager extends React.Component {
   static propTypes = {
-    className: PropTypes.string,
+    className: React.PropTypes.string,
 
-    selectedPlaylist: PropTypes.object,
+    selectedPlaylist: React.PropTypes.object,
 
-    showSearchResults: PropTypes.bool.isRequired,
-    showImportPanel: PropTypes.bool.isRequired,
+    showSearchResults: React.PropTypes.bool.isRequired,
+    showImportPanel: React.PropTypes.bool.isRequired,
 
-    searchSource: PropTypes.string,
-    searchQuery: PropTypes.string,
-    searchResults: PropTypes.array,
-    searchLoadingState: PropTypes.oneOf([ IDLE, LOADING, LOADED ]),
+    searchSource: React.PropTypes.string,
+    searchQuery: React.PropTypes.string,
+    searchResults: React.PropTypes.array,
+    searchLoadingState: React.PropTypes.oneOf([ IDLE, LOADING, LOADED ]),
 
-    onCloseOverlay: PropTypes.func,
-    onSearchSubmit: PropTypes.func,
-    onSearchSourceChange: PropTypes.func,
-    onOpenAddMediaMenu: PropTypes.func,
-    onOpenPreviewMediaDialog: PropTypes.func
+    onCloseOverlay: React.PropTypes.func,
+    onSearchSubmit: React.PropTypes.func,
+    onSearchSourceChange: React.PropTypes.func,
+    onOpenAddMediaMenu: React.PropTypes.func,
+    onOpenPreviewMediaDialog: React.PropTypes.func
   };
 
   render() {

--- a/src/components/PlaylistManager/index.js
+++ b/src/components/PlaylistManager/index.js
@@ -56,14 +56,13 @@ export default class PlaylistManager extends React.Component {
     let panel;
     if (showImportPanel) {
       panel = (
-        <div className="PlaylistPanel PlaylistManager-panel">
+        <div className="PlaylistPanel">
           <PlaylistImport />
         </div>
       );
     } else if (showSearchResults) {
       panel = (
         <SearchResults
-          className="PlaylistManager-panel"
           query={searchQuery}
           results={searchResults}
           loadingState={searchLoadingState}
@@ -72,13 +71,9 @@ export default class PlaylistManager extends React.Component {
         />
       );
     } else if (selectedPlaylist) {
-      panel = (
-        <div className="PlaylistManager-panel">
-          <PlaylistPanel />
-        </div>
-      );
+      panel = <PlaylistPanel />;
     } else {
-      panel = <PlaylistPanelEmpty className="PlaylistManager-panel" />;
+      panel = <PlaylistPanelEmpty />;
     }
 
     return (
@@ -102,7 +97,9 @@ export default class PlaylistManager extends React.Component {
         <div className="AppRow AppRow--middle">
           <PlaylistMenu className="PlaylistManager-menu" />
 
-          {panel}
+          <div className="PlaylistManager-panel">
+            {panel}
+          </div>
         </div>
       </Overlay>
     );

--- a/src/components/PlaylistManager/index.js
+++ b/src/components/PlaylistManager/index.js
@@ -14,17 +14,10 @@ import PlaylistPanelEmpty from './Panel/Empty';
 export default class PlaylistManager extends React.Component {
   static propTypes = {
     className: React.PropTypes.string,
-
     selectedPlaylist: React.PropTypes.object,
-
     showSearchResults: React.PropTypes.bool.isRequired,
     showImportPanel: React.PropTypes.bool.isRequired,
-
-    searchSource: React.PropTypes.string,
-
-    onCloseOverlay: React.PropTypes.func,
-    onSearchSubmit: React.PropTypes.func,
-    onSearchSourceChange: React.PropTypes.func
+    onCloseOverlay: React.PropTypes.func
   };
 
   render() {
@@ -34,11 +27,7 @@ export default class PlaylistManager extends React.Component {
       showSearchResults,
       showImportPanel,
 
-      searchSource,
-
-      onCloseOverlay,
-      onSearchSubmit,
-      onSearchSourceChange
+      onCloseOverlay
     } = this.props;
 
     let panel;
@@ -67,10 +56,6 @@ export default class PlaylistManager extends React.Component {
       >
         <PlaylistHeader
           className="PlaylistManager-header AppRow AppRow--top"
-          selectedPlaylist={selectedPlaylist}
-          searchSource={searchSource}
-          onSearchSubmit={onSearchSubmit}
-          onSearchSourceChange={onSearchSourceChange}
           onCloseOverlay={onCloseOverlay}
         />
 

--- a/src/containers/MediaSearchBar.js
+++ b/src/containers/MediaSearchBar.js
@@ -1,0 +1,21 @@
+import { createStructuredSelector } from 'reselect';
+import { connect } from 'react-redux';
+import SearchBar from '../components/PlaylistManager/Header/SearchBar';
+import {
+  search,
+  setSource
+} from '../actions/SearchActionCreators';
+import {
+  searchSourceTypeSelector
+} from '../selectors/searchSelectors';
+
+const mapStateToProps = createStructuredSelector({
+  source: searchSourceTypeSelector
+});
+
+const mapDispatchToProps = {
+  onSubmit: search,
+  onSourceChange: setSource
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(SearchBar);

--- a/src/containers/PlaylistManager.js
+++ b/src/containers/PlaylistManager.js
@@ -1,16 +1,9 @@
-import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 
-import {
-  search,
-  setSource as setSearchSource
-} from '../actions/SearchActionCreators';
-
 import { selectedPlaylistSelector } from '../selectors/playlistSelectors';
 import {
-  showSearchResultsSelector,
-  searchSourceTypeSelector
+  showSearchResultsSelector
 } from '../selectors/searchSelectors';
 import { showImportPanelSelector } from '../selectors/importSelectors';
 import PlaylistManager from '../components/PlaylistManager';
@@ -18,13 +11,7 @@ import PlaylistManager from '../components/PlaylistManager';
 const mapStateToProps = createStructuredSelector({
   selectedPlaylist: selectedPlaylistSelector,
   showImportPanel: showImportPanelSelector,
-  showSearchResults: showSearchResultsSelector,
-  searchSource: searchSourceTypeSelector
+  showSearchResults: showSearchResultsSelector
 });
 
-const mapDispatchToProps = dispatch => bindActionCreators({
-  onSearchSubmit: search,
-  onSearchSourceChange: setSearchSource
-}, dispatch);
-
-export default connect(mapStateToProps, mapDispatchToProps)(PlaylistManager);
+export default connect(mapStateToProps)(PlaylistManager);

--- a/src/containers/PlaylistManager.js
+++ b/src/containers/PlaylistManager.js
@@ -1,47 +1,28 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { createSelector } from 'reselect';
+import { createStructuredSelector } from 'reselect';
 
-import {
-  openPreviewMediaDialog
-} from '../actions/DialogActionCreators';
-import {
-  addMediaMenu
-} from '../actions/PlaylistActionCreators';
 import {
   search,
   setSource as setSearchSource
 } from '../actions/SearchActionCreators';
 
 import { selectedPlaylistSelector } from '../selectors/playlistSelectors';
-import { searchSelector } from '../selectors/searchSelectors';
+import {
+  showSearchResultsSelector,
+  searchSourceTypeSelector
+} from '../selectors/searchSelectors';
 import { showImportPanelSelector } from '../selectors/importSelectors';
 import PlaylistManager from '../components/PlaylistManager';
 
-const mapStateToProps = createSelector(
-  selectedPlaylistSelector,
-  searchSelector,
-  showImportPanelSelector,
-  (selectedPlaylist, mediaSearch, showImportPanel) => ({
-    ...mediaSearch,
-    selectedPlaylist,
-    showImportPanel
-  })
-);
-
-const selectionOrOne = (media, selection) => {
-  if (selection.isSelected(media)) {
-    return selection.get();
-  }
-  return [ media ];
-};
-
-const onOpenAddMediaMenu = (position, media, selection) =>
-  addMediaMenu(selectionOrOne(media, selection), position);
+const mapStateToProps = createStructuredSelector({
+  selectedPlaylist: selectedPlaylistSelector,
+  showImportPanel: showImportPanelSelector,
+  showSearchResults: showSearchResultsSelector,
+  searchSource: searchSourceTypeSelector
+});
 
 const mapDispatchToProps = dispatch => bindActionCreators({
-  onOpenAddMediaMenu,
-  onOpenPreviewMediaDialog: openPreviewMediaDialog,
   onSearchSubmit: search,
   onSearchSourceChange: setSearchSource
 }, dispatch);

--- a/src/containers/PlaylistManager.js
+++ b/src/containers/PlaylistManager.js
@@ -6,38 +6,26 @@ import {
   openPreviewMediaDialog
 } from '../actions/DialogActionCreators';
 import {
-  addMediaMenu,
-  editMedia,
-  moveMedia,
-  removeMedia,
-  filterPlaylistItems,
-  createPlaylist,
-  renamePlaylist,
-  deletePlaylist,
-  cannotDeleteActivePlaylist,
-  shufflePlaylist,
-  activatePlaylist,
-  loadPlaylist,
-  loadFilteredPlaylistItems
+  addMediaMenu
 } from '../actions/PlaylistActionCreators';
 import {
   search,
   setSource as setSearchSource
 } from '../actions/SearchActionCreators';
 
-import { playlistsIndexSelector } from '../selectors/playlistSelectors';
+import { selectedPlaylistSelector } from '../selectors/playlistSelectors';
 import { searchSelector } from '../selectors/searchSelectors';
 import { showImportPanelSelector } from '../selectors/importSelectors';
 import PlaylistManager from '../components/PlaylistManager';
 
 const mapStateToProps = createSelector(
-  playlistsIndexSelector,
+  selectedPlaylistSelector,
   searchSelector,
   showImportPanelSelector,
-  (playlists, mediaSearch, showingImportPanel) => ({
-    ...playlists,
+  (selectedPlaylist, mediaSearch, showImportPanel) => ({
     ...mediaSearch,
-    showImportPanel: showingImportPanel
+    selectedPlaylist,
+    showImportPanel
   })
 );
 
@@ -50,32 +38,10 @@ const selectionOrOne = (media, selection) => {
 
 const onOpenAddMediaMenu = (position, media, selection) =>
   addMediaMenu(selectionOrOne(media, selection), position);
-const onRemoveFromPlaylist = (playlist, media, selection) =>
-  removeMedia(playlist, selectionOrOne(media, selection));
-const onMoveToFirst = (playlist, media, selection) =>
-  moveMedia(playlist, selectionOrOne(media, selection), { at: 'start' });
-const onEditMedia = (playlist, media) =>
-  editMedia(playlist, media);
-
-const onMoveMedia = (playlist, media, opts) =>
-  moveMedia(playlist, media, opts);
 
 const mapDispatchToProps = dispatch => bindActionCreators({
   onOpenAddMediaMenu,
-  onMoveToFirst,
-  onEditMedia,
-  onMoveMedia,
-  onRemoveFromPlaylist,
   onOpenPreviewMediaDialog: openPreviewMediaDialog,
-  onCreatePlaylist: createPlaylist,
-  onRenamePlaylist: renamePlaylist,
-  onDeletePlaylist: deletePlaylist,
-  onNotDeletable: cannotDeleteActivePlaylist,
-  onShufflePlaylist: shufflePlaylist,
-  onActivatePlaylist: activatePlaylist,
-  onFilterPlaylistItems: filterPlaylistItems,
-  onLoadPlaylistPage: loadPlaylist,
-  onLoadFilteredPlaylistPage: loadFilteredPlaylistItems,
   onSearchSubmit: search,
   onSearchSourceChange: setSearchSource
 }, dispatch);

--- a/src/containers/PlaylistManager.js
+++ b/src/containers/PlaylistManager.js
@@ -6,10 +6,6 @@ import {
   openPreviewMediaDialog
 } from '../actions/DialogActionCreators';
 import {
-  showImportPanel
-} from '../actions/ImportActionCreators';
-import {
-  addMedia,
   addMediaMenu,
   editMedia,
   moveMedia,
@@ -21,13 +17,11 @@ import {
   cannotDeleteActivePlaylist,
   shufflePlaylist,
   activatePlaylist,
-  selectPlaylist,
   loadPlaylist,
   loadFilteredPlaylistItems
 } from '../actions/PlaylistActionCreators';
 import {
   search,
-  showSearchResults,
   setSource as setSearchSource
 } from '../actions/SearchActionCreators';
 
@@ -73,7 +67,6 @@ const mapDispatchToProps = dispatch => bindActionCreators({
   onMoveMedia,
   onRemoveFromPlaylist,
   onOpenPreviewMediaDialog: openPreviewMediaDialog,
-  onAddToPlaylist: addMedia,
   onCreatePlaylist: createPlaylist,
   onRenamePlaylist: renamePlaylist,
   onDeletePlaylist: deletePlaylist,
@@ -81,13 +74,10 @@ const mapDispatchToProps = dispatch => bindActionCreators({
   onShufflePlaylist: shufflePlaylist,
   onActivatePlaylist: activatePlaylist,
   onFilterPlaylistItems: filterPlaylistItems,
-  onSelectPlaylist: selectPlaylist,
-  onSelectSearchResults: showSearchResults,
   onLoadPlaylistPage: loadPlaylist,
   onLoadFilteredPlaylistPage: loadFilteredPlaylistItems,
   onSearchSubmit: search,
-  onSearchSourceChange: setSearchSource,
-  onShowImportPanel: showImportPanel
+  onSearchSourceChange: setSearchSource
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(PlaylistManager);

--- a/src/containers/PlaylistManagerMenu.js
+++ b/src/containers/PlaylistManagerMenu.js
@@ -1,0 +1,42 @@
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { createStructuredSelector } from 'reselect';
+
+import {
+  addMedia as addToPlaylist,
+  createPlaylist,
+  selectPlaylist
+} from '../actions/PlaylistActionCreators';
+import { showImportPanel } from '../actions/ImportActionCreators';
+import { showSearchResults } from '../actions/SearchActionCreators';
+
+import {
+  playlistsSelector,
+  selectedPlaylistSelector
+} from '../selectors/playlistSelectors';
+import {
+  searchQuerySelector,
+  showSearchResultsSelector,
+  searchResultsSelector
+} from '../selectors/searchSelectors';
+import { showImportPanelSelector } from '../selectors/importSelectors';
+import PlaylistsMenu from '../components/PlaylistManager/Menu';
+
+const mapStateToProps = createStructuredSelector({
+  playlists: playlistsSelector,
+  selected: selectedPlaylistSelector,
+  searchQuery: searchQuerySelector,
+  showSearchResults: showSearchResultsSelector,
+  searchResults: searchResultsSelector,
+  showImportPanel: showImportPanelSelector
+});
+
+const mapDispatchToProps = dispatch => bindActionCreators({
+  onAddToPlaylist: addToPlaylist,
+  onCreatePlaylist: createPlaylist,
+  onSelectPlaylist: selectPlaylist,
+  onSelectSearchResults: showSearchResults,
+  onShowImportPanel: showImportPanel
+}, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps)(PlaylistsMenu);

--- a/src/containers/PlaylistManagerMenu.js
+++ b/src/containers/PlaylistManagerMenu.js
@@ -17,7 +17,7 @@ import {
 import {
   searchQuerySelector,
   showSearchResultsSelector,
-  searchResultsSelector
+  searchResultsCountSelector
 } from '../selectors/searchSelectors';
 import { showImportPanelSelector } from '../selectors/importSelectors';
 import PlaylistsMenu from '../components/PlaylistManager/Menu';
@@ -27,7 +27,7 @@ const mapStateToProps = createStructuredSelector({
   selected: selectedPlaylistSelector,
   searchQuery: searchQuerySelector,
   showSearchResults: showSearchResultsSelector,
-  searchResults: searchResultsSelector,
+  searchResults: searchResultsCountSelector,
   showImportPanel: showImportPanelSelector
 });
 

--- a/src/containers/PlaylistManagerPanel.js
+++ b/src/containers/PlaylistManagerPanel.js
@@ -1,0 +1,92 @@
+import { bindActionCreators } from 'redux';
+import { createStructuredSelector } from 'reselect';
+import { connect } from 'react-redux';
+
+import {
+  selectedPlaylistSelector,
+  filteredSelectedPlaylistItemsSelector,
+  isSelectedPlaylistLoadingSelector,
+  isFilteredSelector
+} from '../selectors/playlistSelectors';
+
+import {
+  openPreviewMediaDialog
+} from '../actions/DialogActionCreators';
+import {
+  addMediaMenu,
+  editMedia,
+  moveMedia,
+  removeMedia,
+  filterPlaylistItems,
+  renamePlaylist,
+  deletePlaylist,
+  cannotDeleteActivePlaylist,
+  shufflePlaylist,
+  activatePlaylist,
+  loadPlaylist,
+  loadFilteredPlaylistItems
+} from '../actions/PlaylistActionCreators';
+
+import PlaylistPanel from '../components/PlaylistManager/Panel';
+
+const mapStateToProps = createStructuredSelector({
+  playlist: selectedPlaylistSelector,
+  media: filteredSelectedPlaylistItemsSelector,
+  loading: isSelectedPlaylistLoadingSelector,
+  isFiltered: isFilteredSelector
+});
+
+const selectionOrOne = (media, selection) => {
+  if (selection.isSelected(media)) {
+    return selection.get();
+  }
+  return [ media ];
+};
+
+const onOpenAddMediaMenu = (position, media, selection) =>
+  addMediaMenu(selectionOrOne(media, selection), position);
+const onRemoveFromPlaylist = playlist => (media, selection) =>
+  removeMedia(playlist, selectionOrOne(media, selection));
+const onMoveMedia = playlist => (media, opts) =>
+  moveMedia(playlist, media, opts);
+const onMoveToFirst = playlist => (media, selection) =>
+  moveMedia(playlist, selectionOrOne(media, selection), { at: 'start' });
+const onEditMedia = playlist => media =>
+  editMedia(playlist, media);
+const onLoadPlaylistPage = ({ isFiltered, playlist }) => page => (
+  isFiltered ? loadFilteredPlaylistItems(playlist._id, page) :
+    loadPlaylist(playlist._id, page)
+);
+
+// Most of the playlist-related action creators need to know which playlist to
+// use, i.e. need to have a reference to the selected playlist. The selected
+// playlist is picked out in `mapStateToProps`, but we can't access its result
+// in `mapDispatchToProps` yet. Instead, `mapDispatchToProps` passes the
+// `dispatch` function to the `mergeProps` function below, and then that
+// configures the action creators.
+// TODO Maybe it's better to have versions of these action creators that work on
+// the selected playlist by default? using redux-thunk.
+const mapDispatchToProps = dispatch => ({ dispatch });
+
+const mergeProps = (state, { dispatch }, props) => ({
+  ...props,
+  ...state,
+  ...bindActionCreators({
+    onShufflePlaylist: shufflePlaylist.bind(null, state.playlist._id),
+    onActivatePlaylist: activatePlaylist.bind(null, state.playlist._id),
+    onRenamePlaylist: renamePlaylist.bind(null, state.playlist._id),
+    onDeletePlaylist: deletePlaylist.bind(null, state.playlist._id),
+    onNotDeletable: cannotDeleteActivePlaylist,
+
+    onOpenAddMediaMenu,
+    onOpenPreviewMediaDialog: openPreviewMediaDialog,
+    onMoveToFirst: onMoveToFirst(state.playlist._id),
+    onMoveMedia: onMoveMedia(state.playlist._id),
+    onEditMedia: onEditMedia(state.playlist._id),
+    onRemoveFromPlaylist: onRemoveFromPlaylist(state.playlist._id),
+    onLoadPlaylistPage: onLoadPlaylistPage(state),
+    onFilterPlaylistItems: filterPlaylistItems.bind(null, state.playlist._id)
+  }, dispatch)
+});
+
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(PlaylistPanel);

--- a/src/containers/SearchResultsPanel.js
+++ b/src/containers/SearchResultsPanel.js
@@ -1,0 +1,40 @@
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { createStructuredSelector } from 'reselect';
+
+import {
+  openPreviewMediaDialog
+} from '../actions/DialogActionCreators';
+import {
+  addMediaMenu
+} from '../actions/PlaylistActionCreators';
+
+import {
+  searchQuerySelector,
+  searchResultsSelector,
+  searchLoadingStateSelector
+} from '../selectors/searchSelectors';
+import SearchResults from '../components/PlaylistManager/Panel/SearchResults';
+
+const mapStateToProps = createStructuredSelector({
+  query: searchQuerySelector,
+  results: searchResultsSelector,
+  loadingState: searchLoadingStateSelector
+});
+
+const selectionOrOne = (media, selection) => {
+  if (selection.isSelected(media)) {
+    return selection.get();
+  }
+  return [ media ];
+};
+
+const onOpenAddMediaMenu = (position, media, selection) =>
+  addMediaMenu(selectionOrOne(media, selection), position);
+
+const mapDispatchToProps = dispatch => bindActionCreators({
+  onOpenAddMediaMenu,
+  onOpenPreviewMediaDialog: openPreviewMediaDialog
+}, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps)(SearchResults);

--- a/src/selectors/playlistSelectors.js
+++ b/src/selectors/playlistSelectors.js
@@ -103,8 +103,6 @@ export const nextMediaSelector = createSelector(
 );
 
 export const playlistsIndexSelector = createStructuredSelector({
-  playlists: playlistsSelector,
-  activePlaylist: activePlaylistSelector,
   selectedPlaylist: selectedPlaylistSelector,
   activeMedia: activeMediaSelector,
   selectedMedia: filteredSelectedPlaylistItemsSelector,

--- a/src/selectors/playlistSelectors.js
+++ b/src/selectors/playlistSelectors.js
@@ -102,6 +102,16 @@ export const nextMediaSelector = createSelector(
   media => (media ? media[0] : null)
 );
 
+export const isSelectedPlaylistLoadingSelector = createSelector(
+  selectedPlaylistSelector,
+  selectedPlaylist => Boolean(selectedPlaylist.loading)
+);
+
+export const isFilteredSelector = createSelector(
+  playlistItemFilterSelector,
+  filter => Boolean(filter)
+);
+
 export const playlistsIndexSelector = createStructuredSelector({
   selectedPlaylist: selectedPlaylistSelector,
   activeMedia: activeMediaSelector,

--- a/src/selectors/playlistSelectors.js
+++ b/src/selectors/playlistSelectors.js
@@ -1,4 +1,4 @@
-import { createSelector, createStructuredSelector } from 'reselect';
+import { createSelector } from 'reselect';
 import naturalCmp from 'natural-compare';
 import values from 'object-values';
 
@@ -111,10 +111,3 @@ export const isFilteredSelector = createSelector(
   playlistItemFilterSelector,
   filter => Boolean(filter)
 );
-
-export const playlistsIndexSelector = createStructuredSelector({
-  selectedPlaylist: selectedPlaylistSelector,
-  activeMedia: activeMediaSelector,
-  selectedMedia: filteredSelectedPlaylistItemsSelector,
-  currentFilter: playlistItemFilterSelector
-});

--- a/src/selectors/searchSelectors.js
+++ b/src/selectors/searchSelectors.js
@@ -7,7 +7,7 @@ const searchSourceTypeSelector = createSelector(
   search => search.sourceType
 );
 
-const searchQuerySelector = createSelector(
+export const searchQuerySelector = createSelector(
   baseSearchSelector,
   search => search.query
 );
@@ -22,18 +22,18 @@ const searchResultsCombinedSelector = createSelector(
   search => search.results
 );
 
-const searchResultsSelector = createSelector(
+export const searchResultsSelector = createSelector(
   searchResultsCombinedSelector,
   searchSourceTypeSelector,
   (results, sourceType) => results[sourceType]
 );
 
-const searchResultsCountSelector = createSelector(
+export const searchResultsCountSelector = createSelector(
   searchResultsSelector,
   results => (results ? results.length : 0)
 );
 
-const showSearchResultsSelector = createSelector(
+export const showSearchResultsSelector = createSelector(
   baseSearchSelector,
   search => !!search.showResults
 );

--- a/src/selectors/searchSelectors.js
+++ b/src/selectors/searchSelectors.js
@@ -1,8 +1,8 @@
-import { createSelector, createStructuredSelector } from 'reselect';
+import { createSelector } from 'reselect';
 
 const baseSearchSelector = state => state.mediaSearch;
 
-const searchSourceTypeSelector = createSelector(
+export const searchSourceTypeSelector = createSelector(
   baseSearchSelector,
   search => search.sourceType
 );
@@ -12,7 +12,7 @@ export const searchQuerySelector = createSelector(
   search => search.query
 );
 
-const searchLoadingStateSelector = createSelector(
+export const searchLoadingStateSelector = createSelector(
   baseSearchSelector,
   search => search.loadingState
 );
@@ -37,13 +37,3 @@ export const showSearchResultsSelector = createSelector(
   baseSearchSelector,
   search => !!search.showResults
 );
-
-// eslint-disable-next-line import/prefer-default-export
-export const searchSelector = createStructuredSelector({
-  showSearchResults: showSearchResultsSelector,
-  searchSource: searchSourceTypeSelector,
-  searchQuery: searchQuerySelector,
-  searchResults: searchResultsSelector,
-  searchResultsCount: searchResultsCountSelector,
-  searchLoadingState: searchLoadingStateSelector
-});


### PR DESCRIPTION
Makes the PlaylistManager less of a massive monstrosity and will also make it easier to move the smaller containers around in the future.