### PR TITLE
Show cached playlist items when switching playlists instead of waiting for them to reload.

### DIFF
--- a/src/components/PlaylistManager/Panel/index.js
+++ b/src/components/PlaylistManager/Panel/index.js
@@ -69,9 +69,12 @@ const PlaylistPanel = (props) => {
       </div>
     );
   } else {
+    // This has a `key` to force the media list to remount when the user
+    // switches between playlists, so eg. the scroll position resets properly.
     list = (
       <MediaList
         className="PlaylistPanel-media"
+        key={playlist._id}
         size={media.length}
         media={media}
         rowComponent={isFiltered ? PlainItemRow : PlaylistItemRow}

--- a/src/components/PlaylistManager/Panel/index.js
+++ b/src/components/PlaylistManager/Panel/index.js
@@ -69,12 +69,9 @@ const PlaylistPanel = (props) => {
       </div>
     );
   } else {
-    // This has a `key` to force the media list to remount when the user
-    // switches between playlists, so eg. the scroll position resets properly.
     list = (
       <MediaList
         className="PlaylistPanel-media"
-        key={playlist._id}
         size={media.length}
         media={media}
         rowComponent={isFiltered ? PlainItemRow : PlaylistItemRow}

--- a/src/components/PlaylistManager/index.js
+++ b/src/components/PlaylistManager/index.js
@@ -40,7 +40,15 @@ export default class PlaylistManager extends React.Component {
     } else if (showSearchResults) {
       panel = <SearchResults />;
     } else if (selectedPlaylist) {
-      panel = <PlaylistPanel />;
+      // HACK Give this a key so it's remounted when you switch playlists.
+      // This is because there is some statefulness down the tree, especially
+      // in playlist filters and scroll position.
+      // By forcing a remount using a key we throw away all state and keep it
+      // consistent.
+      // TODO To *actually* fix playlist filters bleeding across playlist lines,
+      // we should reset the playlist filter state alone somehow when the
+      // selected playlist changes.
+      panel = <PlaylistPanel key={selectedPlaylist._id} />;
     } else {
       panel = <PlaylistPanelEmpty />;
     }

--- a/src/reducers/playlists.js
+++ b/src/reducers/playlists.js
@@ -206,11 +206,19 @@ export default function reduce(state = initialState, action = {}) {
       selectedPlaylistID: null
     };
 
-  case LOAD_PLAYLIST_START:
+  case LOAD_PLAYLIST_START: {
     if (meta.page !== 0 || state.playlistItems[payload.playlistID]) {
       return state;
     }
-    return setPlaylistLoading(state, payload.playlistID);
+
+    // Reserve space in the playlistItems array.
+    return updatePlaylistItems(
+      state,
+      payload.playlistID,
+      (items, playlist) => fill(Array(playlist.size), null)
+        .map((item, i) => items[i] || item)
+    );
+  }
   case LOAD_PLAYLIST_COMPLETE:
     if (error) {
       return setPlaylistLoading(state, meta.playlistID, false);

--- a/src/reducers/playlists.js
+++ b/src/reducers/playlists.js
@@ -207,7 +207,7 @@ export default function reduce(state = initialState, action = {}) {
     };
 
   case LOAD_PLAYLIST_START:
-    if (meta.page !== 0) {
+    if (meta.page !== 0 || state.playlistItems[payload.playlistID]) {
       return state;
     }
     return setPlaylistLoading(state, payload.playlistID);


### PR DESCRIPTION
Makes switching playlists a bit nicer.

Playlists that are still loading now don't show a big loading spinner, but show the media rows it will have, similar to what unloaded pages already look like while scrolling down.

Also drive-by fixes #519.