### PR TITLE
Wait for state from /now before rendering

### DIFF
--- a/src/Uwave.js
+++ b/src/Uwave.js
@@ -32,6 +32,9 @@ export default class Uwave {
   constructor(options = {}, session = readSession()) {
     this.options = options;
     this.jwt = session;
+    this.ready = new Promise((resolve) => {
+      this.resolveReady = resolve;
+    });
 
     Object.assign(this, api.constants);
     Object.assign(this, api.components);
@@ -91,7 +94,9 @@ export default class Uwave {
     }
 
     this.store.dispatch(socketConnect());
-    this.store.dispatch(initState());
+    return this.store.dispatch(initState()).then(() => {
+      this.resolveReady();
+    });
   }
 
   getComponent() {

--- a/src/app.js
+++ b/src/app.js
@@ -18,9 +18,9 @@ uw.source('soundcloud', soundCloudSource);
 
 window.uw = uw;
 
-uw.build().then(function () {
+uw.build().then(() => {
   uw.renderToDOM(document.querySelector('#app'));
   document.querySelector('#app-loading').innerHTML = '';
-}).catch(function (err) {
-  document.querySelector('.LoadingScreen-notice').textContent = 'Error: ' + err.message;
+}).catch((err) => {
+  document.querySelector('.LoadingScreen-notice').textContent = `Error: ${err.message}`;
 });

--- a/src/app.js
+++ b/src/app.js
@@ -17,3 +17,10 @@ uw.source('youtube', youTubeSource);
 uw.source('soundcloud', soundCloudSource);
 
 window.uw = uw;
+
+uw.build().then(function () {
+  uw.renderToDOM(document.querySelector('#app'));
+  document.querySelector('#app-loading').innerHTML = '';
+}).catch(function (err) {
+  document.querySelector('.LoadingScreen-notice').textContent = 'Error: ' + err.message;
+});

--- a/src/index.html
+++ b/src/index.html
@@ -31,8 +31,12 @@
       <script src="<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"></script>
     <% } %>
     <script>
-      uw.renderToDOM(document.querySelector('#app'));
-      document.querySelector('#app-loading').innerHTML = '';
+      uw.build().then(function () {
+        uw.renderToDOM(document.querySelector('#app'));
+        document.querySelector('#app-loading').innerHTML = '';
+      }).catch(function (err) {
+        document.querySelector('.LoadingScreen-notice').textContent = 'Error: ' + err.message;
+      });
     </script>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -30,13 +30,5 @@
     <% for (const chunk in htmlWebpackPlugin.files.chunks) { %>
       <script src="<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"></script>
     <% } %>
-    <script>
-      uw.build().then(function () {
-        uw.renderToDOM(document.querySelector('#app'));
-        document.querySelector('#app-loading').innerHTML = '';
-      }).catch(function (err) {
-        document.querySelector('.LoadingScreen-notice').textContent = 'Error: ' + err.message;
-      });
-    </script>
   </body>
 </html>


### PR DESCRIPTION
Currently you see the app without any users etc for a few ms before the /now state loads in. This patch defers the first actual render of the app until the /now state is available.