### PR TITLE
build: Enable lodash paths.

### DIFF
--- a/src/utils/mergeIncludedModels.js
+++ b/src/utils/mergeIncludedModels.js
@@ -7,7 +7,7 @@ export default function mergeIncludedModels({ data, meta, included }) {
     meta.included[type].forEach((path) => {
       data.forEach((item) => {
         const id = getPath(item, path);
-        const model = find(included[type], { _id: id });
+        const model = find(included[type], m => m._id === id);
         setPath(item, path, model);
       });
     });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const readFile = require('fs').readFileSync;
 const path = require('path');
 const DefinePlugin = require('webpack').DefinePlugin;
 const ProgressPlugin = require('webpack').ProgressPlugin;
+const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const HtmlPlugin = require('html-webpack-plugin');
 
@@ -38,17 +39,18 @@ const plugins = [
     loadingScreen: () => require('./tasks/utils/renderLoadingScreen')()
   }),
   extractAppCss,
-  new ProgressPlugin()
+  new ProgressPlugin(),
+  new LodashModuleReplacementPlugin({
+    paths: true
+  })
 ];
 
 if (nodeEnv === 'production') {
-  const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
   const LoaderOptionsPlugin = require('webpack').LoaderOptionsPlugin;
   const OccurrenceOrderPlugin = require('webpack').optimize.OccurrenceOrderPlugin;
   const UglifyJsPlugin = require('webpack').optimize.UglifyJsPlugin;
 
   plugins.push(
-    new LodashModuleReplacementPlugin(),
     new OccurrenceOrderPlugin(),
     new LoaderOptionsPlugin({
       minimize: true,


### PR DESCRIPTION
Bit of a follow-up to #512.

We used the lodash dotted path `a.b.c` functionality in
`mergeIncludedModels`, so enable it again in the lodash
webpack plugin.

Also changes one use of `find` with a matcher object to a function.

Also uses the Lodash Webpack plugin everywhere, instead of just in
the production build, so it becomes easier to catch these problems
in development.