### PR TITLE
Truncate long song names in SoundCloud card, fixes #407.

### DIFF
--- a/src/sources/soundcloud/Player.css
+++ b/src/sources/soundcloud/Player.css
@@ -18,6 +18,7 @@
   }
 
   &-info {
+    display: flex;
     margin-bottom: var(--sc-margins);
   }
 
@@ -26,7 +27,10 @@
     width: 100px;
     height: 100px;
     margin-right: var(--sc-margins);
-    float: left;
+  }
+
+  &-links {
+    width: calc(100% - 100px - var(--sc-margins));
   }
 
   &-permalink {

--- a/src/sources/soundcloud/Player.js
+++ b/src/sources/soundcloud/Player.js
@@ -104,7 +104,7 @@ export default class SoundCloudPlayer extends React.Component {
             rel="noopener noreferrer"
             className="src-soundcloud-Player-permalink"
           >
-            View on
+            View on{' '}
             <img
               src={soundcloudLogo}
               alt="SoundCloud"

--- a/src/sources/soundcloud/Player.js
+++ b/src/sources/soundcloud/Player.js
@@ -9,8 +9,6 @@ const debug = createDebug('uwave:component:video:soundcloud');
 
 const CLIENT_ID = '9d883cdd4c3c54c6dddda2a5b3a11200';
 
-const clearStyle = { clear: 'both' };
-
 export default class SoundCloudPlayer extends React.Component {
   static propTypes = {
     className: PropTypes.string,
@@ -91,13 +89,14 @@ export default class SoundCloudPlayer extends React.Component {
               src={media.thumbnail}
               alt=""
             />
-            <SongInfo
-              artist={sourceData.username}
-              title={sourceData.fullTitle}
-              artistUrl={sourceData.artistUrl}
-              trackUrl={sourceData.permalinkUrl}
-            />
-            <div style={clearStyle} />
+            <div className="src-soundcloud-Player-links">
+              <SongInfo
+                artist={sourceData.username}
+                title={sourceData.fullTitle}
+                artistUrl={sourceData.artistUrl}
+                trackUrl={sourceData.permalinkUrl}
+              />
+            </div>
           </div>
           <a
             href={sourceData.permalinkUrl}

--- a/src/sources/soundcloud/SongInfo.css
+++ b/src/sources/soundcloud/SongInfo.css
@@ -6,6 +6,10 @@
     color: var(--text-color);
     display: block;
     height: 25px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+
     &--track {
       font-weight: bold;
     }

--- a/src/sources/soundcloud/SongInfo.js
+++ b/src/sources/soundcloud/SongInfo.js
@@ -15,6 +15,7 @@ const SongInfo = ({ artist, title, artistUrl, trackUrl }) => (
       target="_blank"
       rel="noopener noreferrer"
       href={artistUrl}
+      title={artist}
     >
       <ArtistIcon style={iconStyles} />
       {artist}
@@ -24,6 +25,7 @@ const SongInfo = ({ artist, title, artistUrl, trackUrl }) => (
       target="_blank"
       rel="noopener noreferrer"
       href={trackUrl}
+      title={title}
     >
       <TitleIcon style={iconStyles} />
       {title}


### PR DESCRIPTION
![New](http://i.imgur.com/2Z9ZDUu.png)

instead of

![Old](http://i.imgur.com/d9q2ofb.png)