### PR TITLE
Add Tabs component with üWave-friendly styling

### DIFF
--- a/src/components/SidePanels/PanelTemplate.js
+++ b/src/components/SidePanels/PanelTemplate.js
@@ -1,10 +1,10 @@
-import cx from 'classnames';
 import * as React from 'react';
+import TabTemplate from '../Tabs/TabTemplate';
 
 const PanelTemplate = ({ selected, children }) => (
-  <div className={cx('SidePanel-panel', selected && 'is-visible')}>
+  <TabTemplate selected={selected} className="SidePanel-panel">
     {children}
-  </div>
+  </TabTemplate>
 );
 
 PanelTemplate.propTypes = {

--- a/src/components/SidePanels/index.js
+++ b/src/components/SidePanels/index.js
@@ -2,43 +2,14 @@ import * as React from 'react';
 import { translate } from 'react-i18next';
 import compose from 'recompose/compose';
 import pure from 'recompose/pure';
-import { Tabs, Tab } from 'material-ui/Tabs';
 
 import Chat from '../../containers/Chat';
 import RoomUserList from '../../containers/RoomUserList';
 import WaitList from '../../containers/WaitList';
 
+import Tabs from '../Tabs';
+import Tab from '../Tabs/Tab';
 import PanelTemplate from './PanelTemplate';
-
-const tabItemContainerStyle = {
-  height: 56,
-  backgroundColor: '#151515'
-};
-
-const tabStyle = {
-  float: 'left',
-  color: '#fff',
-  fontSize: '10pt',
-  height: '100%',
-  backgroundColor: '#151515'
-};
-
-const activeTabStyle = {
-  ...tabStyle,
-  backgroundColor: 'rgba(48, 48, 48, 0.3)'
-};
-
-const inkBarStyle = {
-  height: 3,
-  marginTop: -3,
-  backgroundColor: '#fff'
-};
-
-const contentStyle = {
-  // This ensures that the `position:absolute`s on divs _inside_ container
-  // elements align correctly.
-  position: 'static'
-};
 
 const subHeaderStyle = {
   fontSize: '125%'
@@ -69,9 +40,6 @@ const SidePanels = ({
   <Tabs
     value={selected}
     onChange={onChange}
-    tabItemContainerStyle={tabItemContainerStyle}
-    inkBarStyle={inkBarStyle}
-    contentContainerStyle={contentStyle}
     tabTemplate={PanelTemplate}
   >
     {/* Disabled touch ripples on tabs because they're offset weirdly. Also,
@@ -88,7 +56,6 @@ const SidePanels = ({
       disableTouchRipple
       label={t('chat.title')}
       value="chat"
-      style={selected === 'chat' ? activeTabStyle : tabStyle}
     >
       <Chat />
     </Tab>
@@ -102,7 +69,6 @@ const SidePanels = ({
         </span>
       ]}
       value="room"
-      style={selected === 'room' ? activeTabStyle : tabStyle}
     >
       <RoomUserList />
     </Tab>
@@ -111,7 +77,6 @@ const SidePanels = ({
       disableTouchRipple
       label={getWaitlistLabel(t, waitlistSize, waitlistPosition)}
       value="waitlist"
-      style={selected === 'waitlist' ? activeTabStyle : tabStyle}
     >
       <WaitList />
     </Tab>

--- a/src/components/SidePanels/index.js
+++ b/src/components/SidePanels/index.js
@@ -11,9 +11,22 @@ import Tabs from '../Tabs';
 import Tab from '../Tabs/Tab';
 import PanelTemplate from './PanelTemplate';
 
+const contentContainerStyle = {
+  // This ensures that the `position:absolute`s on divs _inside_ container
+  // elements align correctly.
+  position: 'static'
+};
+
 const subHeaderStyle = {
   fontSize: '125%'
 };
+
+const getUsersLabel = (t, listenerCount) => [
+  t('users.title'),
+  <span key="sub" style={subHeaderStyle}>
+    {listenerCount}
+  </span>
+];
 
 const getWaitlistLabel = (t, size, position) => {
   if (size > 0) {
@@ -40,20 +53,16 @@ const SidePanels = ({
   <Tabs
     value={selected}
     onChange={onChange}
+    contentContainerStyle={contentContainerStyle}
     tabTemplate={PanelTemplate}
   >
-    {/* Disabled touch ripples on tabs because they're offset weirdly. Also,
-      * they interfere with the flexbox column layout for the Waitlist
-      * position, because they add a wrapper <div />.
-      *
-      * NB: SidePanel-tab includes some !important styles because material-ui
+    {/* NB: SidePanel-tab includes some !important styles because material-ui
       * has an otherwise unstyleable element inside its tab bar that breaks our
       * user and waitlist position counter elements. material-ui uses it to
       * properly position tab labels. The overrides remove the height and
       * padding constraints from that in-between element. */}
     <Tab
       className="SidePanel-tab"
-      disableTouchRipple
       label={t('chat.title')}
       value="chat"
     >
@@ -61,20 +70,13 @@ const SidePanels = ({
     </Tab>
     <Tab
       className="SidePanel-tab"
-      disableTouchRipple
-      label={[
-        t('users.title'),
-        <span key="sub" style={subHeaderStyle}>
-          {listenerCount}
-        </span>
-      ]}
+      label={getUsersLabel(t, listenerCount)}
       value="room"
     >
       <RoomUserList />
     </Tab>
     <Tab
       className="SidePanel-tab"
-      disableTouchRipple
       label={getWaitlistLabel(t, waitlistSize, waitlistPosition)}
       value="waitlist"
     >

--- a/src/components/Tabs/Tab.js
+++ b/src/components/Tabs/Tab.js
@@ -1,0 +1,1 @@
+export { Tab as default } from 'material-ui/Tabs';

--- a/src/components/Tabs/TabTemplate.js
+++ b/src/components/Tabs/TabTemplate.js
@@ -1,0 +1,16 @@
+import cx from 'classnames';
+import * as React from 'react';
+
+const TabTemplate = ({ className, selected, children }) => (
+  <div className={cx('Tabs-panel', className, selected && 'is-visible')}>
+    {children}
+  </div>
+);
+
+TabTemplate.propTypes = {
+  children: React.PropTypes.node.isRequired,
+  selected: React.PropTypes.bool.isRequired,
+  className: React.PropTypes.string
+};
+
+export default TabTemplate;

--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -27,9 +27,7 @@ const baseInkBarStyle = {
 };
 
 const baseContentStyle = {
-  // This ensures that the `position:absolute`s on divs _inside_ container
-  // elements align correctly.
-  position: 'static'
+  position: 'relative'
 };
 
 // This component just wraps the Material-UI tabs with some default styling.

--- a/src/components/Tabs/index.js
+++ b/src/components/Tabs/index.js
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import { Tabs as MuiTabs } from 'material-ui/Tabs';
+import TabTemplate from './TabTemplate';
+
+const baseTabItemContainerStyle = {
+  height: 56,
+  backgroundColor: '#151515'
+};
+
+const tabStyle = {
+  float: 'left',
+  color: '#fff',
+  fontSize: '10pt',
+  height: '100%',
+  backgroundColor: '#151515'
+};
+
+const activeTabStyle = {
+  ...tabStyle,
+  backgroundColor: 'rgba(48, 48, 48, 0.3)'
+};
+
+const baseInkBarStyle = {
+  height: 3,
+  marginTop: -3,
+  backgroundColor: '#fff'
+};
+
+const baseContentStyle = {
+  // This ensures that the `position:absolute`s on divs _inside_ container
+  // elements align correctly.
+  position: 'static'
+};
+
+// This component just wraps the Material-UI tabs with some default styling.
+// Our styling isn't quite material design, so we can't just use themes for
+// this stuff.
+const StyledTabs = ({
+  tabItemContainerStyle,
+  inkBarStyle,
+  contentContainerStyle,
+  children,
+  value,
+  ...props
+}) => (
+  <MuiTabs
+    tabItemContainerStyle={{
+      ...baseTabItemContainerStyle,
+      ...tabItemContainerStyle
+    }}
+    inkBarStyle={{
+      ...baseInkBarStyle,
+      ...inkBarStyle
+    }}
+    contentContainerStyle={{
+      ...baseContentStyle,
+      ...contentContainerStyle
+    }}
+    tabTemplate={TabTemplate}
+    value={value}
+    {...props}
+  >
+    {React.Children.map(children, tab => (
+      React.cloneElement(tab, {
+        style: {
+          ...(value === tab.props.value ? activeTabStyle : tabStyle),
+          ...tab.props.style
+        }
+      })
+    ))}
+  </MuiTabs>
+);
+
+StyledTabs.propTypes = {
+  tabItemContainerStyle: React.PropTypes.object,
+  inkBarStyle: React.PropTypes.object,
+  contentContainerStyle: React.PropTypes.object,
+  children: React.PropTypes.arrayOf(React.PropTypes.node).isRequired,
+  value: React.PropTypes.string
+};
+
+export default StyledTabs;


### PR DESCRIPTION
Thin wrapper around material-ui's Tabs with default styles that fit in. All of this was in the SidePanels component first but mostly unrelated to its purpose, so now it's a reusable component.