### PR TITLE
Use a material-ui-like loading spinner.

### DIFF
--- a/src/components/Loader/CircularProgress.css
+++ b/src/components/Loader/CircularProgress.css
@@ -1,0 +1,66 @@
+@import "../../vars.css";
+
+:root {
+  --loader-thickness: 3.6px;
+  --loader-thickness-tiny: 10px;
+  --loader-duration: 1700ms;
+  --pi: 3.1416;
+}
+
+@keyframes rotate-progress-circle {
+  0%   { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+@keyframes scale-progress-circle {
+  8% {
+    stroke-dasharray: 1, calc((100% - var(--loader-thickness)) * var(--pi));
+    stroke-dashoffset: 0;
+  }
+  50%, 58% {
+    stroke-dasharray: calc((65% - var(--loader-thickness)) * var(--pi)), calc((100% - var(--loader-thickness)) * var(--pi));
+    stroke-dashoffset: calc((25% - var(--loader-thickness)) * -var(--pi));
+  }
+  100% {
+    stroke-dasharray: calc((65% - var(--loader-thickness)) * var(--pi)), calc((100% - var(--loader-thickness)) * var(--pi));
+    stroke-dashoffset: calc((99% - var(--loader-thickness)) * -var(--pi));
+  }
+}
+@keyframes scale-progress-circle-tiny {
+  8% {
+    stroke-dasharray: 1, calc((100% - var(--loader-thickness-tiny)) * var(--pi));
+    stroke-dashoffset: 0;
+  }
+  50%, 58% {
+    stroke-dasharray: calc((65% - var(--loader-thickness-tiny)) * var(--pi)), calc((100% - var(--loader-thickness-tiny)) * var(--pi));
+    stroke-dashoffset: calc((25% - var(--loader-thickness-tiny)) * -var(--pi));
+  }
+  100% {
+    stroke-dasharray: calc((65% - var(--loader-thickness-tiny)) * var(--pi)), calc((100% - var(--loader-thickness-tiny)) * var(--pi));
+    stroke-dashoffset: calc((99% - var(--loader-thickness-tiny)) * -var(--pi));
+  }
+}
+
+.MuiCircularProgress {
+  display: inline-block;
+  color: var(--highlight-color);
+  width: 100%;
+  height: 100%;
+
+  &-svg {
+    /* The main animation is loop 4 times. */
+    animation: rotate-progress-circle calc(var(--loader-duration) * (4 / 3)) linear infinite;
+  }
+
+  &-circle {
+    stroke-dasharray: 1, calc((100% - 3px) * 3.141);
+    stroke-dashoffset: 0%;
+    stroke: currentColor;
+    stroke-linecap: round;
+    transition: all var(--loader-duration) cubic-bezier(0.4, 0.0, 0.2, 1);
+    animation: scale-progress-circle var(--loader-duration) cubic-bezier(0.4, 0.0, 0.2, 1) infinite;
+  }
+
+  &--tiny &-circle {
+    animation-name: scale-progress-circle-tiny;
+  }
+}

--- a/src/components/Loader/CircularProgress.js
+++ b/src/components/Loader/CircularProgress.js
@@ -1,0 +1,38 @@
+/**
+ * The CircularProgress component from material-ui v1.0. We use this one instead
+ * of the one from v0.x, because this one is CSS-only!
+ *
+ * Adapted from:
+ * https://github.com/callemall/material-ui/blob/next/src/Progress/CircularProgress.js
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+
+const THICKNESS = {
+  large: 3.6,
+  tiny: 10
+};
+
+const CircularProgress = ({ size = 'large' }) => (
+  <div className={cx('MuiCircularProgress', `MuiCircularProgress--${size}`)}>
+    <svg className="MuiCircularProgress-svg" viewBox="0 0 100 100">
+      <circle
+        className="MuiCircularProgress-circle"
+        cx={50}
+        cy={50}
+        r={50 - (THICKNESS[size] / 2)}
+        fill="none"
+        strokeWidth={THICKNESS[size]}
+        strokeMiterlimit="20"
+      />
+    </svg>
+  </div>
+);
+
+CircularProgress.propTypes = {
+  size: PropTypes.string
+};
+
+export default CircularProgress;

--- a/src/components/Loader/index.css
+++ b/src/components/Loader/index.css
@@ -1,35 +1,6 @@
 @import "../../vars.css";
+@import "./CircularProgress.css";
 
 .Loader {
   position: relative;
-}
-
-.Spinner {
-  border-style: solid;
-  border-color: color(var(--text-color) alpha(0.2));
-  border-left-color: var(--text-color);
-  animation: anim-loader-spin 1.1s infinite linear;
-
-  border-radius: 50%;
-  width: 100%;
-
-  &--tiny {
-    border-width: 3px;
-    /* Hack for squares! padding-bottom is computed according to
-     * parent element width. */
-    padding-bottom: calc(100% - 6px);
-  }
-  &--large {
-    border-width: 1.1em;
-    padding-bottom: calc(100% - 2.2em);
-  }
-}
-
-@keyframes anim-loader-spin {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
 }

--- a/src/components/Loader/index.js
+++ b/src/components/Loader/index.js
@@ -1,10 +1,11 @@
 import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
+import CircularProgress from './CircularProgress';
 
 const Loader = ({ className, size }) => (
   <div className={cx('Loader', className)}>
-    <div className={cx('Spinner', `Spinner--${size}`)} />
+    <CircularProgress size={size} />
   </div>
 );
 


### PR DESCRIPTION
Like this:

![](http://i.imgur.com/lnME8yJ.png)

This spinner was adapted from material-ui@v1.x's CircularProgress. We use material-ui@v0.x atm but its CircularProgress requires javascript for its animation, and the one in v1.x is CSS-only. That's useful because we show the spinner on the loading screen before the JS is loaded in.