### PR TITLE
Flatten invalid nested selectors, closes #639

### DIFF
--- a/src/components/App/index.css
+++ b/src/components/App/index.css
@@ -38,31 +38,30 @@ button, input, optgroup, select, textarea {
 
   background: var(--background-color);
   color: var(--text-color);
+}
 
-  &-middle {
-    position: absolute;
-    top: var(--header-height);
-    bottom: var(--footer-height);
-    left: 0;
-    right: 0;
-  }
+.App-middle {
+  position: absolute;
+  top: var(--header-height);
+  bottom: var(--footer-height);
+  left: 0;
+  right: 0;
 }
 
 .AppColumn {
   position: absolute;
   height: 100%;
-
-  &--full {
-    width: 100%;
-  }
-  &--left {
-    width: 75%;
-    left: 0;
-  }
-  &--right {
-    width: 25%;
-    right: 0;
-  }
+}
+.AppColumn--full {
+  width: 100%;
+}
+.AppColumn--left {
+  width: 75%;
+  left: 0;
+}
+.AppColumn--right {
+  width: 25%;
+  right: 0;
 }
 
 .AppRow {
@@ -70,17 +69,16 @@ button, input, optgroup, select, textarea {
   left: 0;
   right: 0;
   clear: both;
-
-  &--top {
-    height: var(--header-height);
-    top: 0;
-  }
-  &--middle {
-    top: var(--header-height);
-    bottom: var(--footer-height);
-  }
-  &--bottom {
-    height: var(--footer-height);
-    bottom: 0;
-  }
+}
+.AppRow--top {
+  height: var(--header-height);
+  top: 0;
+}
+.AppRow--middle {
+  top: var(--header-height);
+  bottom: var(--footer-height);
+}
+.AppRow--bottom {
+  height: var(--footer-height);
+  bottom: 0;
 }

--- a/src/components/Avatar/index.css
+++ b/src/components/Avatar/index.css
@@ -5,9 +5,9 @@
   border-radius: 50%;
   overflow: hidden;
   display: inline-block;
+}
 
-  &-image {
-    width: 100%;
-    height: 100%;
-  }
+.Avatar-image {
+  width: 100%;
+  height: 100%;
 }

--- a/src/components/Chat/ChatMessages.css
+++ b/src/components/Chat/ChatMessages.css
@@ -22,25 +22,24 @@
       background: var(--chat-background-color2);
     }
   }
+}
 
-  &-scrollDown {
-    position: absolute;
-    bottom: 0;
-    text-align: center;
-    width: 100%;
-    height: 55px;
-    pointer-events: none;
-    overflow: hidden;
-  }
+.ChatMessages-scrollDown {
+  position: absolute;
+  bottom: 0;
+  text-align: center;
+  width: 100%;
+  height: 55px;
+  pointer-events: none;
+  overflow: hidden;
+}
 
-  &-scrollDownButton {
-    pointer-events: all;
-    transition: margin-top 140ms ease-in;
-    margin: auto;
-    margin-top: 55px;
-  }
-
-  &-scrollDown.is-visible &-scrollDownButton {
+.ChatMessages-scrollDownButton {
+  pointer-events: all;
+  transition: margin-top 140ms ease-in;
+  margin: auto;
+  margin-top: 55px;
+  @nest .ChatMessages-scrollDown.is-visible & {
     transition: margin-top 140ms ease-out;
     margin-top: 0;
   }

--- a/src/components/Chat/Input/EmojiSuggestion.css
+++ b/src/components/Chat/Input/EmojiSuggestion.css
@@ -1,10 +1,8 @@
-.EmojiSuggestion {
-  &-image {
-    width: 24px;
-    height: 24px;
-    background-size: contain;
-    background-position: center center;
-    background-repeat: no-repeat;
-    display: inline-block;
-  }
+.EmojiSuggestion-image {
+  width: 24px;
+  height: 24px;
+  background-size: contain;
+  background-position: center center;
+  background-repeat: no-repeat;
+  display: inline-block;
 }

--- a/src/components/Chat/Input/index.css
+++ b/src/components/Chat/Input/index.css
@@ -9,26 +9,26 @@
 .ChatInput {
   height: 100%;
   width: 100%;
+}
 
-  &-suggestions {
-    position: absolute;
-    bottom: 100%;
-    width: 100%;
-  }
+.ChatInput-suggestions {
+  position: absolute;
+  bottom: 100%;
+  width: 100%;
+}
 
-  &-input {
-    margin: 15px 15px 16px 15px;
-    height: 28px;
-    width: calc(100% - 32px);
-    padding: 0 6px;
-    border: 1px solid var(--chat-border-color);
-    background: #222222;
-    color: var(--text-color);
-    font-size: 10pt;
+.ChatInput-input {
+  margin: 15px 15px 16px 15px;
+  height: 28px;
+  width: calc(100% - 32px);
+  padding: 0 6px;
+  border: 1px solid var(--chat-border-color);
+  background: #222222;
+  color: var(--text-color);
+  font-size: 10pt;
 
-    &.is-focused {
-      border-color: var(--highlight-color);
-      outline: none;
-    }
+  &.is-focused {
+    border-color: var(--highlight-color);
+    outline: none;
   }
 }

--- a/src/components/Chat/LogMessage.css
+++ b/src/components/Chat/LogMessage.css
@@ -1,6 +1,4 @@
-.ChatMessage--log {
-  & .ChatMessage-content {
-    padding-left: 10px;
-    color: #aaaaaa;
-  }
+.ChatMessage--log .ChatMessage-content {
+  padding-left: 10px;
+  color: #aaaaaa;
 }

--- a/src/components/Chat/Message.css
+++ b/src/components/Chat/Message.css
@@ -6,71 +6,71 @@
   background: var(--chat-background-color);
   min-height: 32px;
   position: relative;
+}
 
-  &--mention {
-    box-shadow: 5px 0px 0px var(--highlight-color) inset;
-  }
+.ChatMessage--mention {
+  box-shadow: 5px 0px 0px var(--highlight-color) inset;
+}
 
-  &-hover {
-    background: var(--chat-background-color);
-    position: absolute;
-    top: 0;
-    right: 0;
-    padding: 0 6px;
-    display: none;
-    font-size: 80%;
-    z-index: 2;
-  }
+.ChatMessage-hover {
+  background: var(--chat-background-color);
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 0 6px;
+  display: none;
+  font-size: 80%;
+  z-index: 2;
+}
 
-  @nest &:hover &-hover {
-    display: block;
-  }
+.ChatMessage:hover .ChatMessage-hover {
+  display: block;
+}
 
-  &-delete {
-    cursor: pointer;
-    color: #b00;
-  }
+.ChatMessage-delete {
+  cursor: pointer;
+  color: #b00;
+}
 
-  &-timestamp {
-    color: color(var(--text-color) blend(#777777 33%));
-  }
+.ChatMessage-timestamp {
+  color: color(var(--text-color) blend(#777777 33%));
+}
 
-  &-avatar {
-    position: absolute;
-    width: 24px;
-    height: 24px;
-    top: 0;
-    left: 12px;
-    margin: 4px 0;
-  }
+.ChatMessage-avatar {
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  top: 0;
+  left: 12px;
+  margin: 4px 0;
+}
 
-  &-content {
-    position: relative;
-    padding-left: 50px;
-    padding-right: 3px;
-    width: 100%;
-    display: inline-block;
-    margin: 6px 0;
-    word-wrap: break-word;
-  }
+.ChatMessage-content {
+  position: relative;
+  padding-left: 50px;
+  padding-right: 3px;
+  width: 100%;
+  display: inline-block;
+  margin: 6px 0;
+  word-wrap: break-word;
+}
 
-  &-cardable {
-    cursor: pointer;
-    padding: 0;
-  }
+.ChatMessage-cardable {
+  cursor: pointer;
+  padding: 0;
+}
 
-  &-username {
-    color: #9ba0a0;
-    font-weight: 600;
-  }
+.ChatMessage-username {
+  color: #9ba0a0;
+  font-weight: 600;
+}
 
-  &-text {
-    margin-left: 5px;
-  }
+.ChatMessage-text {
+  margin-left: 5px;
+}
 
-  &--loading {
-    opacity: 0.7;
-  }
+.ChatMessage--loading {
+  opacity: 0.7;
 }
 
 .ChatMention {

--- a/src/components/Chat/index.css
+++ b/src/components/Chat/index.css
@@ -5,17 +5,16 @@
 @import "./Message.css";
 @import "./Motd.css";
 
-.ChatContainer {
-  &-messages {
-    position: absolute;
-    top: 0;
-    bottom: var(--footer-height);
-    width: 100%;
-  }
-  &-input {
-    position: absolute;
-    bottom: 0;
-    height: var(--footer-height);
-    width: 100%;
-  }
+.ChatContainer-messages {
+  position: absolute;
+  top: 0;
+  bottom: var(--footer-height);
+  width: 100%;
+}
+
+.ChatContainer-input {
+  position: absolute;
+  bottom: 0;
+  height: var(--footer-height);
+  width: 100%;
 }

--- a/src/components/Dialogs/ConfirmDialog/index.css
+++ b/src/components/Dialogs/ConfirmDialog/index.css
@@ -1,14 +1,12 @@
-.ConfirmDialog {
-  &-buttons {
-    display: flex;
-    justify-content: space-between;
-  }
+.ConfirmDialog-buttons {
+  display: flex;
+  justify-content: space-between;
+}
 
-  &-spacer {
-    width: 40px;
-  }
+.ConfirmDialog-spacer {
+  width: 40px;
+}
 
-  &-button {
-    width: 50%;
-  }
+.ConfirmDialog-button {
+  width: 50%;
 }

--- a/src/components/Dialogs/EditMediaDialog/index.css
+++ b/src/components/Dialogs/EditMediaDialog/index.css
@@ -6,25 +6,27 @@
 .EditMediaDialogForm {
   display: flex;
   justify-content: space-between;
-  &-column {
-    width: 50%;
-  }
-  &-separator {
-    /* Pushes columns to the side! */
-  }
+}
+
+.EditMediaDialogForm-column {
+  width: 50%;
+}
+
+.EditMediaDialogForm-separator {
+  /* Pushes columns to the side! */
 }
 
 .EditMediaDialogGroup {
   display: flex;
   justify-content: center;
+}
 
-  &-field {
-    flex-grow: 1;
-  }
+.EditMediaDialogGroup-field {
+  flex-grow: 1;
+}
 
-  &-label {
-    line-height: 50px;
-    white-space: nowrap;
-    padding: 0 20px;
-  }
+.EditMediaDialogGroup-label {
+  line-height: 50px;
+  white-space: nowrap;
+  padding: 0 20px;
 }

--- a/src/components/Dialogs/LoginDialog/LoginForm.css
+++ b/src/components/Dialogs/LoginDialog/LoginForm.css
@@ -1,5 +1,3 @@
-.LoginForm {
-  &-forgot {
-    font-size: 10pt;
-  }
+.LoginForm-forgot {
+  font-size: 10pt;
 }

--- a/src/components/Dialogs/PreviewMediaDialog/index.css
+++ b/src/components/Dialogs/PreviewMediaDialog/index.css
@@ -1,6 +1,4 @@
-.PreviewMediaDialog {
-  &-content {
-    overflow: hidden;
-    position: relative;
-  }
+.PreviewMediaDialog-content {
+  overflow: hidden;
+  position: relative;
 }

--- a/src/components/FooterBar/NextMedia.css
+++ b/src/components/FooterBar/NextMedia.css
@@ -11,8 +11,8 @@
   &:hover {
     background-color: var(--background-hover-color);
   }
+}
 
-  &-playlist {
-    color: var(--text-color);
-  }
+.NextMedia-playlist {
+  color: var(--text-color);
 }

--- a/src/components/FooterBar/Responses/Bar.css
+++ b/src/components/FooterBar/Responses/Bar.css
@@ -19,25 +19,25 @@
   &:hover {
     background-color: var(--background-hover-color);
   }
+}
 
-  &--disabled {
-    cursor: default;
-    &:hover {
-      background-color: transparent;
-    }
+.ResponseButton--disabled {
+  cursor: default;
+  &:hover {
+    background-color: transparent;
   }
+}
 
-  &-content {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0 15px;
-    position: relative;
-  }
+.ResponseButton-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 15px;
+  position: relative;
+}
 
-  &-icon {
-    height: 36px;
-    width: 36px;
-    padding: 6px 12px 6px 0px;
-  }
+.ResponseButton-icon {
+  height: 36px;
+  width: 36px;
+  padding: 6px 12px 6px 0px;
 }

--- a/src/components/FooterBar/UserInfo.css
+++ b/src/components/FooterBar/UserInfo.css
@@ -10,22 +10,22 @@
   &:hover {
     background-color: var(--background-hover-color);
   }
+}
 
-  &-avatar {
-    width: 50px;
-    height: 50px;
-    margin: auto;
-    display: block;
-  }
+.UserInfo-avatar {
+  width: 50px;
+  height: 50px;
+  margin: auto;
+  display: block;
+}
 
-  &-settings {
-    position: absolute;
-    bottom: 4px;
-    right: 3px;
-    height: 23px;
-    width: 23px;
-    border-radius: 50%;
-    border: 2px solid var(--background-color);
-    background: var(--background-color);
-  }
+.UserInfo-settings {
+  position: absolute;
+  bottom: 4px;
+  right: 3px;
+  height: 23px;
+  width: 23px;
+  border-radius: 50%;
+  border: 2px solid var(--background-color);
+  background: var(--background-color);
 }

--- a/src/components/FooterBar/index.css
+++ b/src/components/FooterBar/index.css
@@ -9,55 +9,56 @@
   z-index: 20; /* on top of overlays */
   border-top: 1px solid var(--chat-border-color);
   background: var(--background-color);
+}
 
-  &-guest {
-    font-size: 12pt;
-    padding: 0 25px;
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    height: 100%;
-    flex-grow: 1;
-  }
+.FooterBar-guest {
+  font-size: 12pt;
+  padding: 0 25px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  height: 100%;
+  flex-grow: 1;
+}
 
-  &-user {
-    height: 100%;
-    width: 75px;
-  }
+.FooterBar-user {
+  height: 100%;
+  width: 75px;
+}
 
-  &-next {
-    flex-grow: 1;
-    height: 100%;
-    overflow: hidden;
-  }
+.FooterBar-next {
+  flex-grow: 1;
+  height: 100%;
+  overflow: hidden;
+}
 
-  &-responses {
-    height: 100%;
-    &--spaced {
-      padding-right: 1rem;
-    }
-  }
+.FooterBar-responses {
+  height: 100%;
+}
 
-  &-skip {
-    height: 100%;
-    padding-right: 0.5rem;
-  }
+.FooterBar-responses--spaced {
+  padding-right: 1rem;
+}
 
-  &-join {
-    font-size: 12pt;
-    float: right;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    width: 125px;
-    background: var(--highlight-color);
-    cursor: pointer;
+.FooterBar-skip {
+  height: 100%;
+  padding-right: 0.5rem;
+}
 
-    &--locked {
-      width: 140px;
-    }
-  }
+.FooterBar-join {
+  font-size: 12pt;
+  float: right;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  width: 125px;
+  background: var(--highlight-color);
+  cursor: pointer;
+}
+
+.FooterBar-join--locked {
+  width: 140px;
 }
 
 .FooterAuthButton {
@@ -71,18 +72,18 @@
   cursor: pointer;
   color: var(--text-color);
   font-size: 12pt;
+}
 
-  &--login {
-    background: var(--background-color);
-    &:hover {
-      background: var(--background-hover-color);
-    }
+.FooterAuthButton--login {
+  background: var(--background-color);
+  &:hover {
+    background: var(--background-hover-color);
   }
+}
 
-  &--register {
-    background: var(--highlight-color);
-    &:hover {
-      background: var(--highbright-color);
-    }
+.FooterAuthButton--register {
+  background: var(--highlight-color);
+  &:hover {
+    background: var(--highbright-color);
   }
 }

--- a/src/components/Form/Button.css
+++ b/src/components/Form/Button.css
@@ -16,14 +16,14 @@
   font-size: 12pt;
   transition: opacity 150ms;
 
-  &-loading {
-    width: calc(var(--forms-textfield-size) * 0.8);
-    height: calc(var(--forms-textfield-size) * 0.8);
-    margin: auto;
-  }
-
   &:disabled {
     cursor: default;
     opacity: 0.5;
   }
+}
+
+.Button-loading {
+  width: calc(var(--forms-textfield-size) * 0.8);
+  height: calc(var(--forms-textfield-size) * 0.8);
+  margin: auto;
 }

--- a/src/components/Form/TextField.css
+++ b/src/components/Form/TextField.css
@@ -7,32 +7,32 @@
   border-right-color: #3e3e3e;
   height: var(--forms-textfield-size);
   font-size: 12pt;
+}
 
-  &-input {
-    width: 100%;
-    border: 0;
-    height: 100%;
-    background: transparent;
-    line-height: var(--forms-textfield-size);
-    display: block;
-    float: left;
-    padding: 0 var(--forms-element-margin);
-    padding-right: var(--forms-textfield-size);
-    font-size: 12pt;
-    color: var(--text-color);
+.TextField-input {
+  width: 100%;
+  border: 0;
+  height: 100%;
+  background: transparent;
+  line-height: var(--forms-textfield-size);
+  display: block;
+  float: left;
+  padding: 0 var(--forms-element-margin);
+  padding-right: var(--forms-textfield-size);
+  font-size: 12pt;
+  color: var(--text-color);
 
-    &::placeholder {
-      color: #9f9d9e;
-    }
+  &::placeholder {
+    color: #9f9d9e;
   }
+}
 
-  &-icon {
-    width: var(--forms-textfield-size);
-    height: var(--forms-textfield-size);
-    margin-left: -var(--forms-textfield-size);
-    padding: 13px;
-    display: block;
-    float: left;
-    text-align: center;
-  }
+.TextField-icon {
+  width: var(--forms-textfield-size);
+  height: var(--forms-textfield-size);
+  margin-left: -var(--forms-textfield-size);
+  padding: 13px;
+  display: block;
+  float: left;
+  text-align: center;
 }

--- a/src/components/Form/index.css
+++ b/src/components/Form/index.css
@@ -10,8 +10,8 @@
   &:first-child {
     margin-top: 0;
   }
+}
 
-  &--noSpacing {
-    margin: 0;
-  }
+.FormGroup--noSpacing {
+  margin: 0;
 }

--- a/src/components/HeaderBar/AppTitle.css
+++ b/src/components/HeaderBar/AppTitle.css
@@ -4,22 +4,22 @@
   display: flex;
   align-items: center;
   padding-right: 20px;
+}
 
-  &-logo {
-    line-height: var(--header-height);
-    height: var(--header-height);
-    background-image: url(../../../assets/img/logo-white.png);
-    background-repeat: no-repeat;
-    background-position: center center;
-    background-size: contain;
-    margin-left: 10px;
-    font-size: 0;
-    flex-grow: 2;
-  }
+.AppTitle-logo {
+  line-height: var(--header-height);
+  height: var(--header-height);
+  background-image: url(../../../assets/img/logo-white.png);
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: contain;
+  margin-left: 10px;
+  font-size: 0;
+  flex-grow: 2;
+}
 
-  &-button {}
+.AppTitle-button {}
 
-  &--hasAboutPage {
-    padding-right: 0;
-  }
+.AppTitle--hasAboutPage {
+  padding-right: 0;
 }

--- a/src/components/HeaderBar/Progress.css
+++ b/src/components/HeaderBar/Progress.css
@@ -1,12 +1,10 @@
 @import "../../vars.css";
 
-.Progress {
-  &-fill {
-    background: var(--highlight-color);
-    height: 100%;
-    width: 100%;
-    transform: scaleX(0);
-    transform-origin: top left;
-    transition: transform 1s linear;
-  }
+.Progress-fill {
+  background: var(--highlight-color);
+  height: 100%;
+  width: 100%;
+  transform: scaleX(0);
+  transform-origin: top left;
+  transition: transform 1s linear;
 }

--- a/src/components/HeaderBar/Volume.css
+++ b/src/components/HeaderBar/Volume.css
@@ -1,8 +1,6 @@
-.VolumeSlider {
-  &-slider {
-    height: 24px;
-    display: inline-block;
-    width: calc(100% - 30px);
-    margin-left: 6px;
-  }
+.VolumeSlider-slider {
+  height: 24px;
+  display: inline-block;
+  width: calc(100% - 30px);
+  margin-left: 6px;
 }

--- a/src/components/HeaderBar/index.css
+++ b/src/components/HeaderBar/index.css
@@ -9,56 +9,56 @@
   height: 100%;
   width: 100%;
   z-index: 4; /* below overlays, above video */
+}
 
-  &-title {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 240px;
-    margin: 0;
-  }
+.HeaderBar-title {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 240px;
+  margin: 0;
+}
 
-  &-volume {
-    position: absolute;
-    right: var(--header-height);
-    top: 0;
-    width: 200px;
-    padding: 15px;
-  }
+.HeaderBar-volume {
+  position: absolute;
+  right: var(--header-height);
+  top: 0;
+  width: 200px;
+  padding: 15px;
+}
 
-  &-history {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    width: var(--header-height);
-    background: #111;
-  }
+.HeaderBar-history {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: var(--header-height);
+  background: #111;
+}
 
-  &-now-playing {
-    position: absolute;
-    top: 5px;
-    left: 250px;
-    right: calc(200px + var(--header-height));
-    line-height: 25px;
-  }
+.HeaderBar-now-playing {
+  position: absolute;
+  top: 5px;
+  left: 250px;
+  right: calc(200px + var(--header-height));
+  line-height: 25px;
+}
 
-  &-dj {
-    position: absolute;
-    top: 30px;
-    left: 250px;
-    right: 200px;
-    font-size: 80%;
-    color: var(--muted-text-color);
-  }
+.HeaderBar-dj {
+  position: absolute;
+  top: 30px;
+  left: 250px;
+  right: 200px;
+  font-size: 80%;
+  color: var(--muted-text-color);
+}
 
-  &-progress {
-    position: absolute;
-    bottom: 1px;
-    height: 2px;
-    width: 100%;
-    /* show above the history button background fill colour,
-     * but below the history icon and tooltip */
-    z-index: 6;
-  }
+.HeaderBar-progress {
+  position: absolute;
+  bottom: 1px;
+  height: 2px;
+  width: 100%;
+  /* show above the history button background fill colour,
+   * but below the history icon and tooltip */
+  z-index: 6;
 }

--- a/src/components/Loader/CircularProgress.css
+++ b/src/components/Loader/CircularProgress.css
@@ -45,22 +45,21 @@
   color: var(--highlight-color);
   width: 100%;
   height: 100%;
+}
 
-  &-svg {
-    /* The main animation is loop 4 times. */
-    animation: rotate-progress-circle calc(var(--loader-duration) * (4 / 3)) linear infinite;
-  }
+.MuiCircularProgress-svg {
+  /* The main animation is loop 4 times. */
+  animation: rotate-progress-circle calc(var(--loader-duration) * (4 / 3)) linear infinite;
+}
 
-  &-circle {
-    stroke-dasharray: 1, calc((100% - 3px) * 3.141);
-    stroke-dashoffset: 0%;
-    stroke: currentColor;
-    stroke-linecap: round;
-    transition: all var(--loader-duration) cubic-bezier(0.4, 0.0, 0.2, 1);
-    animation: scale-progress-circle var(--loader-duration) cubic-bezier(0.4, 0.0, 0.2, 1) infinite;
-  }
-
-  &--tiny &-circle {
+.MuiCircularProgress-circle {
+  stroke-dasharray: 1, calc((100% - 3px) * 3.141);
+  stroke-dashoffset: 0%;
+  stroke: currentColor;
+  stroke-linecap: round;
+  transition: all var(--loader-duration) cubic-bezier(0.4, 0.0, 0.2, 1);
+  animation: scale-progress-circle var(--loader-duration) cubic-bezier(0.4, 0.0, 0.2, 1) infinite;
+  @nest .MuiCircularProgress--tiny & {
     animation-name: scale-progress-circle-tiny;
   }
 }

--- a/src/components/LoadingScreen/index.css
+++ b/src/components/LoadingScreen/index.css
@@ -12,15 +12,15 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
+}
 
-  &-loader {
-    height: 250px;
-    width: 250px;
-    height: 50vmin;
-    width: 50vmin;
-  }
+.LoadingScreen-loader {
+  height: 250px;
+  width: 250px;
+  height: 50vmin;
+  width: 50vmin;
+}
 
-  &-notice {
-    color: var(--text-color);
-  }
+.LoadingScreen-notice {
+  color: var(--text-color);
 }

--- a/src/components/MediaList/Actions.css
+++ b/src/components/MediaList/Actions.css
@@ -8,11 +8,11 @@
   &.is-selected {
     background: var(--highlight-color);
   }
+}
 
-  &-action {
-    height: 100%;
-    cursor: pointer;
-    display: inline-block;
-    padding: 6px 15px;
-  }
+.MediaActions-action {
+  height: 100%;
+  cursor: pointer;
+  display: inline-block;
+  padding: 6px 15px;
 }

--- a/src/components/MediaList/MediaLoadingIndicator.css
+++ b/src/components/MediaList/MediaLoadingIndicator.css
@@ -5,9 +5,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
+}
 
-  &-spinner {
-    width: 32px;
-    height: 32px;
-  }
+.MediaLoadingIndicator-spinner {
+  width: 32px;
+  height: 32px;
 }

--- a/src/components/MediaList/Row.css
+++ b/src/components/MediaList/Row.css
@@ -6,10 +6,6 @@
   position: relative;
   background: var(--media-list-color);
 
-  &--alternate {
-    background: var(--media-list-alternate-color);
-  }
-
   &.is-loading {
     opacity: 0.75;
   }
@@ -17,53 +13,57 @@
   &.is-selected {
     background: color(var(--highlight-color) alpha(* 70%));
   }
+}
 
-  &-loader {
-    margin: 0 15px;
-  }
+.MediaListRow-loader {
+  margin: 0 15px;
+}
 
-  &-thumb {
-    height: 100%;
-    width: 55px;
-    margin: 0 15px;
-    padding: 7px 0;
-    float: left;
-  }
+.MediaListRow-thumb {
+  height: 100%;
+  width: 55px;
+  margin: 0 15px;
+  padding: 7px 0;
+  float: left;
+}
 
-  &-image {
-    max-width: 100%;
-    max-height: 100%;
-  }
+.MediaListRow-image {
+  max-width: 100%;
+  max-height: 100%;
+}
 
-  &-artist {
-    height: 100%;
-    float: left;
-    width: calc(50% - var(--media-list-spacing) - var(--media-list-thumb-width) - var(--media-list-duration-width));
-    margin-right: var(--media-list-spacing);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
+.MediaListRow-artist {
+  height: 100%;
+  float: left;
+  width: calc(50% - var(--media-list-spacing) - var(--media-list-thumb-width) - var(--media-list-duration-width));
+  margin-right: var(--media-list-spacing);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
-  &-title {
-    height: 100%;
-    float: left;
-    width: calc(50% - var(--media-list-spacing));
-    margin-right: var(--media-list-spacing);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
+.MediaListRow-title {
+  height: 100%;
+  float: left;
+  width: calc(50% - var(--media-list-spacing));
+  margin-right: var(--media-list-spacing);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
-  &-duration {
-    height: 100%;
-    float: left;
-    width: var(--media-list-duration-width);
-  }
+.MediaListRow-duration {
+  height: 100%;
+  float: left;
+  width: var(--media-list-duration-width);
+}
 
-  &-actions {
-    height: 100%;
-    position: absolute;
-    right: 0;
-  }
+.MediaListRow-actions {
+  height: 100%;
+  position: absolute;
+  right: 0;
+}
+
+.MediaListRow--alternate {
+  background: var(--media-list-alternate-color);
 }

--- a/src/components/Overlay/Header/Close.css
+++ b/src/components/Overlay/Header/Close.css
@@ -6,9 +6,9 @@
   width: var(--overlay-header-close-size);
   height: var(--overlay-header-close-size);
   padding: 12px;
+}
 
-  &-icon {
-    font-size: 32px;
-    line-height: var(--overlay-header-close-size);
-  }
+.OverlayHeaderClose-icon {
+  font-size: 32px;
+  line-height: var(--overlay-header-close-size);
 }

--- a/src/components/Overlay/Header/index.css
+++ b/src/components/Overlay/Header/index.css
@@ -4,31 +4,31 @@
 .OverlayHeader {
   background: var(--background-color);
   height: var(--header-height);
+}
 
-  &-title {
-    float: left;
-    height: 100%;
-    padding-top: 17px;
-    font-size: 10pt;
-    text-align: center;
+.OverlayHeader-title {
+  float: left;
+  height: 100%;
+  padding-top: 17px;
+  font-size: 10pt;
+  text-align: center;
 
-    /* max width = 300px */
-    width: 33%;
-    @media (min-width: 1200px) {
-      width: 300px;
-    }
+  /* max width = 300px */
+  width: 33%;
+  @media (min-width: 1200px) {
+    width: 300px;
   }
+}
 
-  &-content {
-    float: left;
-    height: 100%;
-    width: calc(100% - 33% - var(--overlay-header-close-size));
-    @media (min-width: 1200px) {
-      width: calc(100% - 300px - var(--overlay-header-close-size));
-    }
+.OverlayHeader-content {
+  float: left;
+  height: 100%;
+  width: calc(100% - 33% - var(--overlay-header-close-size));
+  @media (min-width: 1200px) {
+    width: calc(100% - 300px - var(--overlay-header-close-size));
   }
+}
 
-  &-close {
-    float: left;
-  }
+.OverlayHeader-close {
+  float: left;
 }

--- a/src/components/Overlay/index.css
+++ b/src/components/Overlay/index.css
@@ -5,36 +5,37 @@
   height: 100%;
   width: 100%;
   z-index: 6;
+}
 
-  &--from-bottom {
-    top: auto;
-    bottom: 0;
-  }
-  &--from-top {
-    top: 0;
-    bottom: auto;
-  }
+.Overlay--from-bottom {
+  top: auto;
+  bottom: 0;
+}
+.Overlay--from-top {
+  top: 0;
+  bottom: auto;
+}
 
-  &-body {
-    height: 100%;
-    height: 100vh;
-  }
+.Overlay-body {
+  height: 100%;
+  height: 100vh;
+}
 
-  /* Animations!.. */
-  &-enter {
-    overflow-y: hidden;
-    height: 0%;
-    &-active {
-      transition: height 180ms ease-out;
-      height: 100%;
-    }
-  }
-  &-leave {
-    overflow-y: hidden;
-    height: 100%;
-    &-active {
-      transition: height 180ms ease-in;
-      height: 0%;
-    }
-  }
+/* Animations!.. */
+.Overlay-enter {
+  overflow-y: hidden;
+  height: 0%;
+}
+.Overlay-enter-active {
+  transition: height 180ms ease-out;
+  height: 100%;
+}
+
+.Overlay-leave {
+  overflow-y: hidden;
+  height: 100%;
+}
+.Overlay-leave-active {
+  transition: height 180ms ease-in;
+  height: 0%;
 }

--- a/src/components/PlaylistManager/Header/SearchBar.css
+++ b/src/components/PlaylistManager/Header/SearchBar.css
@@ -12,39 +12,39 @@
   &.is-focused {
     border-color: var(--highlight-color);
   }
+}
 
-  &-icon {
-    width: 80px;
-    height: 100%;
-    float: left;
-    text-align: center;
-    font-size: 32px;
-    line-height: 38px;
+.SearchBar-icon {
+  width: 80px;
+  height: 100%;
+  float: left;
+  text-align: center;
+  font-size: 32px;
+  line-height: 38px;
+}
+
+.SearchBar-query {
+  height: 100%;
+  margin-left: 80px;
+  margin-right: 100px;
+}
+
+.SearchBar-input {
+  background: transparent;
+  width: 100%;
+  height: 100%;
+  border: none;
+  padding: 0;
+  color: var(--text-color);
+  font-size: 14pt;
+
+  &:focus {
+    outline: 0;
   }
+}
 
-  &-query {
-    height: 100%;
-    margin-left: 80px;
-    margin-right: 100px;
-  }
-
-  &-input {
-    background: transparent;
-    width: 100%;
-    height: 100%;
-    border: none;
-    padding: 0;
-    color: var(--text-color);
-    font-size: 14pt;
-
-    &:focus {
-      outline: 0;
-    }
-  }
-
-  &-source {
-    float: right;
-    margin: 0 5px;
-    height: 100%;
-  }
+.SearchBar-source {
+  float: right;
+  margin: 0 5px;
+  height: 100%;
 }

--- a/src/components/PlaylistManager/Header/SourcePicker.css
+++ b/src/components/PlaylistManager/Header/SourcePicker.css
@@ -6,21 +6,21 @@
 
 .SourcePicker {
   width: var(--source-picker-width);
+}
 
-  &-active {
-    cursor: pointer;
-    width: 100%;
-    height: 100%;
-    padding: 0;
-  }
+.SourcePicker-active {
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+}
 
-  &-list {
-    width: var(--source-picker-width);
-  }
+.SourcePicker-list {
+  width: var(--source-picker-width);
+}
 
-  &-item {
-    cursor: pointer;
-    width: 100%;
-    padding: 5px;
-  }
+.SourcePicker-item {
+  cursor: pointer;
+  width: 100%;
+  padding: 5px;
 }

--- a/src/components/PlaylistManager/Header/SourcePickerElement.css
+++ b/src/components/PlaylistManager/Header/SourcePickerElement.css
@@ -4,9 +4,9 @@
   background-position: center center;
   background-repeat: no-repeat;
   background-size: contain;
+}
 
-  &--active {
-    width: 48px;
-    float: left;
-  }
+.SourcePickerElement--active {
+  width: 48px;
+  float: left;
 }

--- a/src/components/PlaylistManager/Import/ImportPanel.css
+++ b/src/components/PlaylistManager/Import/ImportPanel.css
@@ -1,12 +1,12 @@
 .ImportPanel {
   height: 100%;
+}
 
-  &-loading {
-    margin: auto;
-    width: 25%;
-  }
+.ImportPanel-loading {
+  margin: auto;
+  width: 25%;
+}
 
-  &-body {
-    height: calc(100% - 54px);
-  }
+.ImportPanel-body {
+  height: calc(100% - 54px);
 }

--- a/src/components/PlaylistManager/Import/ImportPanelHeader.css
+++ b/src/components/PlaylistManager/Import/ImportPanelHeader.css
@@ -4,9 +4,9 @@
   font-size: 14pt;
   display: flex;
   justify-content: space-between;
+}
 
-  &-content {
-    flex-grow: 1;
-    padding-left: 15px;
-  }
+.ImportPanelHeader-content {
+  flex-grow: 1;
+  padding-left: 15px;
 }

--- a/src/components/PlaylistManager/Import/ImportSourceBlock.css
+++ b/src/components/PlaylistManager/Import/ImportSourceBlock.css
@@ -1,9 +1,7 @@
-.ImportSourceBlock {
-  &-image {
-    max-width: 100%;
-    max-height: 50px;
-    display: block;
-    margin: auto;
-    margin-bottom: 16px;
-  }
+.ImportSourceBlock-image {
+  max-width: 100%;
+  max-height: 50px;
+  display: block;
+  margin: auto;
+  margin-bottom: 16px;
 }

--- a/src/components/PlaylistManager/Import/index.css
+++ b/src/components/PlaylistManager/Import/index.css
@@ -8,9 +8,9 @@
   height: 100%;
   background: var(--background-color);
   overflow: auto;
+}
 
-  &-source {
-    padding: 16px;
-    width: 50%;
-  }
+.PlaylistImport-source {
+  padding: 16px;
+  width: 50%;
 }

--- a/src/components/PlaylistManager/Menu/Row.css
+++ b/src/components/PlaylistManager/Menu/Row.css
@@ -7,48 +7,48 @@
   cursor: pointer;
   width: 100%;
 
-  &-content {
-    display: flex;
-    justify-content: space-between;
-  }
-
-  &-active-icon {
-    display: block;
-    float: left;
-    height: 44px;
-    margin-right: 7px;
-    padding-top: 5px;
-  }
-
-  &-loading {
-    width: 24px;
-    height: 24px;
-    float: left;
-    margin: 10px 7px 10px 0;
-  }
-
-  &-title {
-    align-self: flex-start;
-    /* dot dot dot */
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  &-count {
-    align-self: flex-end;
-    color: var(--highlight-color);
-    margin-right: 5px;
-  }
-
-  &--create {
-    background-color: var(--highlight-color);
-  }
-
   &.is-selected {
     background: var(--media-list-alternate-color);
   }
   &.is-droppable {
     background: var(--media-list-alternate-color);
   }
+}
+
+.PlaylistMenuRow-content {
+  display: flex;
+  justify-content: space-between;
+}
+
+.PlaylistMenuRow-active-icon {
+  display: block;
+  float: left;
+  height: 44px;
+  margin-right: 7px;
+  padding-top: 5px;
+}
+
+.PlaylistMenuRow-loading {
+  width: 24px;
+  height: 24px;
+  float: left;
+  margin: 10px 7px 10px 0;
+}
+
+.PlaylistMenuRow-title {
+  align-self: flex-start;
+  /* dot dot dot */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.PlaylistMenuRow-count {
+  align-self: flex-end;
+  color: var(--highlight-color);
+  margin-right: 5px;
+}
+
+.PlaylistMenuRow--create {
+  background-color: var(--highlight-color);
 }

--- a/src/components/PlaylistManager/Panel/Meta.css
+++ b/src/components/PlaylistManager/Panel/Meta.css
@@ -4,20 +4,20 @@
   font-size: 14pt;
   display: flex;
   justify-content: space-between;
+}
 
-  &-name {
-    flex-grow: 1;
-    padding-left: 15px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
+.PlaylistMeta-name {
+  flex-grow: 1;
+  padding-left: 15px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
-  &-active {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    padding-right: 20px;
-    height: 100%;
-  }
+.PlaylistMeta-active {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding-right: 20px;
+  height: 100%;
 }

--- a/src/components/PlaylistManager/Panel/PlaylistFilter.css
+++ b/src/components/PlaylistManager/Panel/PlaylistFilter.css
@@ -6,26 +6,26 @@
 
 .PlaylistMediaFilter {
   display: flex;
+}
 
-  &-input {
-    width: 180px;
-    border-radius: 2px;
-    background: #252727;
-    border: 1px solid #252727;
-    color: var(--text-color);
-    font-size: 12pt;
-    padding: 0 8px;
-    height: var(--playlist-filter-input-height);
-    display: none;
-    margin-top: calc((54px - var(--playlist-filter-input-height)) / 2);
+.PlaylistMediaFilter-input {
+  width: 180px;
+  border-radius: 2px;
+  background: #252727;
+  border: 1px solid #252727;
+  color: var(--text-color);
+  font-size: 12pt;
+  padding: 0 8px;
+  height: var(--playlist-filter-input-height);
+  display: none;
+  margin-top: calc((54px - var(--playlist-filter-input-height)) / 2);
 
-    &:focus {
-      outline: none;
-      border: 1px solid var(--highlight-color);
-    }
+  &:focus {
+    outline: none;
+    border: 1px solid var(--highlight-color);
+  }
 
-    &.is-open {
-      display: block;
-    }
+  &.is-open {
+    display: block;
   }
 }

--- a/src/components/PlaylistManager/Panel/PlaylistItemRow.css
+++ b/src/components/PlaylistManager/Panel/PlaylistItemRow.css
@@ -1,7 +1,5 @@
-.PlaylistItemRow {
-  &-drop-indicator {
-    background: white;
-    height: 3px;
-    width: 100%;
-  }
+.PlaylistItemRow-drop-indicator {
+  background: white;
+  height: 3px;
+  width: 100%;
 }

--- a/src/components/PlaylistManager/Panel/SearchResults.css
+++ b/src/components/PlaylistManager/Panel/SearchResults.css
@@ -1,11 +1,9 @@
-.SearchResults {
-  &-query {
-    height: 54px;
-    line-height: 54px;
-    font-size: 14pt;
-    padding-left: 15px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
+.SearchResults-query {
+  height: 54px;
+  line-height: 54px;
+  font-size: 14pt;
+  padding-left: 15px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/src/components/PlaylistManager/Panel/index.css
+++ b/src/components/PlaylistManager/Panel/index.css
@@ -8,17 +8,17 @@
   background: color(var(--background-color) alpha(* 96%));
   height: 100%;
   width: 100%;
+}
 
-  &-loading {
-    margin: auto;
-    width: 25%;
-  }
+.PlaylistPanel-loading {
+  margin: auto;
+  width: 25%;
+}
 
-  &-media {
-    height: calc(100% - 54px);
-  }
+.PlaylistPanel-media {
+  height: calc(100% - 54px);
+}
 
-  &--empty {
-    padding: 16px;
-  }
+.PlaylistPanel--empty {
+  padding: 16px;
 }

--- a/src/components/PlaylistManager/index.css
+++ b/src/components/PlaylistManager/index.css
@@ -5,25 +5,26 @@
 
 .PlaylistManager {
   z-index: 10;
+}
 
-  &-menu {
-    width: 33%; /* 25% of total screen width */
-    float: left;
+.PlaylistManager-menu {
+  width: 33%; /* 25% of total screen width */
+  float: left;
 
-    /* menu would be larger than 300px */
-    @media (min-width: 1200px) {
-      width: 300px;
-    }
+  /* menu would be larger than 300px */
+  @media (min-width: 1200px) {
+    width: 300px;
   }
-  &-panel {
-    position: absolute;
-    left: 33%;
-    right: 0;
-    height: 100%;
+}
 
-    /* menu would be larger than 300px */
-    @media (min-width: 1200px) {
-      left: 300px;
-    }
+.PlaylistManager-panel {
+  position: absolute;
+  left: 33%;
+  right: 0;
+  height: 100%;
+
+  /* menu would be larger than 300px */
+  @media (min-width: 1200px) {
+    left: 300px;
   }
 }

--- a/src/components/ReCaptcha/index.css
+++ b/src/components/ReCaptcha/index.css
@@ -2,10 +2,8 @@
   --recaptcha-iframe-height: 78px;
 }
 
-.ReCaptcha {
-  &-spinner {
-    width: var(--recaptcha-iframe-height);
-    height: var(--recaptcha-iframe-height);
-    margin: auto;
-  }
+.ReCaptcha-spinner {
+  width: var(--recaptcha-iframe-height);
+  height: var(--recaptcha-iframe-height);
+  margin: auto;
 }

--- a/src/components/RoomHistory/Row.css
+++ b/src/components/RoomHistory/Row.css
@@ -27,59 +27,59 @@
   &.is-selected {
     background: color(var(--highlight-color) alpha(* 70%));
   }
+}
 
-  &-thumb {
-    height: 100%;
-    width: 55px;
-    margin: 0 15px;
-    padding: 7px 0;
-    float: left;
-  }
+.HistoryRow-thumb {
+  height: 100%;
+  width: 55px;
+  margin: 0 15px;
+  padding: 7px 0;
+  float: left;
+}
 
-  &-image {
-    max-width: 100%;
-    max-height: 100%;
-  }
+.HistoryRow-image {
+  max-width: 100%;
+  max-height: 100%;
+}
 
-  &-song {
-    font-size: 1em;
-    height: 100%;
-    float: left;
-    width: calc(100% - var(--media-list-spacing) - var(--history-list-not-song-width));
-    margin-right: var(--media-list-spacing);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
+.HistoryRow-song {
+  font-size: 1em;
+  height: 100%;
+  float: left;
+  width: calc(100% - var(--media-list-spacing) - var(--history-list-not-song-width));
+  margin-right: var(--media-list-spacing);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
-  &-votes {
-    height: 100%;
-    float: left;
-    width: var(--history-list-votes-width);
-  }
+.HistoryRow-votes {
+  height: 100%;
+  float: left;
+  width: var(--history-list-votes-width);
+}
 
-  &-user {
-    height: 100%;
-    float: left;
-    width: var(--history-list-user-width);
-    text-align: right;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
+.HistoryRow-user {
+  height: 100%;
+  float: left;
+  width: var(--history-list-user-width);
+  text-align: right;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
-  &-time {
-    height: 100%;
-    float: left;
-    text-align: right;
-    padding-right: 20px;
-    color: var(--muted-text-color);
-    width: var(--history-list-time-width);
-  }
+.HistoryRow-time {
+  height: 100%;
+  float: left;
+  text-align: right;
+  padding-right: 20px;
+  color: var(--muted-text-color);
+  width: var(--history-list-time-width);
+}
 
-  &-actions {
-    height: 100%;
-    position: absolute;
-    right: 0;
-  }
+.HistoryRow-actions {
+  height: 100%;
+  position: absolute;
+  right: 0;
 }

--- a/src/components/RoomHistory/index.css
+++ b/src/components/RoomHistory/index.css
@@ -3,11 +3,12 @@
 
 .RoomHistory {
   z-index: 10;
+}
 
-  &-body {
-    background: color(var(--background-color) alpha(* 96%));
-  }
-  &-list {
-    max-height: 100%;
-  }
+.RoomHistory-body {
+  background: color(var(--background-color) alpha(* 96%));
+}
+
+.RoomHistory-list {
+  max-height: 100%;
 }

--- a/src/components/RoomUserList/Row.css
+++ b/src/components/RoomUserList/Row.css
@@ -1,13 +1,11 @@
-.UserRow {
-  &-votes {
-    float: right;
-    display: flex;
-    align-items: center;
-    height: 100%;
-    margin-right: 4px;
-  }
+.UserRow-votes {
+  float: right;
+  display: flex;
+  align-items: center;
+  height: 100%;
+  margin-right: 4px;
+}
 
-  &-voteIcon {
-    margin: 0 4px;
-  }
+.UserRow-voteIcon {
+  margin: 0 4px;
 }

--- a/src/components/SettingsManager/Profile.css
+++ b/src/components/SettingsManager/Profile.css
@@ -1,10 +1,8 @@
-.SettingsPanelProfile {
-  &-username {
-    font-size: 120%;
-    font-weight: normal;
-  }
-  &-avatar {
-    width: 120px;
-    height: 120px;
-  }
+.SettingsPanelProfile-username {
+  font-size: 120%;
+  font-weight: normal;
+}
+.SettingsPanelProfile-avatar {
+  width: 120px;
+  height: 120px;
 }

--- a/src/components/SettingsManager/SettingsPanel.css
+++ b/src/components/SettingsManager/SettingsPanel.css
@@ -2,32 +2,32 @@
 
 .SettingsPanel {
   padding: 20px 50px;
+}
 
-  &-divider {
-    height: 1px;
-    border: none;
-    background: var(--muted-text-color);
-    margin: 20px 0;
-  }
+.SettingsPanel-divider {
+  height: 1px;
+  border: none;
+  background: var(--muted-text-color);
+  margin: 20px 0;
+}
 
-  &-header {
-    margin: 0 0 20px 0;
-    font-weight: 400;
-  }
+.SettingsPanel-header {
+  margin: 0 0 20px 0;
+  font-weight: 400;
+}
 
-  &-toggle {
-    margin: 0 0 20px 0;
-  }
+.SettingsPanel-toggle {
+  margin: 0 0 20px 0;
+}
 
-  &-column {
-    width: 50%;
-    float: left;
+.SettingsPanel-column {
+  width: 50%;
+  float: left;
+}
 
-    &--left {
-      padding-right: 50px;
-    }
-    &--right {
-      padding-left: 50px;
-    }
-  }
+.SettingsPanel-column--left {
+  padding-right: 50px;
+}
+.SettingsPanel-column--right {
+  padding-left: 50px;
 }

--- a/src/components/SettingsManager/index.css
+++ b/src/components/SettingsManager/index.css
@@ -4,9 +4,9 @@
 
 .SettingsManager {
   z-index: 10;
+}
 
-  &-body {
-    overflow-y: scroll;
-    background: color(var(--background-color) alpha(* 96%));
-  }
+.SettingsManager-body {
+  overflow-y: scroll;
+  background: color(var(--background-color) alpha(* 96%));
 }

--- a/src/components/SidePanels/index.css
+++ b/src/components/SidePanels/index.css
@@ -1,36 +1,34 @@
 @import "../../vars.css";
 
-.SidePanel {
-  &-tab {
-    /* material-ui needs box-sizing: content-box on an element that is not
-     * inline-styleable :( */
-    > div {
-      box-sizing: content-box;
-      /* OK please don't hurt me :( */
-      height: auto !important;
-      padding: 0 !important;
-    }
-
-    &-guests {
-      margin-left: 5px;
-      font-size: 80%;
-      color: #777;
-    }
+.SidePanel-tab {
+  /* material-ui needs box-sizing: content-box on an element that is not
+   * inline-styleable :( */
+  > div {
+    box-sizing: content-box;
+    /* OK please don't hurt me :( */
+    height: auto !important;
+    padding: 0 !important;
   }
 
-  &-panel {
-    position: absolute;
-    top: var(--header-height);
-    bottom: 0;
-    left: 0;
-    right: 0;
+  .SidePanel-tab-guests {
+    margin-left: 5px;
+    font-size: 80%;
+    color: #777;
+  }
+}
 
-    visibility: hidden;
-    opacity: 0;
+.SidePanel-panel {
+  position: absolute;
+  top: var(--header-height);
+  bottom: 0;
+  left: 0;
+  right: 0;
 
-    &.is-visible {
-      visibility: visible;
-      opacity: 1;
-    }
+  visibility: hidden;
+  opacity: 0;
+
+  &.is-visible {
+    visibility: visible;
+    opacity: 1;
   }
 }

--- a/src/components/SongTitle/index.css
+++ b/src/components/SongTitle/index.css
@@ -6,11 +6,12 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
 
-  &--large {
-    font-size: 14pt;
-  }
-  &--mediaRow {
-    font-size: 1em;
-  }
+.SongTitle--large {
+  font-size: 14pt;
+}
+
+.SongTitle--mediaRow {
+  font-size: 1em;
 }

--- a/src/components/UserCard/index.css
+++ b/src/components/UserCard/index.css
@@ -1,10 +1,10 @@
 .UserCard {
   position: absolute;
   transform: translateX(-100%);
+}
 
-  &-avatar {
-    width: 40px;
-    height: 40px;
-    margin-right: 16px;
-  }
+.UserCard-avatar {
+  width: 40px;
+  height: 40px;
+  margin-right: 16px;
 }

--- a/src/components/UserList/UserRow.css
+++ b/src/components/UserList/UserRow.css
@@ -5,13 +5,13 @@
   padding: 5px 0;
   display: block;
   text-decoration: none;
+}
 
-  &--cardable {
-    cursor: pointer;
-  }
+.UserRow--cardable {
+  cursor: pointer;
+}
 
-  &-avatar {
-    float: left;
-    margin: 3px 10px;
-  }
+.UserRow-avatar {
+  float: left;
+  margin: 3px 10px;
 }

--- a/src/components/UserList/index.css
+++ b/src/components/UserList/index.css
@@ -4,11 +4,12 @@
   width: 100%;
   height: 100%;
   overflow-y: scroll;
+}
 
-  &-row {
-    background: var(--user-list-color);
-    &--alternate {
-      background: var(--user-list-alternate-color);
-    }
-  }
+.UserList-row {
+  background: var(--user-list-color);
+}
+
+.UserList-row--alternate {
+  background: var(--user-list-alternate-color);
 }

--- a/src/components/Video/VideoBackdrop.css
+++ b/src/components/Video/VideoBackdrop.css
@@ -7,8 +7,8 @@
 
   min-width: 100%;
   min-height: 100%;
+}
 
-  &--blurry {
-    filter: blur(1em);
-  }
+.VideoBackdrop--blurry {
+  filter: blur(1em);
 }

--- a/src/components/Video/index.css
+++ b/src/components/Video/index.css
@@ -13,33 +13,33 @@
   height: 100%;
   overflow: hidden;
   background: black;
+}
 
-  &-capture {
-    @apply --video-overlay;
-    top: 0;
-    right: 0;
-    left: 0;
-    bottom: 0;
-  }
+.Video-capture {
+  @apply --video-overlay;
+  top: 0;
+  right: 0;
+  left: 0;
+  bottom: 0;
+}
 
-  &-progress {
-    @apply --video-overlay;
-    bottom: 0;
-    left: 0;
-    right: 0;
-  }
+.Video-progress {
+  @apply --video-overlay;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
 
-  &-toolbar {
-    @apply --video-overlay;
-    background-color: var(--background-color);
-    top: 0;
-    right: 0;
+.Video-toolbar {
+  @apply --video-overlay;
+  background-color: var(--background-color);
+  top: 0;
+  right: 0;
 
-    display: none;
-  }
+  display: none;
 
   /* Only show the toolbar on hover. */
-  &:hover .Video-toolbar {
+  @nest .Video:hover & {
     display: block;
   }
 }

--- a/src/components/WaitList/ModRow.css
+++ b/src/components/WaitList/ModRow.css
@@ -1,35 +1,33 @@
-.WaitlistRow {
-  &--moderate {
-    display: flex;
-  }
+.WaitlistRow--moderate {
+  display: flex;
+}
 
-  &-card {
-    flex-grow: 2;
-    cursor: pointer;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
+.WaitlistRow-card {
+  flex-grow: 2;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
-  &-tools {
-    float: right;
-    height: 100%;
-    padding: 5px;
-    white-space: nowrap;
-  }
+.WaitlistRow-tools {
+  float: right;
+  height: 100%;
+  padding: 5px;
+  white-space: nowrap;
+}
 
-  /* TODO use `&-handle, &-remove` here? */
-  &-tool {
-    display: inline-flex;
-    align-items: center;
-    height: 100%;
-    padding: 0 4px;
-  }
+/* TODO use `&-handle, &-remove` here? */
+.WaitlistRow-tool {
+  display: inline-flex;
+  align-items: center;
+  height: 100%;
+  padding: 0 4px;
+}
 
-  &-handle {
-    cursor: move;
-  }
-  &-remove {
-    cursor: pointer;
-  }
+.WaitlistRow-handle {
+  cursor: move;
+}
+.WaitlistRow-remove {
+  cursor: pointer;
 }

--- a/src/components/WaitList/SimpleRow.css
+++ b/src/components/WaitList/SimpleRow.css
@@ -1,18 +1,18 @@
 .WaitlistRow {
-  &-position {
-    float: left;
-    text-align: center;
-    padding: 0 0 0 7px;
-  }
-
-  &-drop-indicator {
-    border-top: 3px solid #fff;
-    background: transparent;
-    height: 37px;
-    width: 100%;
-  }
-
   &.is-dragging {
     display: none;
   }
+}
+
+.WaitlistRow-position {
+  float: left;
+  text-align: center;
+  padding: 0 0 0 7px;
+}
+
+.WaitlistRow-drop-indicator {
+  border-top: 3px solid #fff;
+  background: transparent;
+  height: 37px;
+  width: 100%;
 }

--- a/src/markdown.css
+++ b/src/markdown.css
@@ -14,10 +14,8 @@ body {
   margin: auto;
 }
 
-.Privacy {
-  &-logo {
-    height: 1.25em;
-    margin-right: 0.5em;
-    vertical-align: sub;
-  }
+.Privacy-logo {
+  height: 1.25em;
+  margin-right: 0.5em;
+  vertical-align: sub;
 }

--- a/src/sources/soundcloud/Player.css
+++ b/src/sources/soundcloud/Player.css
@@ -9,35 +9,35 @@
   margin: auto;
   height: 300px;
   background: var(--background-color);
+}
 
-  &-meta {
-    background: color(var(--background-color) alpha(* 20%));
-    position: relative;
-    padding: var(--sc-margins);
-    z-index: 3;
-  }
+.src-soundcloud-Player-meta {
+  background: color(var(--background-color) alpha(* 20%));
+  position: relative;
+  padding: var(--sc-margins);
+  z-index: 3;
+}
 
-  &-info {
-    display: flex;
-    margin-bottom: var(--sc-margins);
-  }
+.src-soundcloud-Player-info {
+  display: flex;
+  margin-bottom: var(--sc-margins);
+}
 
-  &-art {
-    display: block;
-    width: 100px;
-    height: 100px;
-    margin-right: var(--sc-margins);
-  }
+.src-soundcloud-Player-art {
+  display: block;
+  width: 100px;
+  height: 100px;
+  margin-right: var(--sc-margins);
+}
 
-  &-links {
-    width: calc(100% - 100px - var(--sc-margins));
-  }
+.src-soundcloud-Player-links {
+  width: calc(100% - 100px - var(--sc-margins));
+}
 
-  &-permalink {
-    display: block;
-    font: 14pt;
-    color: var(--text-color);
-    text-align: right;
-    text-decoration: none;
-  }
+.src-soundcloud-Player-permalink {
+  display: block;
+  font: 14pt;
+  color: var(--text-color);
+  text-align: right;
+  text-decoration: none;
 }

--- a/src/sources/soundcloud/SongInfo.css
+++ b/src/sources/soundcloud/SongInfo.css
@@ -1,21 +1,19 @@
 @import "../../vars.css";
 
-.src-soundcloud-SongInfo {
-  &-link {
-    font: 14pt;
+.src-soundcloud-SongInfo-link {
+  font: 14pt;
+  color: var(--text-color);
+  display: block;
+  height: 25px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+
+  &:visited {
     color: var(--text-color);
-    display: block;
-    height: 25px;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-
-    &--track {
-      font-weight: bold;
-    }
-
-    &:visited {
-      color: var(--text-color);
-    }
   }
+}
+
+.src-soundcloud-SongInfo-link--track {
+  font-weight: bold;
 }

--- a/src/sources/youtube/Player.css
+++ b/src/sources/youtube/Player.css
@@ -3,10 +3,11 @@
   height: 100%;
   position: relative;
   z-index: 3;
+}
 
-  &--small, &--preview {
-    margin: auto;
-    width: 640px;
-    height: 360px;
-  }
+.src-youtube-Player--small,
+.src-youtube-Player--preview {
+  margin: auto;
+  width: 640px;
+  height: 360px;
 }

--- a/src/sources/youtube/PlaylistPanel.css
+++ b/src/sources/youtube/PlaylistPanel.css
@@ -1,9 +1,7 @@
-.src-youtube-PlaylistPanel {
-  &-header {
-    display: flex;
-  }
+.src-youtube-PlaylistPanel-header {
+  display: flex;
+}
 
-  &-name {
-    flex-grow: 1;
-  }
+.src-youtube-PlaylistPanel-name {
+  flex-grow: 1;
 }

--- a/src/sources/youtube/PlaylistRow.css
+++ b/src/sources/youtube/PlaylistRow.css
@@ -4,32 +4,30 @@
   --yt-import-button-width: 54px;
 }
 
-.src-youtube-PlaylistRow {
-  &-info {
-    height: 100%;
-    line-height: 1.4;
-    float: left;
-    width: calc(100% - var(--media-list-thumb-width) - var(--media-list-spacing) - var(--yt-import-button-width));
-    margin-right: var(--media-list-spacing);
-  }
+.src-youtube-PlaylistRow-info {
+  height: 100%;
+  line-height: 1.4;
+  float: left;
+  width: calc(100% - var(--media-list-thumb-width) - var(--media-list-spacing) - var(--yt-import-button-width));
+  margin-right: var(--media-list-spacing);
+}
 
-  &-name {
-    margin: 5px 0 3px 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
+.src-youtube-PlaylistRow-name {
+  margin: 5px 0 3px 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
-  &-size {
-    font-size: 85%;
-    color: #777;
-    float: left;
-  }
+.src-youtube-PlaylistRow-size {
+  font-size: 85%;
+  color: #777;
+  float: left;
+}
 
-  &-import {
-    height: 100%;
-    line-height: 1; /* .MediaListRow sets this to 54px but we don't need that */
-    float: left;
-    width: var(--yt-import-button-width);
-  }
+.src-youtube-PlaylistRow-import {
+  height: 100%;
+  line-height: 1; /* .MediaListRow sets this to 54px but we don't need that */
+  float: left;
+  width: var(--yt-import-button-width);
 }


### PR DESCRIPTION
This patch fixes some invalid selectors. CSS nesting doesn't actually
work like this:

```css
.Parent {
  &-child {
    color: red;
  }
}
```

Instead, the `&` is a selector that matches real elements, so here
`color: red` only applies to `.Parent`s that also match `-child`,
which doesn't make a whole lot of sense. It used to work because
the postcss nesting plugin happens to compile it to `.Parent-child`.

Ref: https://tabatkins.github.io/specs/css-nesting/#nest-selector

(Churn churn churn)