### PR TITLE
Remove side effects from componentWillMount

### DIFF
--- a/src/components/ReCaptcha/index.js
+++ b/src/components/ReCaptcha/index.js
@@ -15,13 +15,21 @@ if (typeof window !== 'undefined') {
   };
 }
 
-export default class ReCaptcha extends React.Component {
-  state = { grecaptcha: window.grecaptcha };
+function loadReCaptcha(cb) {
+  loadScript(`${GRECAPTCHA_API}?onload=${onloadCallbackName}&render=explicit`);
+  onloadCallbacks.push(cb);
+}
 
-  componentWillMount() {
+export default class ReCaptcha extends React.Component {
+  state = {
+    grecaptcha: window.grecaptcha
+  };
+
+  componentDidMount() {
     if (!this.state.grecaptcha) {
-      loadScript(`${GRECAPTCHA_API}?onload=${onloadCallbackName}&render=explicit`);
-      onloadCallbacks.push(grecaptcha => this.setState({ grecaptcha }));
+      loadReCaptcha((grecaptcha) => {
+        this.setState({ grecaptcha });
+      });
     }
   }
 

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -58,6 +58,7 @@ export default class AppContainer extends React.Component {
     };
   }
 
+  // TODO move this to constructor?
   componentWillMount() {
     // Start the clock! üWave stores the current time in the application state
     // primarily to make sure that different timers in the UI update simultaneously.

--- a/src/utils/timed.js
+++ b/src/utils/timed.js
@@ -1,19 +1,23 @@
 import * as React from 'react';
+import wrapDisplayName from 'recompose/wrapDisplayName';
 import { currentTimeSelector } from '../selectors/timeSelectors';
 
 export default function () {
   return (Component) => {
     class Timed extends React.Component {
+      static displayName = wrapDisplayName(Component, 'Timed');
+
       static contextTypes = {
         store: React.PropTypes.object.isRequired,
         timerCallbacks: React.PropTypes.arrayOf(React.PropTypes.func).isRequired
       };
 
-      state = {};
+      state = {
+        currentTime: this.getCurrentTime()
+      };
 
-      componentWillMount() {
+      componentDidMount() {
         this.context.timerCallbacks.push(this.tick);
-        this.tick();
       }
 
       componentWillUnmount() {
@@ -24,9 +28,13 @@ export default function () {
         }
       }
 
+      getCurrentTime() {
+        return currentTimeSelector(this.context.store.getState());
+      }
+
       tick = () => {
         this.setState({
-          currentTime: currentTimeSelector(this.context.store.getState())
+          currentTime: this.getCurrentTime()
         });
       };
 


### PR DESCRIPTION
This way only components that are actually in the DOM will be able to have side effects.
While I don't think we'll want to support server side rendering explicitly (since it's pretty useless for a heavily interactive application like this), this way we'll at least not fire requests or start timers if you _do_ try to render it on the server.

See https://github.com/facebook/react/issues/7671