### PR TITLE
request: Resolve HTTP requests with return value from onComplete

### DIFF
--- a/src/store/request.js
+++ b/src/store/request.js
@@ -104,11 +104,12 @@ export default function middleware(middlewareOptions = {}) {
       .then(rejectNonOK)
       .then(res => res.json())
       .then((res) => {
+        let responseValue = res;
         if (onComplete) {
-          dispatch(onComplete(res));
+          responseValue = dispatch(onComplete(responseValue));
         }
         dispatch(requestComplete(res, completedMeta));
-        return res;
+        return responseValue;
       })
       .catch((error) => {
         if (onError) {


### PR DESCRIPTION
Fixes #554

The favorite action for new playlists relied on the playlist object
being returned from `createPlaylist`, but it was instead returning
the raw HTTP response. This patch uses the result from request
`onComplete` handlers if possible.