### PR TITLE
video: Use React to generate SVG video backdrop.

### DIFF
--- a/src/components/Video/VideoBackdrop.js
+++ b/src/components/Video/VideoBackdrop.js
@@ -1,53 +1,68 @@
 import * as React from 'react';
 
-const supportsBlur = typeof window !== 'undefined' && window.CSS &&
-  (CSS.supports('filter', 'blur(1em)') || CSS.supports('-webkit-filter', 'blur(1em)'));
+/**
+ * Check if the browser supports the CSS `blur()` filter.
+ */
+function supportsBlur() {
+  // Be conservative if we're not in the browser.
+  if (typeof window === 'undefined' || !window.CSS) {
+    return false;
+  }
 
-const makeSvgString = (url) => {
-  const width = 800;
-  const height = 480;
-  const blur = 20;
-  return `
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-      version="1.1"
-      viewBox="0 0 ${width} ${height}"
-    >
+  return (
+    CSS.supports('filter', 'blur(1em)') ||
+    CSS.supports('-webkit-filter', 'blur(1em)')
+  );
+}
+
+/**
+ * A Video backdrop, blurred using the CSS `blur()` filter.
+ */
+const CSSVideoBackdrop = ({ url }) => (
+  <img
+    className="VideoBackdrop VideoBackdrop--blurry"
+    src={url}
+    alt=""
+  />
+);
+
+CSSVideoBackdrop.propTypes = {
+  url: React.PropTypes.string.isRequired
+};
+
+const svgWidth = 800;
+const svgHeight = 480;
+const svgBlur = 20;
+
+/**
+ * A Video backdrop, blurred using an SVG filter.
+ */
+const SVGVideoBackdrop = ({ url }) => (
+  <div className="VideoBackdrop VideoBackdrop--svg">
+    <svg viewBox={`0 0 ${svgWidth} ${svgHeight}`}>
       <defs>
         <filter id="blur">
-          <feGaussianBlur stdDeviation="${blur} ${blur}" result="blur" />
+          <feGaussianBlur stdDeviation={`${svgBlur} ${svgBlur}`} result="blur" />
         </filter>
       </defs>
       <image
-        xlink:href="${url}"
-        x="${blur * -3}"
-        y="${blur * -3}"
+        xlinkHref={url}
+        x={svgBlur * -3}
+        y={svgBlur * -3}
         filter="url(#blur)"
-        width="${width + (blur * 6)}"
-        height="${height + (blur * 6)}"
+        width={svgWidth + (svgBlur * 6)}
+        height={svgHeight + (svgBlur * 6)}
       />
     </svg>
-  `.replace(/\s+/g, ' ').trim();
-};
+  </div>
+);
 
-const VideoBackdrop = ({ url }) => {
-  if (!supportsBlur) {
-    const svg = { __html: makeSvgString(url) };
-    /* eslint-disable react/no-danger */
-    return (
-      <div
-        className="VideoBackdrop VideoBackdrop--svg"
-        dangerouslySetInnerHTML={svg}
-      />
-    );
-    /* eslint-enable react/no-danger */
-  }
-  return <img className="VideoBackdrop VideoBackdrop--blurry" src={url} alt="" />;
-};
-
-VideoBackdrop.propTypes = {
+SVGVideoBackdrop.propTypes = {
   url: React.PropTypes.string.isRequired
 };
+
+// If the browser supports the CSS `blur()` filter, we can use the <img>-style
+// backdrop. Otherwise, fall back to the SVG backdrop.
+const VideoBackdrop = supportsBlur() ? CSSVideoBackdrop : SVGVideoBackdrop;
 
 export default VideoBackdrop;


### PR DESCRIPTION
Removes our only use of `dangerouslySetInnerHtml`.