### PR TITLE
Use `import` everywhere

### DIFF
--- a/src/MuiTheme.js
+++ b/src/MuiTheme.js
@@ -1,6 +1,6 @@
 import * as Colors from 'material-ui/styles/colors';
 import * as ColorManipulator from 'material-ui/utils/colorManipulator';
-import * as Spacing from 'material-ui/styles/spacing';
+import Spacing from 'material-ui/styles/spacing';
 
 export default {
   spacing: Spacing,

--- a/src/Uwave.js
+++ b/src/Uwave.js
@@ -6,6 +6,8 @@ import 'whatwg-fetch';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+import { AppContainer as HotContainer } from 'react-hot-loader';
+import injectTapEventPlugin from 'react-tap-event-plugin';
 import AppContainer from './containers/App';
 import { get as readSession } from './utils/Session';
 import configureStore from './store/configureStore';
@@ -18,7 +20,7 @@ import './utils/commands';
 // A Material-UI dependency, removes the delay from tap events on some mobile
 // devices. üWave currently isn't compatible with mobile yet, but material-ui
 // wants this!
-require('react-tap-event-plugin')();
+injectTapEventPlugin();
 
 export default class Uwave {
   options = {};
@@ -36,7 +38,6 @@ export default class Uwave {
     Object.assign(this, api.actions);
 
     if (module.hot) {
-      const HotContainer = require('react-hot-loader').AppContainer;
       this._getComponent = this.getComponent;
       this.getComponent = () => (
         <HotContainer>{this._getComponent()}</HotContainer>

--- a/src/actions/ChatActionCreators.js
+++ b/src/actions/ChatActionCreators.js
@@ -40,6 +40,8 @@ import {
   hasMention
 } from '../utils/chatMentions';
 
+import mentionSoundUrl from '../../assets/audio/mention.mp3';
+
 export function receiveMotd(text) {
   return {
     type: RECEIVE_MOTD,
@@ -114,7 +116,6 @@ export function inputMessage(text) {
 
 let mentionSound;
 if (typeof window !== 'undefined' && window.Audio) {
-  const mentionSoundUrl = require('../../assets/audio/mention.mp3');
   mentionSound = new window.Audio(mentionSoundUrl);
 }
 function playMentionSound() {

--- a/src/actions/LoginActionCreators.js
+++ b/src/actions/LoginActionCreators.js
@@ -1,3 +1,4 @@
+import createDebug from 'debug';
 import {
   INIT_STATE,
   SOCKET_CONNECT,
@@ -28,7 +29,7 @@ import { setVoteStats } from './VoteActionCreators';
 import { setWaitList } from './WaitlistActionCreators';
 import { currentUserSelector, tokenSelector } from '../selectors/userSelectors';
 
-const debug = require('debug')('uwave:actions:login');
+const debug = createDebug('uwave:actions:login');
 
 export function socketConnect() {
   return { type: SOCKET_CONNECT };

--- a/src/sources/soundcloud/Player.js
+++ b/src/sources/soundcloud/Player.js
@@ -1,10 +1,10 @@
 import cx from 'classnames';
 import * as React from 'react';
-
+import createDebug from 'debug';
 import SongInfo from './SongInfo';
 import soundcloudLogo from '../../../assets/img/soundcloud-inline.png';
 
-const debug = require('debug')('uwave:component:video:soundcloud');
+const debug = createDebug('uwave:component:video:soundcloud');
 
 const CLIENT_ID = '9d883cdd4c3c54c6dddda2a5b3a11200';
 

--- a/src/sources/youtube/PlayerEmbed.js
+++ b/src/sources/youtube/PlayerEmbed.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import YouTube from 'react-youtube';
+import createDebug from 'debug';
 
-const debug = require('debug')('uwave:component:video:youtube');
+const debug = createDebug('uwave:component:video:youtube');
 
 export default class YouTubePlayerEmbed extends React.Component {
   static propTypes = {

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -1,6 +1,6 @@
 import { applyMiddleware, combineReducers, compose, createStore } from 'redux';
 import thunk from 'redux-thunk';
-
+import createLogger from 'redux-logger';
 import persistSettings from './persistSettings';
 import webApiRequest from './request';
 import webApiSocket from './socket';
@@ -29,7 +29,7 @@ export default function createUwaveStore(initialState = {}, options = {}) {
     // Redux-Logger logs state changes to the console, including the
     // Before-state, the Action object, and the After-state. Invaluable for
     // debugging :)
-    enableLogging && require('redux-logger')()
+    enableLogging && createLogger()
   ].filter(Boolean);
 
   const store = createStore(
@@ -56,9 +56,10 @@ export default function createUwaveStore(initialState = {}, options = {}) {
     // changed. See /tasks/watch.js for more on Hot Reloading!
     // This is only used when debugging, not in a deployed app.
     module.hot.accept('../reducers', () => {
-      store.replaceReducer(combineReducers(
-        require('../reducers')
-      ));
+      store.replaceReducer(combineReducers({
+        ...reducers,
+        sources: createSourcesReducer(options)
+      }));
     });
   }
 

--- a/src/store/socket.js
+++ b/src/store/socket.js
@@ -1,3 +1,4 @@
+import createDebug from 'debug';
 import WebSocket from '../utils/ReconnectingWebSocket';
 
 import {
@@ -40,7 +41,7 @@ import {
 } from '../actions/WaitlistActionCreators';
 import { favorited, receiveVote } from '../actions/VoteActionCreators';
 
-const debug = require('debug')('uwave:websocket');
+const debug = createDebug('uwave:websocket');
 
 function defaultUrl() {
   const port = location.port || (location.protocol === 'https:' ? 443 : 80);

--- a/src/utils/ChatCommands.js
+++ b/src/utils/ChatCommands.js
@@ -1,6 +1,7 @@
 import find from 'array-find';
+import createDebug from 'debug';
 
-const debug = require('debug')('uwave:chat-commands');
+const debug = createDebug('uwave:chat-commands');
 
 const commands = {};
 

--- a/test/common.js
+++ b/test/common.js
@@ -2,3 +2,13 @@ require('babel-register')({
   plugins: [ 'transform-es2015-modules-commonjs' ]
 });
 require('yamlify/register');
+
+// Mock an asset like Webpack's file-loader.
+function mockAsset(modulePath) {
+  const path = require.resolve(modulePath);
+  require.cache[path] = {
+    exports: path
+  };
+}
+
+mockAsset('../assets/audio/mention.mp3');


### PR DESCRIPTION
Removes the last few `require` calls from the üWave source.

Earlier some `require` calls were just leftovers, and the mention sound was included through a `require` call inside an `if` so it won't be included when running tests. Now I manually insert a JS module into the require cache, so it uses that instead when running tests.