### PR TITLE
privacy: Fix logo size.

### DIFF
--- a/src/markdown.css
+++ b/src/markdown.css
@@ -1,4 +1,6 @@
 @import "./vars.css";
+/* Include some of the app base styles.  */
+@import "./components/App/index.css";
 
 body {
   font-family: Open Sans, sans-serif;
@@ -10,4 +12,12 @@ body {
 #app {
   width: 1024px;
   margin: auto;
+}
+
+.Privacy {
+  &-logo {
+    height: 1.25em;
+    margin-right: 0.5em;
+    vertical-align: sub;
+  }
 }

--- a/static/privacy.md
+++ b/static/privacy.md
@@ -1,4 +1,4 @@
-# ![üWave](../assets/img/logo-white.png) Privacy Policy
+# <img src="../assets/img/logo-white.png" alt="üWave" class="Privacy-logo"> Privacy Policy
 
 üWave attempts to store only the bare minimum of data necessary to make the site
 easy to use.


### PR DESCRIPTION
Now the üWave logo fits in better with the header text.