### PR TITLE
middleware: Remove old experimental plugin file code

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -4,69 +4,27 @@ import trumpet from 'trumpet';
 import router from 'router';
 import serveStatic from 'serve-static';
 
-function injectConfig(config, { pluginsScript, pluginsStyle } = {}) {
+function injectConfig(config) {
   const transform = trumpet();
   transform.select('#u-wave-config')
     .createWriteStream()
     .end(JSON.stringify(config));
-  if (pluginsScript) {
-    transform.select('#u-wave-plugins').setAttribute('src', pluginsScript);
-  }
-  if (pluginsStyle) {
-    transform.select('#u-wave-plugins-style').setAttribute('href', pluginsStyle);
-  }
   return transform;
 }
 
 export default function uwaveWebClient(uw, options = {}) {
   const {
     basePath = path.join(__dirname, '../public'),
-    pluginsScript = null,
-    pluginsScriptFile = null,
-    pluginsStyle = null,
-    pluginsStyleFile = null,
     fs = defaultFs, // Should only be used by the dev server.
     ...clientOptions
   } = options;
 
-  const pluginsScriptName = 'custom.js';
-  const pluginsStyleName = 'custom.css';
   const clientRouter = router();
-
-  if (pluginsScriptFile) {
-    clientRouter.get(`/${pluginsScriptName}`, (req, res) => {
-      res.writeHeader(200, { 'content-type': 'application/javascript' });
-      fs.createReadStream(pluginsScriptFile).pipe(res);
-    });
-  } else if (pluginsScript) {
-    clientRouter.get(`/${pluginsScriptName}`, (req, res) => {
-      res.writeHeader(200, { 'content-type': 'application/javascript' });
-      res.end(pluginsScript);
-    });
-  }
-
-  if (pluginsStyleFile) {
-    clientRouter.get(`/${pluginsStyleName}`, (req, res) => {
-      res.writeHeader(200, { 'content-type': 'text/css' });
-      fs.createReadStream(pluginsStyleFile).pipe(res);
-    });
-  } else if (pluginsStyle) {
-    clientRouter.get(`/${pluginsStyleName}`, (req, res) => {
-      res.writeHeader(200, { 'content-type': 'text/css' });
-      res.end(pluginsStyle);
-    });
-  }
 
   return clientRouter
     .get('/', (req, res) => {
       fs.createReadStream(path.join(basePath, 'index.html'), 'utf8')
-        .pipe(injectConfig(
-          clientOptions,
-          {
-            pluginsScript: (pluginsScriptFile || pluginsScript) ? pluginsScriptName : null,
-            pluginsStyle: (pluginsStyleFile || pluginsStyle) ? pluginsStyleName : null
-          }
-        ))
+        .pipe(injectConfig(clientOptions))
         .pipe(res);
     })
     .use(serveStatic(basePath));


### PR DESCRIPTION
Never ended up using this. This way was quite limited since you need to be able to change components to do most useful things and that wasn't possible in a custom JS file that runs after the main app. We've just used a fork for custom stuff on https://welovekpop.club/ so far and I think that's the simplest way to keep doing it for now … I don't have a good alternative extensibility system in mind.