### PR TITLE
Default to `https://sigil.u-wave.net` avatars.

### DIFF
--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -6,7 +6,7 @@ const Avatar = ({ className, user }) => (
   <div className={cx('Avatar', className)}>
     <img
       className="Avatar-image"
-      src={user.avatar || `https://sigil.cupcake.io/uwave-${encodeURIComponent(user._id)}`}
+      src={user.avatar || `https://sigil.u-wave.net/${encodeURIComponent(user._id)}`}
       alt={user.username}
     />
   </div>


### PR DESCRIPTION
It's the same thing as sigil.cupcake.io but with an üWave name on it.