### PR TITLE
build: Show more helpful Redis/Mongo connection errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.3",
+    "explain-error": "^1.0.3",
     "express": "^4.14.1",
     "extract-loader": "^0.1.0",
     "extract-text-webpack-plugin": "^2.0.0-rc.3",


### PR DESCRIPTION
This is especially useful for mongodb because they didn't use to show anything at all if the connection failed, the web api would just not respond