### PR TITLE
Chat performance fixes

### DIFF
--- a/src/components/Chat/ChatMessages.css
+++ b/src/components/Chat/ChatMessages.css
@@ -1,3 +1,5 @@
+@import "../../vars.css";
+
 .ChatMessages {
   height: 100%;
   overflow-y: scroll;
@@ -8,4 +10,16 @@
    * TODO fix that^ in src/components/Tooltip. Should resize(?) the positioning
    * wrapper if it's close to the edge of the screen. */
   overflow-x: hidden;
+
+  /* Add alternating background colours for child messages. */
+  /* Some messages are wrapped in additional elements, eg. to align User cards,
+   * so we need both these selectors here. */
+  & > .ChatMessage:nth-child(2n),
+  & > :nth-child(2n) .ChatMessage {
+    background: var(--chat-background-color2);
+
+    & .ChatMessage-hover {
+      background: var(--chat-background-color2);
+    }
+  }
 }

--- a/src/components/Chat/ChatMessages.js
+++ b/src/components/Chat/ChatMessages.js
@@ -30,15 +30,6 @@ export default class ChatMessages extends React.Component {
     }
   }
 
-  makeDeleteHandler(msg) {
-    if (this.props.canDeleteMessages) {
-      return () => {
-        this.props.onDeleteMessage(msg._id);
-      };
-    }
-    return null;
-  }
-
   scrollToBottom() {
     const el = this.container;
     el.scrollTop = el.scrollHeight;
@@ -86,7 +77,7 @@ export default class ChatMessages extends React.Component {
         key={msg._id}
         alternate={alternate}
         compileOptions={this.props.compileOptions}
-        onDelete={this.makeDeleteHandler(msg)}
+        onDelete={this.props.canDeleteMessages ? this.props.onDeleteMessage : null}
         {...msg}
       />
     );

--- a/src/components/Chat/ChatMessages.js
+++ b/src/components/Chat/ChatMessages.js
@@ -60,13 +60,11 @@ export default class ChatMessages extends React.Component {
     );
   }
 
-  renderMessage(msg, index) {
-    const alternate = index % 2 === 0;
+  renderMessage(msg) {
     if (msg.type === 'log') {
       return (
         <LogMessage
           key={msg._id}
-          alternate={alternate}
           {...msg}
         />
       );
@@ -75,7 +73,6 @@ export default class ChatMessages extends React.Component {
     return (
       <Message
         key={msg._id}
-        alternate={alternate}
         compileOptions={this.props.compileOptions}
         onDelete={this.props.canDeleteMessages ? this.props.onDeleteMessage : null}
         {...msg}

--- a/src/components/Chat/LogMessage.js
+++ b/src/components/Chat/LogMessage.js
@@ -1,15 +1,8 @@
-import cx from 'classnames';
 import * as React from 'react';
 import pure from 'recompose/pure';
 
-const LogMessage = ({ alternate, text }) => (
-  <div
-    className={cx(
-      'ChatMessage',
-      'ChatMessage--log',
-      alternate && 'ChatMessage--alternate'
-    )}
-  >
+const LogMessage = ({ text }) => (
+  <div className="ChatMessage ChatMessage--log">
     <div className="ChatMessage-content">
       <span className="ChatMessage-text">{text}</span>
     </div>
@@ -17,7 +10,6 @@ const LogMessage = ({ alternate, text }) => (
 );
 
 LogMessage.propTypes = {
-  alternate: React.PropTypes.bool,
   text: React.PropTypes.string.isRequired
 };
 

--- a/src/components/Chat/Message.css
+++ b/src/components/Chat/Message.css
@@ -7,13 +7,6 @@
   min-height: 32px;
   position: relative;
 
-  &--alternate {
-    background: var(--chat-background-color2);
-  }
-  @nest &--alternate &-hover {
-    background: var(--chat-background-color2);
-  }
-
   &--mention {
     box-shadow: 5px 0px 0px var(--highlight-color) inset;
   }

--- a/src/components/Chat/Message.js
+++ b/src/components/Chat/Message.js
@@ -27,7 +27,6 @@ const enhance = compose(
 );
 
 const Message = ({
-  alternate,
   user,
   text,
   parsedText,
@@ -62,7 +61,6 @@ const Message = ({
     'ChatMessage',
     inFlight && 'ChatMessage--loading',
     isMention && 'ChatMessage--mention',
-    alternate && 'ChatMessage--alternate'
   );
   return (
     <div className={className}>
@@ -85,7 +83,6 @@ const Message = ({
 };
 
 Message.propTypes = {
-  alternate: React.PropTypes.bool,
   user: React.PropTypes.object.isRequired,
   text: React.PropTypes.string.isRequired,
   parsedText: React.PropTypes.array.isRequired,

--- a/src/components/Chat/Message.js
+++ b/src/components/Chat/Message.js
@@ -2,7 +2,7 @@ import cx from 'classnames';
 import * as React from 'react';
 import compose from 'recompose/compose';
 import pure from 'recompose/pure';
-import withProps from 'recompose/withProps';
+import withHandlers from 'recompose/withHandlers';
 
 import userCardable from '../../utils/userCardable';
 import Avatar from '../Avatar';
@@ -16,12 +16,14 @@ import MessageTimestamp from './MessageTimestamp';
 const enhance = compose(
   pure,
   userCardable(),
-  withProps(props => ({
-    onUsernameClick(event) {
+  withHandlers({
+    onDeleteClick: props => () =>
+      props.onDeleteMessage(props._id),
+    onUsernameClick: props => (event) => {
       event.preventDefault();
       props.openUserCard(props.user);
     }
-  }))
+  })
 );
 
 const Message = ({
@@ -33,7 +35,7 @@ const Message = ({
   isMention,
   timestamp,
   compileOptions,
-  onDelete,
+  onDeleteClick,
   onUsernameClick
 }) => {
   let avatar;
@@ -67,7 +69,7 @@ const Message = ({
       {avatar}
       <div className="ChatMessage-content">
         <div className="ChatMessage-hover">
-          {onDelete && <DeleteButton onDelete={onDelete} />}
+          {onDeleteClick && <DeleteButton onDelete={onDeleteClick} />}
           <MessageTimestamp date={date} />
         </div>
         <button
@@ -90,7 +92,7 @@ Message.propTypes = {
   inFlight: React.PropTypes.bool,
   timestamp: React.PropTypes.number.isRequired,
   isMention: React.PropTypes.bool.isRequired,
-  onDelete: React.PropTypes.func,
+  onDeleteClick: React.PropTypes.func,
   compileOptions: React.PropTypes.shape({
     availableEmoji: React.PropTypes.array,
     emojiImages: React.PropTypes.object


### PR DESCRIPTION
These patches change two things that could cause the entire chat message list to rerender every time a new message was received.

The chat delete button handlers for moderators are now not recreated each time the list rerenders, so no longer cause all chat messages to rerender too.

I removed the striped chat message display (maybe will add it back with a CSS-only solution later) because it caused all chat messages to switch their `alternate` classname when 1) a message is deleted or 2) a new message comes in whilst there are already 512 messages in scrollback. Now it looks like:

![Not-striped screenshot](https://gateway.ipfs.io/ipfs/QmPoPUKMzDdaxg59mEiTQrPfNXUnFUFHBxgwCSBxLpH7Mb)

Which honestly is not that bad :thinking: but I'll see if the stripes can work well using _just_ CSS.