### PR TITLE
Use a unique key for media list rows.

### DIFF
--- a/src/components/MediaList/Row.css
+++ b/src/components/MediaList/Row.css
@@ -62,6 +62,11 @@
   height: 100%;
   position: absolute;
   right: 0;
+  display: none;
+}
+
+.MediaListRow:hover .MediaListRow-actions {
+  display: block;
 }
 
 .MediaListRow--alternate {

--- a/src/components/MediaList/Row.js
+++ b/src/components/MediaList/Row.js
@@ -43,19 +43,9 @@ export default class Row extends React.Component {
     selected: false
   };
 
-  state = { showActions: false };
-
   componentDidMount() {
     this.props.connectDragPreview(getEmptyImage());
   }
-
-  handleMouseEnter = () => {
-    this.setState({ showActions: true });
-  };
-
-  handleMouseLeave = () => {
-    this.setState({ showActions: false });
-  };
 
   handleDoubleClick = () => {
     this.props.onOpenPreviewMediaDialog(this.props.media);
@@ -92,7 +82,6 @@ export default class Row extends React.Component {
       // etc
       onClick
     } = this.props;
-    const { showActions } = this.state;
     const selectedClass = selected ? 'is-selected' : '';
     const loadingClass = media.loading ? 'is-loading' : '';
     const duration = 'start' in media
@@ -123,14 +112,12 @@ export default class Row extends React.Component {
         <div className="MediaListRow-duration">
           {formatDuration(duration)}
         </div>
-        {showActions && (
-          <Actions
-            className={cx('MediaListRow-actions', selectedClass)}
-            selection={selection}
-            media={media}
-            makeActions={makeActions}
-          />
-        )}
+        <Actions
+          className={cx('MediaListRow-actions', selectedClass)}
+          selection={selection}
+          media={media}
+          makeActions={makeActions}
+        />
       </div>
     );
   }

--- a/src/components/MediaList/index.js
+++ b/src/components/MediaList/index.js
@@ -53,7 +53,7 @@ export default class MediaList extends React.Component {
     this.setState({ selection });
   }
 
-  renderRow = (index, key) => {
+  renderRow = (index) => {
     const makeActions = this.props.makeActions;
     const props = this.props.rowProps || {};
     const media = this.props.media[index];
@@ -62,7 +62,7 @@ export default class MediaList extends React.Component {
     if (!media) {
       return (
         <LoadingRow
-          key={key}
+          key={index}
           className="MediaList-row"
           selected={selected}
         />
@@ -72,7 +72,7 @@ export default class MediaList extends React.Component {
     const isAlternate = index % 2 === 0;
     return (
       <MediaRow
-        key={key}
+        key={media ? media._id : index}
         {...props}
         className={cx('MediaList-row', isAlternate && 'MediaListRow--alternate')}
         media={media}

--- a/src/components/RoomHistory/Row.css
+++ b/src/components/RoomHistory/Row.css
@@ -18,15 +18,6 @@
   height: 54px;
   line-height: 54px;
   position: relative;
-  background: var(--media-list-color);
-}
-
-.HistoryRow:nth-child(2n+1) {
-  background: var(--media-list-alternate-color);
-}
-
-.HistoryRow.is-selected {
-  background: color(var(--highlight-color) alpha(* 70%));
 }
 
 .HistoryRow-thumb {


### PR DESCRIPTION
This means the same dom element is used for the same media row as long as it's in view, so when you scroll it's not just the contents being moved.