### PR TITLE
Resync time if the local clock changes unexpectedly.

### DIFF
--- a/src/actions/TickerActionCreators.js
+++ b/src/actions/TickerActionCreators.js
@@ -13,21 +13,45 @@ export function syncTimestamps(clientTimeBefore, serverTime) {
 
 export function sync() {
   const before = Date.now();
-  return get('/server/time', {
-    onComplete: serverTime => syncTimestamps(before, serverTime)
+  return get('/now', {
+    onComplete: now => syncTimestamps(before, now.time)
   });
 }
 
 export function createTimer() {
   return (dispatch) => {
     const callbacks = [];
-    const intv = setInterval(() => {
+    let last = Date.now();
+    let syncing = false;
+
+    function notifyListeners() {
       callbacks.forEach(cb => cb());
+    }
+    function finishedSync() {
+      syncing = false;
+      notifyListeners();
+    }
+
+    const intv = setInterval(() => {
+      // Resync if one 1000ms interval skipped over more than 5s of time.
+      // This most likely means the user's computer's time changed.
+      const now = Date.now();
+      if (Math.abs(last - now) > 5000) {
+        syncing = true;
+        dispatch(sync()).then(finishedSync, finishedSync);
+      } else if (!syncing) {
+        // If we're currently syncing we don't update timed elements for
+        // a while, to prevent weird back and forth jumps.
+        notifyListeners();
+      }
+      last = now;
     }, 1000);
+
     dispatch({
       type: SET_TIMER,
       payload: intv
     });
+
     return callbacks;
   };
 }


### PR DESCRIPTION
This does add a whole tonne of logic to the timers but if your computer clock changes for some reason (timezone change, synced with a time server, or whatever) üWave will now resync its clock with the server time.