### PR TITLE
Fix some warning output in Webpack build

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "devDependencies": {
     "autoprefixer": "^6.7.2",
     "babel-eslint": "^7.1.1",
-    "babel-loader": "^6.2.10",
+    "babel-loader": "^7.0.0-beta.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-export-extensions": "^6.22.0",
     "babel-plugin-transform-react-constant-elements": "^6.22.0",

--- a/tasks/utils/renderLoadingScreen.js
+++ b/tasks/utils/renderLoadingScreen.js
@@ -10,6 +10,8 @@ module.exports = function renderLoadingScreen() {
   const muiTheme = require('../../src/MuiTheme').default;
   /* eslint-enable import/no-unresolved */
 
+  muiTheme.userAgent = 'all';
+
   return renderToStaticMarkup(
     React.createElement(
       MuiThemeProvider,

--- a/tasks/utils/renderMarkdown.js
+++ b/tasks/utils/renderMarkdown.js
@@ -7,6 +7,7 @@ const getMuiTheme = require('material-ui/styles/getMuiTheme').default;
 module.exports = function renderMarkdown(source) {
   const Markdown = require('../../src/components/Markdown').default;
   const muiTheme = require('../../src/MuiTheme').default;
+  muiTheme.userAgent = 'all';
 
   return renderToStaticMarkup(
     React.createElement(


### PR DESCRIPTION
- Update Babel loader to the beta, which uses an up-to-date version of `loader-utils`.
- Set the userAgent used for build-time rendering of markdown and the loading spinner to "all" (used by material-ui for vendor prefixing CSS).

This way the webpack output is 100% clean