### PR TITLE
build: Fix locale import paths in lib/ and es/

### DIFF
--- a/tasks/js.js
+++ b/tasks/js.js
@@ -29,6 +29,12 @@ const rewriteLocaleImports = () => ({
     ImportDeclaration(path) {
       const source = path.get('source');
       source.node.value = source.node.value.replace(/^\.\.\/locale\/(.*?)\.yaml/, './locale/$1.js');
+    },
+    CallExpression(path) {
+      if (path.get('callee').isImport()) {
+        const source = path.get('arguments.0');
+        source.node.value = source.node.value.replace(/^\.\.\/locale\/(.*?)\.yaml/, './locale/$1.js');
+      }
     }
   }
 });


### PR DESCRIPTION
The babel build script for the lib/ and es/ folders rewrites imports for locale .yaml files to refer to compiled .js files, so it's possible to `require()` them. I broke this in #609, as most locale .yaml files are now loaded using `import('x')` calls rather than `import x from 'x'` statements.