### PR TITLE
build: Fix recompiling es/ and lib/ dirs if es/ is up-to-date but lib/ is not

### DIFF
--- a/tasks/js.js
+++ b/tasks/js.js
@@ -63,7 +63,7 @@ gulp.task('js:babel', [ 'js:locales' ], () => {
 
   return gulp.src(src)
     .pipe(plumber())
-    .pipe(newer(destEs))
+    .pipe(newer(destCommonjs))
     .pipe(through.obj((file, enc, cb) => {
       const path = relative(`${__dirname}/../`, file.path);
       log(`Compiling '${colors.cyan(path)}'...`);


### PR DESCRIPTION
Not exactly sure how the modules get out of sync, but I've had it a few times with lib/middleware.js. The middleware wouldn't recompile because es/middleware was up to date.