### PR TITLE
Small `serve` task cleanup

### DIFF
--- a/tasks/serve.js
+++ b/tasks/serve.js
@@ -82,6 +82,13 @@ gulp.task('serve', () => {
       serverSideRender: true
     });
 
+    // Delay responding to HTTP requests until the first build is complete.
+    app.use((req, res, next) => {
+      dev.waitUntilValid(() => {
+        next();
+      });
+    });
+
     app.use(createWebClient(uw, {
       apiUrl,
       emoji: emojione.emoji,


### PR DESCRIPTION
This adds the üWave Web Client middleware _before_ the webpack dev middleware, so our middleware will be able to serve the `index.html` and inject config before the dev middleware gets to.