### PR TITLE
Add loading spinner to and move reload into shuffle operation.

### DIFF
--- a/src/actions/PlaylistActionCreators.js
+++ b/src/actions/PlaylistActionCreators.js
@@ -47,11 +47,11 @@ export function flattenPlaylistItem(item) {
   };
 }
 
-export function loadPlaylistStart(playlistID, page) {
+export function loadPlaylistStart(playlistID, page, { sneaky = false } = {}) {
   return {
     type: LOAD_PLAYLIST_START,
     payload: { playlistID },
-    meta: { page }
+    meta: { page, sneaky }
   };
 }
 
@@ -63,14 +63,10 @@ export function loadPlaylistComplete(playlistID, media, pagination) {
   };
 }
 
-export function loadPlaylist(playlistID, page = 0, sneaky = false) {
+export function loadPlaylist(playlistID, page = 0, meta = {}) {
   return get(`/playlists/${playlistID}/media`, {
     qs: { page, limit: MEDIA_PAGE_SIZE },
-    onStart: () => (dispatch) => {
-      if (!sneaky) {
-        dispatch(loadPlaylistStart(playlistID, page));
-      }
-    },
+    onStart: () => loadPlaylistStart(playlistID, page, meta),
     onComplete: res => loadPlaylistComplete(
       playlistID,
       mergeIncludedModels(res).map(flattenPlaylistItem),
@@ -602,7 +598,7 @@ export function shufflePlaylist(playlistID) {
         meta: { playlistID }
       })
     });
-    const loadOperation = loadPlaylist(playlistID, 0, true);
+    const loadOperation = loadPlaylist(playlistID, 0, { sneaky: true });
 
     return dispatch(shuffleOperation)
       .then(() => dispatch(loadOperation))

--- a/src/components/PlaylistManager/Panel/Meta.js
+++ b/src/components/PlaylistManager/Panel/Meta.js
@@ -3,13 +3,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { translate } from 'react-i18next';
 import Checkbox from 'material-ui/Checkbox';
-import IconButton from 'material-ui/IconButton';
-import ShuffleIcon from 'material-ui/svg-icons/av/shuffle';
 import ActiveIcon from 'material-ui/svg-icons/toggle/check-box';
 import ActivateIcon from 'material-ui/svg-icons/toggle/check-box-outline-blank';
 
 import RenamePlaylistButton from './RenamePlaylistButton';
 import DeletePlaylistButton from './DeletePlaylistButton';
+import ShufflePlaylistButton from './ShufflePlaylistButton';
 import PlaylistFilter from './PlaylistFilter';
 
 const checkboxIconStyle = { fill: '#fff' };
@@ -43,13 +42,7 @@ const PlaylistMeta = ({
     <PlaylistFilter
       onFilter={onFilter}
     />
-    <IconButton
-      onClick={onShufflePlaylist}
-      tooltip={t('playlists.shuffle')}
-      tooltipPosition="top-center"
-    >
-      <ShuffleIcon color="#555" hoverColor="#fff" />
-    </IconButton>
+    <ShufflePlaylistButton onShuffle={onShufflePlaylist} />
     <RenamePlaylistButton
       initialName={name}
       onRename={onRenamePlaylist}

--- a/src/components/PlaylistManager/Panel/ShufflePlaylistButton.js
+++ b/src/components/PlaylistManager/Panel/ShufflePlaylistButton.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import compose from 'recompose/compose';
+import withState from 'recompose/withState';
+import withHandlers from 'recompose/withHandlers';
+import { translate } from 'react-i18next';
+import IconButton from 'material-ui/IconButton';
+import ShuffleIcon from 'material-ui/svg-icons/av/shuffle';
+import Loader from '../../Loader';
+
+const enhance = compose(
+  withState('isLoading', 'setLoading', false),
+  withHandlers({
+    onClick: props => () => {
+      props.setLoading(true);
+      props.onShuffle().then(() => {
+        props.setLoading(false);
+      }, () => {
+        props.setLoading(false);
+      });
+    }
+  }),
+  translate()
+);
+
+const ShuffleButton = ({
+  t,
+  isLoading,
+  onClick
+}) => (
+  <IconButton
+    onClick={onClick}
+    tooltip={t('playlists.shuffle')}
+    tooltipPosition="top-center"
+  >
+    {isLoading ? (
+      <Loader size="tiny" />
+    ) : (
+      <ShuffleIcon color="#555" hoverColor="#fff" />
+    )}
+  </IconButton>
+);
+
+ShuffleButton.propTypes = {
+  t: PropTypes.func.isRequired,
+  isLoading: PropTypes.bool.isRequired,
+  onClick: PropTypes.func.isRequired,
+  onShuffle: PropTypes.func.isRequired // eslint-disable-line react/no-unused-prop-types
+};
+
+export default enhance(ShuffleButton);

--- a/src/reducers/playlists.js
+++ b/src/reducers/playlists.js
@@ -27,7 +27,6 @@ import {
   MOVE_MEDIA_COMPLETE,
   UPDATE_MEDIA_START,
   UPDATE_MEDIA_COMPLETE,
-  SHUFFLE_PLAYLIST_COMPLETE,
   FILTER_PLAYLIST_ITEMS,
   FILTER_PLAYLIST_ITEMS_COMPLETE
 } from '../constants/actionTypes/playlists';
@@ -230,9 +229,6 @@ export default function reduce(state = initialState, action = {}) {
       playlist => ({ ...playlist, loading: false }),
       items => mergePlaylistPage(meta.size, items, payload.media, meta)
     );
-  case SHUFFLE_PLAYLIST_COMPLETE:
-    // Clear the local playlist item cache.
-    return updatePlaylistItems(state, payload.playlistID, () => []);
 
   case FILTER_PLAYLIST_ITEMS:
     // Only the selected playlist can be filtered.

--- a/src/reducers/playlists.js
+++ b/src/reducers/playlists.js
@@ -206,7 +206,7 @@ export default function reduce(state = initialState, action = {}) {
     };
 
   case LOAD_PLAYLIST_START: {
-    if (meta.page !== 0 || state.playlistItems[payload.playlistID]) {
+    if (meta.sneaky || meta.page !== 0 || state.playlistItems[payload.playlistID]) {
       return state;
     }
 


### PR DESCRIPTION
Fixes #413.

`shufflePlaylist` now only resolves when the playlist items have also been reloaded.