### PR TITLE
video: Always render VideoBackdrop regardless of current media source.

### DIFF
--- a/src/components/Video/index.js
+++ b/src/components/Video/index.js
@@ -5,6 +5,7 @@ import screenfull from 'screenfull';
 
 import injectMediaSources from '../../utils/injectMediaSources';
 
+import VideoBackdrop from './VideoBackdrop';
 import VideoProgressBar from './VideoProgressBar';
 import VideoToolbar from './VideoToolbar';
 import MouseMoveCapture from './VideoMouseMoveCapture';
@@ -137,6 +138,7 @@ export default class Video extends React.Component {
         ref={this.refElement}
         className={cx('Video', `Video--${media.sourceType}`, `Video--${size}`)}
       >
+        <VideoBackdrop url={media.thumbnail} />
         {players}
 
         {isFullscreen && (

--- a/src/sources/soundcloud/Player.js
+++ b/src/sources/soundcloud/Player.js
@@ -1,6 +1,5 @@
 import cx from 'classnames';
 import * as React from 'react';
-import VideoBackdrop from '../../components/Video/VideoBackdrop';
 
 import SongInfo from './SongInfo';
 
@@ -83,7 +82,6 @@ export default class SoundCloudPlayer extends React.Component {
 
     return (
       <div className={cx('src-soundcloud-Player', this.props.className)}>
-        <VideoBackdrop url={media.thumbnail} />
         <div className="src-soundcloud-Player-meta">
           <div className="src-soundcloud-Player-info">
             <img

--- a/src/sources/youtube/Player.js
+++ b/src/sources/youtube/Player.js
@@ -1,7 +1,6 @@
 import cx from 'classnames';
 import * as React from 'react';
 
-import VideoBackdrop from '../../components/Video/VideoBackdrop';
 import YouTubePlayerEmbed from './PlayerEmbed';
 
 const YouTubePlayer = ({
@@ -15,14 +14,9 @@ const YouTubePlayer = ({
 }) => {
   const modeClass = `src-youtube-Player--${mode}`;
 
-  let backdrop;
-  if (active && mode !== 'large') {
-    backdrop = <VideoBackdrop url={media.thumbnail} />;
-  }
   // Wrapper span so the backdrop can be full-size…
   return (
     <span hidden={!active}>
-      {backdrop}
       <div className={cx('src-youtube-Player', modeClass, className)}>
         {enabled && (
           <YouTubePlayerEmbed


### PR DESCRIPTION
Using the blurred thumbnail as a background is a very good default, so no reason to make individual sources responsible for it.