### PR TITLE
Update extract-text-webpack-plugin usage.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -99,9 +99,9 @@ module.exports = {
     rules: [
       {
         test: /\.css$/,
-        loader: extractAppCss.extract({
-          fallbackLoader: 'style-loader',
-          loader: [ 'css-loader', 'postcss-loader' ]
+        use: extractAppCss.extract({
+          fallback: 'style-loader',
+          use: [ 'css-loader', 'postcss-loader' ]
         })
       },
       {


### PR DESCRIPTION
Fixes a few warnings when building üWave Web:

```
fallbackLoader option has been deprecated - replace with "fallback"
loader option has been deprecated - replace with "use"
```