### PR TITLE
build: Add `jsnext:main` to entry point fields.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -208,5 +208,13 @@ module.exports = {
         ]
       }
     ].filter(Boolean)
+  },
+  resolve: {
+    mainFields: [
+      'browser',
+      'module',
+      'jsnext:main',
+      'main'
+    ]
   }
 };


### PR DESCRIPTION
A bunch of packages still use the older `jsnext:main` convention to list ES-modules entry points in their `package.json` files.