### PR TITLE
header: Redo progress bar animation.

### DIFF
--- a/src/components/HeaderBar/Progress.css
+++ b/src/components/HeaderBar/Progress.css
@@ -6,5 +6,5 @@
   width: 100%;
   transform: scaleX(0);
   transform-origin: top left;
-  transition: transform 1s linear;
+  transition: transform 0s linear;
 }

--- a/src/components/HeaderBar/Progress.js
+++ b/src/components/HeaderBar/Progress.js
@@ -2,37 +2,37 @@ import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import transformStyle from '../../utils/transformStyle';
-import timed from '../../utils/timed';
 
-const Progress = ({ className, media, currentTime, startTime }) => {
-  let width = 0;
-  if (media) {
-    const duration = media ? media.end - media.start : 0;
-    const elapsed = startTime ? Math.max((currentTime - startTime) / 1000, 0) : 0;
-    width = duration
-      // Ensure that the result is between 0 and 1
-      ? Math.max(0, Math.min(1, elapsed / duration))
-      : 0;
-  }
-  if (!isFinite(width)) {
-    width = 0;
+const Progress = ({ className, currentProgress, timeRemaining }) => {
+  function animate(el) {
+    if (!el) return;
+
+    // Set the width to the current progress without animating
+    Object.assign(el.style, {
+      transitionDuration: '0s'
+    }, transformStyle(`scaleX(${currentProgress})`));
+
+    // Force browser to rerender the bar immediately
+    el.scrollWidth; // eslint-disable-line no-unused-expressions
+
+    // Set up the actual animation. Progress bar goes to 100% full
+    // in $timeRemaining seconds.
+    Object.assign(el.style, {
+      transitionDuration: `${timeRemaining}s`
+    }, transformStyle('scaleX(1)'));
   }
 
   return (
     <div className={cx('Progress', className)}>
-      <div
-        className="Progress-fill"
-        style={transformStyle(`scaleX(${width})`)}
-      />
+      <div className="Progress-fill" ref={animate} />
     </div>
   );
 };
 
 Progress.propTypes = {
   className: PropTypes.string,
-  media: PropTypes.object,
-  currentTime: PropTypes.number.isRequired,
-  startTime: PropTypes.number
+  currentProgress: PropTypes.number.isRequired,
+  timeRemaining: PropTypes.number.isRequired
 };
 
-export default timed()(Progress);
+export default Progress;

--- a/src/components/HeaderBar/index.js
+++ b/src/components/HeaderBar/index.js
@@ -13,7 +13,8 @@ const HeaderBar = ({
   title,
   dj,
   media,
-  mediaStartTime,
+  mediaProgress,
+  mediaTimeRemaining,
   volume,
   muted,
   hasAboutPage,
@@ -37,11 +38,13 @@ const HeaderBar = ({
     </AppTitle>
     <CurrentMedia className="HeaderBar-now-playing" media={media} />
     {dj && <CurrentDJ className="HeaderBar-dj" dj={dj} />}
-    <Progress
-      className="HeaderBar-progress"
-      media={media}
-      startTime={mediaStartTime}
-    />
+    {media && (
+      <Progress
+        className="HeaderBar-progress"
+        currentProgress={mediaProgress}
+        timeRemaining={mediaTimeRemaining}
+      />
+    )}
     <div className="HeaderBar-volume">
       <Volume
         volume={volume}
@@ -63,7 +66,8 @@ HeaderBar.propTypes = {
 
   dj: PropTypes.object,
   media: PropTypes.object,
-  mediaStartTime: PropTypes.number,
+  mediaProgress: PropTypes.number.isRequired,
+  mediaTimeRemaining: PropTypes.number.isRequired,
   volume: PropTypes.number,
   muted: PropTypes.bool,
   hasAboutPage: PropTypes.bool.isRequired,

--- a/src/containers/HeaderBar.js
+++ b/src/containers/HeaderBar.js
@@ -9,12 +9,18 @@ import { createStructuredSelector } from 'reselect';
 import { setVolume, mute, unmute } from '../actions/PlaybackActionCreators';
 import { toggleRoomHistory, toggleAbout } from '../actions/OverlayActionCreators';
 
-import { djSelector, mediaSelector, startTimeSelector } from '../selectors/boothSelectors';
+import {
+  djSelector,
+  mediaSelector,
+  mediaProgressSelector,
+  timeRemainingSelector
+} from '../selectors/boothSelectors';
 import { volumeSelector, isMutedSelector } from '../selectors/settingSelectors';
 import HeaderBar from '../components/HeaderBar';
 
 const mapStateToProps = createStructuredSelector({
-  mediaStartTime: startTimeSelector,
+  mediaProgress: mediaProgressSelector,
+  mediaTimeRemaining: timeRemainingSelector,
   media: mediaSelector,
   dj: djSelector,
   volume: volumeSelector,


### PR DESCRIPTION
This patch changes the media progress bar to use a single CSS
transition, instead of updating the width every second. That's not super
interesting, if a little bit faster (since there is no need for React to
reconcile every second). It's also slightly more accurate, since
previously the progress bar would always lag behind by about 1 second.

The progress bar width is now also set instantly when the page is loaded
or a new song starts, so there's no weird backward animation when a new
song starts.