### PR TITLE
Use babel-preset-env and .babelrc.js

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,28 +1,5 @@
 {
-  "presets": [
-    ["env", {
-      "modules": false
-    }],
-    "stage-2",
-    "react"
-  ],
-  "plugins": [
-    "transform-decorators-legacy",
-    "transform-export-extensions",
-    ["transform-runtime", { "polyfill": false }]
-  ],
-  "env": {
-    "development": {
-      "plugins": [
-        "react-hot-loader/babel"
-      ]
-    },
-    "production": {
-      "plugins": [
-        "transform-react-constant-elements",
-        "transform-react-inline-elements",
-        ["transform-react-remove-prop-types", { "mode": "wrap" }]
-      ]
-    }
-  }
+  // Defer to .babelrc.js.
+  // TODO remove this file when Babel 7 is released.
+  "presets": ["./.babelrc.js"]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,7 @@
 {
   "presets": [
-    ["latest", {
-      "es2015": { "modules": false }
+    ["env", {
+      "modules": false
     }],
     "stage-2",
     "react"

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,4 +1,6 @@
-module.exports = {
+const env = process.env.BABEL_ENV || process.env.NODE_ENV || 'development';
+
+const preset = {
   presets: [
     ['env', {
       modules: false
@@ -10,19 +12,19 @@ module.exports = {
     'transform-decorators-legacy',
     'transform-export-extensions',
     ['transform-runtime', { polyfill: false }]
-  ],
-  env: {
-    development: {
-      plugins: [
-        'react-hot-loader/babel'
-      ]
-    },
-    production: {
-      plugins: [
-        'transform-react-constant-elements',
-        'transform-react-inline-elements',
-        ['transform-react-remove-prop-types', { mode: 'wrap' }]
-      ]
-    }
-  }
+  ]
 };
+
+if (env === 'development') {
+  preset.plugins.push('react-hot-loader/babel');
+}
+
+if (env === 'production') {
+  preset.plugins.push(
+    'transform-react-constant-elements',
+    'transform-react-inline-elements',
+    ['transform-react-remove-prop-types', { mode: 'wrap' }]
+  );
+}
+
+module.exports = preset;

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,0 +1,28 @@
+module.exports = {
+  presets: [
+    ['env', {
+      modules: false
+    }],
+    'stage-2',
+    'react'
+  ],
+  plugins: [
+    'transform-decorators-legacy',
+    'transform-export-extensions',
+    ['transform-runtime', { polyfill: false }]
+  ],
+  env: {
+    development: {
+      plugins: [
+        'react-hot-loader/babel'
+      ]
+    },
+    production: {
+      plugins: [
+        'transform-react-constant-elements',
+        'transform-react-inline-elements',
+        ['transform-react-remove-prop-types', { mode: 'wrap' }]
+      ]
+    }
+  }
+};

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -13,7 +13,12 @@ const preset = {
   presets: [
     ['env', {
       modules: false,
-      targets
+      loose: env === 'production',
+      targets,
+      // Force enable the classes transform, react-hot-loader doesn't
+      // appear to work well with native classes + arrow functions in
+      // transpiled class properties.
+      include: ['transform-es2015-classes']
     }],
     'stage-2',
     'react'

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,9 +1,19 @@
 const env = process.env.BABEL_ENV || process.env.NODE_ENV || 'development';
+const browsers = process.env.BROWSERSLIST;
+
+const targets = {};
+if (browsers) {
+  targets.browsers = browsers;
+}
+if (env === 'production') {
+  targets.uglify = true;
+}
 
 const preset = {
   presets: [
     ['env', {
-      modules: false
+      modules: false,
+      targets
     }],
     'stage-2',
     'react'

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,3 @@ script:
 
 after_script:
   - greenkeeper-lockfile-upload
-
-cache:
-  directories:
-    - "node_modules"

--- a/package-lock.json
+++ b/package-lock.json
@@ -776,34 +776,16 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true
     },
-    "babel-preset-es2015": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
-      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
-      "dev": true
-    },
-    "babel-preset-es2016": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2016/-/babel-preset-es2016-6.24.1.tgz",
-      "integrity": "sha1-+QC/k+LrwNJ235uKtZck6/2Vn4s=",
-      "dev": true
-    },
-    "babel-preset-es2017": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2017/-/babel-preset-es2017-6.24.1.tgz",
-      "integrity": "sha1-WXvq37n38gi8/YoS6bKym4svFNE=",
+    "babel-preset-env": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.5.2.tgz",
+      "integrity": "sha1-zUrpCm6Utwn5c3SzPl+LmDVWre8=",
       "dev": true
     },
     "babel-preset-flow": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
       "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
-      "dev": true
-    },
-    "babel-preset-latest": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-latest/-/babel-preset-latest-6.24.1.tgz",
-      "integrity": "sha1-Z33gaRVKdIXC0lxXfAL2JLhbheg=",
       "dev": true
     },
     "babel-preset-react": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "babel-plugin-transform-react-inline-elements": "^6.22.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.0",
     "babel-plugin-transform-runtime": "^6.22.0",
-    "babel-preset-latest": "^6.22.0",
+    "babel-preset-env": "^1.5.2",
     "babel-preset-react": "^6.22.0",
     "babel-preset-stage-2": "^6.22.0",
     "babel-register": "^6.22.0",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -7,7 +7,13 @@ module.exports = (options) => {
       'postcss-url': {
         url: 'rebase'
       },
-      'postcss-cssnext': {},
+      'postcss-cssnext': {
+        features: {
+          // Force enable custom properties so they can be used in color()
+          // function calls even if the target browser does not support them.
+          customProperties: true
+        }
+      },
       cssnano: env === 'production' && {
         autoprefixer: false
       }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -197,7 +197,11 @@ module.exports = {
           query: {
             babelrc: false,
             presets: [
-              [ 'latest', { es2015: { modules: false } } ]
+              [ 'env', {
+                modules: false,
+                loose: true,
+                targets: { uglify: true }
+              } ]
             ]
           }
         }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,3 @@
-const readFile = require('fs').readFileSync;
 const path = require('path');
 const escapeStringRegExp = require('escape-string-regexp');
 const DefinePlugin = require('webpack').DefinePlugin;
@@ -89,16 +88,6 @@ if (nodeEnv === 'production') {
     }),
     new ModuleConcatenationPlugin()
   );
-}
-
-// Workaround: Seems like babel-loader doesn't pick up on the environment type
-// correctly, so we manually load the .babelrc and add the production plugins
-// if necessary.
-const babelrc = JSON.parse(
-  readFile(path.join(__dirname, '.babelrc'), 'utf8')
-);
-if (nodeEnv === 'production') {
-  babelrc.plugins = babelrc.plugins.concat(babelrc.env.production.plugins);
 }
 
 const context = path.join(__dirname, 'src');
@@ -211,7 +200,7 @@ module.exports = {
         test: /\.js$/,
         exclude: /node_modules/,
         use: [
-          { loader: 'babel-loader', query: babelrc },
+          'babel-loader',
           nodeEnv !== 'production' && {
             loader: 'eslint-loader',
             query: { cache: true }


### PR DESCRIPTION
`babel-preset-latest` will be deprecated in favour of `babel-preset-env`. This PR switches to `-env` and prepares for a few more upcoming Babel changes, and takes the opportunity to add some `babel-preset-env` related features to the build.

Babel 7 will probably support .babelrc.js files, for now I pointed our `.babelrc` to use `.babelrc.js` as a preset. It doesn't use Babel's `env` option anymore but instead checks the target environment manually.
This removes Babel hacks from `webpack.config.js`.

You can now specify a `BROWSERSLIST` environment var in development mode to enable only the transforms you need in your dev environment, to speed up compilation. Eg:

```
BROWSERLIST="firefox 51" npm start
```

Will not compile `class`es, for example. It also applies to CSS. However for CSS, variables are always compiled. The `color()` function isn't supported anywhere yet AFAIK and to be polyfilled it needs to know what values variables have.