### PR TITLE
chat: Fix squeezed display of non-square emoji in suggestions list.

### DIFF
--- a/src/components/Chat/Input/EmojiSuggestion.css
+++ b/src/components/Chat/Input/EmojiSuggestion.css
@@ -1,0 +1,10 @@
+.EmojiSuggestion {
+  &-image {
+    width: 24px;
+    height: 24px;
+    background-size: contain;
+    background-position: center center;
+    background-repeat: no-repeat;
+    display: inline-block;
+  }
+}

--- a/src/components/Chat/Input/EmojiSuggestion.js
+++ b/src/components/Chat/Input/EmojiSuggestion.js
@@ -10,12 +10,9 @@ const EmojiSuggestion = ({
     value={emoji.shortcode}
     primaryText={`:${emoji.shortcode}:`}
     leftAvatar={
-      <img
-        alt=""
-        className="Emoji"
-        src={`/assets/emoji/${emoji.image}`}
-        width={24}
-        height={24}
+      <span
+        className="EmojiSuggestion-image"
+        style={{ backgroundImage: `url(/assets/emoji/${emoji.image})` }}
       />
     }
   />

--- a/src/components/Chat/Input/index.css
+++ b/src/components/Chat/Input/index.css
@@ -1,4 +1,5 @@
 @import "../../../vars.css";
+@import "./EmojiSuggestion.css";
 
 .ChatInputWrapper {
   background: var(--chat-background-color);


### PR DESCRIPTION
Emoji that aren't squares are stretched a bit weirdly in the suggestions list:

![](http://i.imgur.com/UpjvLzA.png)

When they're supposed to be centered vertically and horizontically, with maintained aspect ratio:

![](http://i.imgur.com/eV6PsUf.png)

This changes the emoji suggestions to use a CSS background with size `contain`, just like emoji in chat messages already do.