### PR TITLE
build: add Lodash Webpack plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "gulp-yaml": "^1.0.1",
     "html-webpack-plugin": "^2.24.1",
     "json-loader": "^0.5.4",
+    "lodash-webpack-plugin": "^0.10.6",
     "loud-rejection": "^1.3.0",
     "mocha": "^3.0.0",
     "npm-run-path": "^2.0.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,11 +42,13 @@ const plugins = [
 ];
 
 if (nodeEnv === 'production') {
+  const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
   const LoaderOptionsPlugin = require('webpack').LoaderOptionsPlugin;
   const OccurrenceOrderPlugin = require('webpack').optimize.OccurrenceOrderPlugin;
   const UglifyJsPlugin = require('webpack').optimize.UglifyJsPlugin;
 
   plugins.push(
+    new LodashModuleReplacementPlugin(),
     new OccurrenceOrderPlugin(),
     new LoaderOptionsPlugin({
       minimize: true,


### PR DESCRIPTION
Also changes one use of Lodash's implicit _.property wrapping.

The lodash Webpack plugin removes unused lodash features. Need to try this out a bit more first to make sure we're not using any of the features that are being removed.

Lodash 5.x will disable most or all of those features by default so it's good to make sure we're not using any of them now.