### PR TITLE
chat: Fix chat timestamps appearing behind emoji.

### DIFF
--- a/src/components/Chat/Message.css
+++ b/src/components/Chat/Message.css
@@ -26,6 +26,7 @@
     padding: 0 6px;
     display: none;
     font-size: 80%;
+    z-index: 2;
   }
 
   @nest &:hover &-hover {


### PR DESCRIPTION
Before/After:

![Screenshot](http://i.imgur.com/wxcBdW1.png)

Emoji would render on top of chat timestamps and delete buttons.
This change instead renders the timestamps and delete buttons on
top.