### PR TITLE
Implement password reset page

### DIFF
--- a/locale/en.yaml
+++ b/locale/en.yaml
@@ -165,3 +165,6 @@ uwave:
     forgotPassword: Forgot Password?
     privacyPolicy: Privacy Policy
     agree: I am at least 13 years old and accept the {{privacyPolicy}}.
+  resetPassword:
+    introduction: Enter a new password below.
+    submit: Reset Password

--- a/locale/en.yaml
+++ b/locale/en.yaml
@@ -164,6 +164,7 @@ uwave:
     password: Password
     forgotPassword: Forgot Password?
     requestPasswordReset: Reset Password
+    passwordResetSent: "We've sent an email to that address with password reset instructions."
     privacyPolicy: Privacy Policy
     agree: I am at least 13 years old and accept the {{privacyPolicy}}.
   resetPassword:

--- a/locale/en.yaml
+++ b/locale/en.yaml
@@ -168,3 +168,4 @@ uwave:
   resetPassword:
     introduction: Enter a new password below.
     submit: Reset Password
+    success: Your password has been reset. You can now close this page.

--- a/locale/en.yaml
+++ b/locale/en.yaml
@@ -163,6 +163,7 @@ uwave:
     email: E-mail
     password: Password
     forgotPassword: Forgot Password?
+    requestPasswordReset: Reset Password
     privacyPolicy: Privacy Policy
     agree: I am at least 13 years old and accept the {{privacyPolicy}}.
   resetPassword:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2607,7 +2607,7 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.2.11",
+        "readable-stream": "2.3.3",
         "typedarray": "0.0.6"
       },
       "dependencies": {
@@ -2618,27 +2618,33 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.2.11",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-          "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
             "isarray": "1.0.0",
             "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.0.1",
-            "string_decoder": "1.0.2",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
             "util-deprecate": "1.0.2"
           }
         },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+          "dev": true
+        },
         "string_decoder": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
-          "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -15375,11 +15381,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -15426,6 +15427,11 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-0.2.0.tgz",
       "integrity": "sha1-q6Nt4I3O5qWjN9SbLqHaGyj8Ds8="
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringify-object": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "babel-register": "^6.22.0",
     "chai": "^4.1.1",
     "chai-enzyme": "^0.8.0",
+    "concat-stream": "^1.6.0",
     "copy-webpack-plugin": "^4.0.1",
     "cross-env": "^5.0.5",
     "css-loader": "^0.28.4",

--- a/src/actions/LoginActionCreators.js
+++ b/src/actions/LoginActionCreators.js
@@ -170,14 +170,10 @@ export function logout() {
 
 export function resetPassword(email) {
   return post('/auth/password/reset', email, {
-    onStart: () => ({
+    onComplete: () => ({
       type: RESET_PASSWORD_COMPLETE,
       payload: 'Successfully sent password reset email'
     }),
-    onComplete: token => (dispatch) => {
-      debug('reset token: ', token);
-      dispatch(closeLoginDialog());
-    },
     onError: error => ({
       type: RESET_PASSWORD_COMPLETE,
       error: true,

--- a/src/components/Dialogs/LoginDialog/ResetPasswordForm.js
+++ b/src/components/Dialogs/LoginDialog/ResetPasswordForm.js
@@ -14,10 +14,14 @@ class ResetPasswordForm extends React.Component {
   static propTypes = {
     t: PropTypes.func.isRequired,
     error: PropTypes.object,
-    onResetPassword: PropTypes.func
+    onResetPassword: PropTypes.func.isRequired,
+    onCloseDialog: PropTypes.func.isRequired
   };
 
-  state = { busy: false };
+  state = {
+    busy: false,
+    done: false
+  };
 
   componentWillReceiveProps() {
     this.setState({ busy: false });
@@ -26,8 +30,13 @@ class ResetPasswordForm extends React.Component {
   handleSubmit = (event) => {
     event.preventDefault();
     this.setState({ busy: true });
-    this.props.onResetPassword({
+    Promise.resolve(this.props.onResetPassword({
       email: this.email.value
+    })).then(() => {
+      this.setState({
+        busy: false,
+        done: true
+      });
     });
   };
 
@@ -36,8 +45,21 @@ class ResetPasswordForm extends React.Component {
   };
 
   render() {
-    const { t, error } = this.props;
-    const { busy } = this.state;
+    const { t, error, onCloseDialog } = this.props;
+    const { busy, done } = this.state;
+
+    if (done) {
+      return (
+        <div>
+          <p>{t('login.passwordResetSent')}</p>
+          <p>
+            <Button className="ResetPasswordForm-submit" onClick={onCloseDialog}>
+              {t('close')}
+            </Button>
+          </p>
+        </div>
+      );
+    }
 
     return (
       <Form className="ResetPasswordForm" onSubmit={this.handleSubmit}>

--- a/src/components/Dialogs/LoginDialog/ResetPasswordForm.js
+++ b/src/components/Dialogs/LoginDialog/ResetPasswordForm.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { translate } from 'react-i18next';
 import EmailIcon from 'material-ui/svg-icons/communication/email';
 import Loader from '../../Loader';
 import Form from '../../Form';
@@ -7,8 +8,11 @@ import FormGroup from '../../Form/Group';
 import TextField from '../../Form/TextField';
 import Button from '../../Form/Button';
 
-export default class ResetPasswordForm extends React.Component {
+const enhance = translate();
+
+class ResetPasswordForm extends React.Component {
   static propTypes = {
+    t: PropTypes.func.isRequired,
     error: PropTypes.object,
     onResetPassword: PropTypes.func
   };
@@ -32,7 +36,7 @@ export default class ResetPasswordForm extends React.Component {
   };
 
   render() {
-    const { error } = this.props;
+    const { t, error } = this.props;
     const { busy } = this.state;
 
     return (
@@ -53,10 +57,14 @@ export default class ResetPasswordForm extends React.Component {
             className="ResetPasswordForm-submit"
             disabled={busy}
           >
-            {busy ? <div className="Button-loading"><Loader size="tiny" /></div> : 'RESET PASSWORD'}
+            {busy ? (
+              <div className="Button-loading"><Loader size="tiny" /></div>
+            ) : t('login.requestPasswordReset')}
           </Button>
         </FormGroup>
       </Form>
     );
   }
 }
+
+export default enhance(ResetPasswordForm);

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -16,6 +16,12 @@ function injectTitle(transform, title) {
     .end(title);
 }
 
+function injectResetKey(transform, key) {
+  transform.select('#reset-data')
+    .createWriteStream()
+    .end(key);
+}
+
 export default function uwaveWebClient(uw, options = {}) {
   const {
     basePath = path.join(__dirname, '../public'),
@@ -38,12 +44,11 @@ export default function uwaveWebClient(uw, options = {}) {
     })
     .get('/reset/:key', (req, res) => {
       const transform = trumpet();
-      transform.select('#reset-data')
-        .createWriteStream()
-        .end(req.params.key);
+      injectTitle(transform, title);
+      injectConfig(transform, { apiUrl: clientOptions.apiUrl });
+      injectResetKey(transform, req.params.key);
 
       fs.createReadStream(path.join(basePath, 'password-reset.html'), 'utf8')
-        .pipe(injectConfig({ apiUrl: clientOptions.apiUrl }))
         .pipe(transform)
         .pipe(res);
     })

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -36,5 +36,16 @@ export default function uwaveWebClient(uw, options = {}) {
         .pipe(transform)
         .pipe(res);
     })
+    .get('/reset/:key', (req, res) => {
+      const transform = trumpet();
+      transform.select('#reset-data')
+        .createWriteStream()
+        .end(req.params.key);
+
+      fs.createReadStream(path.join(basePath, 'password-reset.html'), 'utf8')
+        .pipe(injectConfig({ apiUrl: clientOptions.apiUrl }))
+        .pipe(transform)
+        .pipe(res);
+    })
     .use(serveStatic(basePath));
 }

--- a/src/password-reset.html
+++ b/src/password-reset.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title><%= htmlWebpackPlugin.options.title %></title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,600,600italic,400italic">
+
+    <% for (const file in htmlWebpackPlugin.files.css) { %>
+      <link href="<%= htmlWebpackPlugin.files.css[file] %>" rel="stylesheet">
+    <% } %>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script id="u-wave-config" type="application/json"></script>
+    <script id="reset-data" type="text/plain"></script>
+    <% for (const chunk in htmlWebpackPlugin.files.chunks) { %>
+      <script src="<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"></script>
+    <% } %>
+  </body>
+</html>

--- a/src/password-reset/actions.js
+++ b/src/password-reset/actions.js
@@ -1,4 +1,7 @@
-import { SET_RESET_KEY } from './constants';
+import {
+  SET_RESET_KEY,
+  SET_RESET_SUCCESS
+} from './constants';
 import { post } from '../actions/RequestActionCreators';
 
 export function setResetKey(key) {
@@ -8,17 +11,21 @@ export function setResetKey(key) {
   };
 }
 
+export function resetPasswordComplete() {
+  return { type: SET_RESET_SUCCESS };
+}
+
 export function resetPassword(newPassword) {
   return (dispatch, getState) => {
     const { key } = getState().passwordReset;
 
-    dispatch(post(`/auth/password/reset/${key}`, {
-      email: null,
-      password: newPassword
-    }, {
-      onComplete(result) {
-        console.log(result);
-      }
+    return dispatch(post(`/auth/password/reset/${key}`, { password: newPassword }, {
+      onComplete: resetPasswordComplete,
+      onError: err => ({
+        type: SET_RESET_SUCCESS,
+        error: true,
+        payload: err
+      })
     }));
   };
 }

--- a/src/password-reset/actions.js
+++ b/src/password-reset/actions.js
@@ -1,0 +1,24 @@
+import { SET_RESET_KEY } from './constants';
+import { post } from '../actions/RequestActionCreators';
+
+export function setResetKey(key) {
+  return {
+    type: SET_RESET_KEY,
+    payload: key
+  };
+}
+
+export function resetPassword(newPassword) {
+  return (dispatch, getState) => {
+    const { key } = getState().passwordReset;
+
+    dispatch(post(`/auth/password/reset/${key}`, {
+      email: null,
+      password: newPassword
+    }, {
+      onComplete(result) {
+        console.log(result);
+      }
+    }));
+  };
+}

--- a/src/password-reset/app.css
+++ b/src/password-reset/app.css
@@ -1,0 +1,21 @@
+@import "normalize.css";
+
+@import "../vars.css";
+@import "../components/App/index.css";
+@import "../components/Form/index.css";
+@import "./components/PasswordResetPage/index.css";
+
+body {
+  margin: 0;
+}
+
+#app {
+  background: var(--background-color);
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  overflow-y: scroll;
+  padding-top: 20px;
+}

--- a/src/password-reset/app.js
+++ b/src/password-reset/app.js
@@ -1,10 +1,11 @@
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import React from 'react';
+import ReactDOM from 'react-dom';
 import { createStore, applyMiddleware, combineReducers } from 'redux';
 import { Provider } from 'react-redux';
 import { parse as parseQS } from 'querystring';
 import thunk from 'redux-thunk';
 import { AppContainer as HotContainer } from 'react-hot-loader';
+import createLocale from '../locale';
 import webApiRequest from '../store/request';
 import * as reducers from './reducers';
 import { setResetKey } from './actions';
@@ -27,10 +28,12 @@ const store = createStore(
 const qs = parseQS(location.search.slice(1));
 store.dispatch(setResetKey(key || qs.key));
 
-ReactDOM.render((
-  <HotContainer>
-    <Provider store={store}>
-      <App />
-    </Provider>
-  </HotContainer>
-), document.querySelector('#app'));
+createLocale('en').then((locale) => {
+  ReactDOM.render((
+    <HotContainer>
+      <Provider store={store}>
+        <App locale={locale} />
+      </Provider>
+    </HotContainer>
+  ), document.querySelector('#app'));
+});

--- a/src/password-reset/app.js
+++ b/src/password-reset/app.js
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { createStore, applyMiddleware, combineReducers } from 'redux';
+import { Provider } from 'react-redux';
+import { parse as parseQS } from 'querystring';
+import thunk from 'redux-thunk';
+import { AppContainer as HotContainer } from 'react-hot-loader';
+import webApiRequest from '../store/request';
+import * as reducers from './reducers';
+import { setResetKey } from './actions';
+import App from './containers/PasswordResetApp';
+
+import './app.css';
+
+const config = document.querySelector('#u-wave-config').textContent;
+const key = document.querySelector('#reset-data').textContent;
+
+const store = createStore(
+  combineReducers(reducers),
+  { config },
+  applyMiddleware(
+    thunk,
+    webApiRequest()
+  ),
+);
+
+const qs = parseQS(location.search.slice(1));
+store.dispatch(setResetKey(key || qs.key));
+
+ReactDOM.render((
+  <HotContainer>
+    <Provider store={store}>
+      <App />
+    </Provider>
+  </HotContainer>
+), document.querySelector('#app'));

--- a/src/password-reset/components/PasswordResetPage/index.css
+++ b/src/password-reset/components/PasswordResetPage/index.css
@@ -1,0 +1,5 @@
+.PasswordReset {
+  padding: 20px;
+  max-width: 780px;
+  margin: auto;
+}

--- a/src/password-reset/components/PasswordResetPage/index.js
+++ b/src/password-reset/components/PasswordResetPage/index.js
@@ -1,0 +1,103 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import EmailIcon from 'material-ui/svg-icons/communication/email';
+import PasswordIcon from 'material-ui/svg-icons/action/lock';
+import Paper from 'material-ui/Paper';
+import { translate } from 'react-i18next';
+import Form from '../../../components/Form';
+import FormGroup from '../../../components/Form/Group';
+import TextField from '../../../components/Form/TextField';
+import Button from '../../../components/Form/Button';
+
+const enhance = translate();
+
+class PasswordResetPage extends React.Component {
+  static propTypes = {
+    t: PropTypes.func.isRequired,
+    email: PropTypes.string.isRequired,
+    onSubmit: PropTypes.func.isRequired
+  };
+
+  state = {
+    newPassword: '',
+    newPasswordConfirm: ''
+  };
+
+  isValid() {
+    return this.state.newPassword.length >= 6 &&
+      this.state.newPassword === this.state.newPasswordConfirm;
+  }
+
+  handlePasswordChange = (event) => {
+    this.setState({
+      newPassword: event.target.value
+    });
+  };
+
+  handlePasswordConfirmChange = (event) => {
+    this.setState({
+      newPasswordConfirm: event.target.value
+    });
+  };
+
+  handleSubmit = (event) => {
+    event.preventDefault();
+
+    if (this.isValid()) {
+      this.props.onSubmit(this.state.newPassword);
+    }
+  };
+
+  render() {
+    const { t, email } = this.props;
+    const isValid = this.isValid();
+
+    return (
+      <Paper className="PasswordReset">
+        <p>
+          {t('resetPassword.introduction')}
+        </p>
+        <Form onSubmit={this.handleSubmit}>
+          {email && (
+            // Not used at the moment, but we may show (parts of) the user's
+            // email address on the reset page at some point.
+            <FormGroup>
+              <TextField
+                type="email"
+                disabled
+                value={email}
+                placeholder={t('login.email')}
+                icon={<EmailIcon color="#9f9d9e" />}
+              />
+            </FormGroup>
+          )}
+          <FormGroup>
+            <TextField
+              type="password"
+              value={this.state.newPassword}
+              onChange={this.handlePasswordChange}
+              placeholder={t('login.password')}
+              icon={<PasswordIcon color="#9f9d9e" />}
+            />
+          </FormGroup>
+          <FormGroup>
+            <TextField
+              type="password"
+              value={this.state.newPasswordConfirm}
+              onChange={this.handlePasswordConfirmChange}
+              placeholder={t('login.password')}
+              icon={<PasswordIcon color="#9f9d9e" />}
+            />
+          </FormGroup>
+          <FormGroup>
+            <Button disabled={!isValid}>
+              {t('login.login')}
+            </Button>
+          </FormGroup>
+        </Form>
+      </Paper>
+    );
+  }
+}
+
+export default enhance(PasswordResetPage);

--- a/src/password-reset/components/PasswordResetPage/index.js
+++ b/src/password-reset/components/PasswordResetPage/index.js
@@ -91,7 +91,7 @@ class PasswordResetPage extends React.Component {
           </FormGroup>
           <FormGroup>
             <Button disabled={!isValid}>
-              {t('login.login')}
+              {t('resetPassword.submit')}
             </Button>
           </FormGroup>
         </Form>

--- a/src/password-reset/components/PasswordResetSuccessPage/index.js
+++ b/src/password-reset/components/PasswordResetSuccessPage/index.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { translate } from 'react-i18next';
+import Paper from 'material-ui/Paper';
+
+const enhance = translate();
+
+const PasswordResetSuccessPage = ({ t }) => (
+  <Paper className="PasswordReset">
+    <p>{t('resetPassword.success')}</p>
+  </Paper>
+);
+
+PasswordResetSuccessPage.propTypes = {
+  t: PropTypes.func.isRequired
+};
+
+export default enhance(PasswordResetSuccessPage);

--- a/src/password-reset/constants.js
+++ b/src/password-reset/constants.js
@@ -1,4 +1,5 @@
 export const SET_RESET_KEY = 'uwave/password-reset/SET_RESET_KEY';
+export const SET_RESET_SUCCESS = 'uwave/password-reset/SET_RESET_SUCCESS';
 
 export const RESET_PASSWORD_START = 'uwave/password-reset/RESET_PASSWORD_START';
 export const RESET_PASSWORD_COMPLETE = 'uwave/password-reset/RESET_PASSWORD_COMPLETE';

--- a/src/password-reset/constants.js
+++ b/src/password-reset/constants.js
@@ -1,0 +1,4 @@
+export const SET_RESET_KEY = 'uwave/password-reset/SET_RESET_KEY';
+
+export const RESET_PASSWORD_START = 'uwave/password-reset/RESET_PASSWORD_START';
+export const RESET_PASSWORD_COMPLETE = 'uwave/password-reset/RESET_PASSWORD_COMPLETE';

--- a/src/password-reset/containers/PasswordResetApp.js
+++ b/src/password-reset/containers/PasswordResetApp.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
@@ -6,9 +6,6 @@ import { I18nextProvider } from 'react-i18next';
 import { resetPassword } from '../actions';
 import PasswordResetPage from '../components/PasswordResetPage';
 import { muiThemeSelector } from '../../selectors/settingSelectors';
-import createLocale from '../../locale';
-
-const HARDCODED_LOCALE = 'en';
 
 const mapStateToProps = createStructuredSelector({
   muiTheme: muiThemeSelector
@@ -20,16 +17,17 @@ const mapDispatchToProps = {
 
 const enhance = connect(mapStateToProps, mapDispatchToProps);
 
-const PasswordResetApp = ({ ...props, muiTheme }) => (
+const PasswordResetApp = ({ muiTheme, locale, ...props }) => (
   <MuiThemeProvider muiTheme={muiTheme}>
-    <I18nextProvider i18n={createLocale(HARDCODED_LOCALE)}>
+    <I18nextProvider i18n={locale}>
       <PasswordResetPage {...props} />
     </I18nextProvider>
   </MuiThemeProvider>
 );
 
 PasswordResetApp.propTypes = {
-  muiTheme: React.PropTypes.object.isRequired
+  muiTheme: React.PropTypes.object.isRequired,
+  locale: React.PropTypes.object.isRequired
 };
 
 export default enhance(PasswordResetApp);

--- a/src/password-reset/containers/PasswordResetApp.js
+++ b/src/password-reset/containers/PasswordResetApp.js
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { createStructuredSelector } from 'reselect';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import { I18nextProvider } from 'react-i18next';
+import { resetPassword } from '../actions';
+import PasswordResetPage from '../components/PasswordResetPage';
+import { muiThemeSelector } from '../../selectors/settingSelectors';
+import createLocale from '../../locale';
+
+const HARDCODED_LOCALE = 'en';
+
+const mapStateToProps = createStructuredSelector({
+  muiTheme: muiThemeSelector
+});
+
+const mapDispatchToProps = {
+  onSubmit: resetPassword
+};
+
+const enhance = connect(mapStateToProps, mapDispatchToProps);
+
+const PasswordResetApp = ({ ...props, muiTheme }) => (
+  <MuiThemeProvider muiTheme={muiTheme}>
+    <I18nextProvider i18n={createLocale(HARDCODED_LOCALE)}>
+      <PasswordResetPage {...props} />
+    </I18nextProvider>
+  </MuiThemeProvider>
+);
+
+PasswordResetApp.propTypes = {
+  muiTheme: React.PropTypes.object.isRequired
+};
+
+export default enhance(PasswordResetApp);

--- a/src/password-reset/containers/PasswordResetApp.js
+++ b/src/password-reset/containers/PasswordResetApp.js
@@ -1,14 +1,18 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import { I18nextProvider } from 'react-i18next';
 import { resetPassword } from '../actions';
+import ErrorArea from '../../containers/ErrorArea';
 import PasswordResetPage from '../components/PasswordResetPage';
+import PasswordResetSuccessPage from '../components/PasswordResetSuccessPage';
 import { muiThemeSelector } from '../../selectors/settingSelectors';
 
 const mapStateToProps = createStructuredSelector({
-  muiTheme: muiThemeSelector
+  muiTheme: muiThemeSelector,
+  success: state => state.passwordReset.success
 });
 
 const mapDispatchToProps = {
@@ -17,17 +21,25 @@ const mapDispatchToProps = {
 
 const enhance = connect(mapStateToProps, mapDispatchToProps);
 
-const PasswordResetApp = ({ muiTheme, locale, ...props }) => (
+const PasswordResetApp = ({ muiTheme, locale, success, ...props }) => (
   <MuiThemeProvider muiTheme={muiTheme}>
     <I18nextProvider i18n={locale}>
-      <PasswordResetPage {...props} />
+      <div>
+        {success ? (
+          <PasswordResetSuccessPage />
+        ) : (
+          <PasswordResetPage {...props} />
+        )}
+        <ErrorArea />
+      </div>
     </I18nextProvider>
   </MuiThemeProvider>
 );
 
 PasswordResetApp.propTypes = {
-  muiTheme: React.PropTypes.object.isRequired,
-  locale: React.PropTypes.object.isRequired
+  muiTheme: PropTypes.object.isRequired,
+  locale: PropTypes.object.isRequired,
+  success: PropTypes.bool
 };
 
 export default enhance(PasswordResetApp);

--- a/src/password-reset/index.html
+++ b/src/password-reset/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title><%= htmlWebpackPlugin.options.title %></title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,600,600italic,400italic">
+
+    <% for (const file in htmlWebpackPlugin.files.css) { %>
+      <link href="<%= htmlWebpackPlugin.files.css[file] %>" rel="stylesheet">
+    <% } %>
+  </head>
+  <body>
+    <div id="app"></div>
+    <% for (const chunk in htmlWebpackPlugin.files.chunks) { %>
+      <script src="<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"></script>
+    <% } %>
+  </body>
+</html>

--- a/src/password-reset/reducers.js
+++ b/src/password-reset/reducers.js
@@ -1,15 +1,26 @@
-import { SET_RESET_KEY } from './constants';
+import {
+  SET_RESET_KEY,
+  SET_RESET_SUCCESS
+} from './constants';
 
 export auth from '../reducers/auth';
 export config from '../reducers/config';
+export errors from '../reducers/errors';
 export theme from '../reducers/theme';
 
 export function passwordReset(state = {}, action = {}) {
+  if (action.error) return state;
+
   switch (action.type) {
   case SET_RESET_KEY:
     return {
       ...state,
       key: action.payload
+    };
+  case SET_RESET_SUCCESS:
+    return {
+      ...state,
+      success: true
     };
 
   default:

--- a/src/password-reset/reducers.js
+++ b/src/password-reset/reducers.js
@@ -1,0 +1,18 @@
+import { SET_RESET_KEY } from './constants';
+
+export auth from '../reducers/auth';
+export config from '../reducers/config';
+export theme from '../reducers/theme';
+
+export function passwordReset(state = {}, action = {}) {
+  switch (action.type) {
+  case SET_RESET_KEY:
+    return {
+      ...state,
+      key: action.payload
+    };
+
+  default:
+    return state;
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,6 +52,14 @@ const plugins = [
     minify: nodeEnv === 'production' ? htmlMinifierOptions : false,
     loadingScreen: () => require('./tasks/utils/renderLoadingScreen')()
   }),
+  new HtmlPlugin({
+    chunks: [ 'passwordReset' ],
+    inject: false,
+    template: './password-reset.html',
+    filename: 'password-reset.html',
+    title: 'Reset Password',
+    minify: nodeEnv === 'production' ? htmlMinifierOptions : false
+  }),
   extractAppCss,
   new ProgressPlugin(),
   new LodashModuleReplacementPlugin({
@@ -87,7 +95,8 @@ if (nodeEnv === 'production') {
 
 const context = path.join(__dirname, 'src');
 const entries = {
-  app: [ './app.js', './app.css' ]
+  app: [ './app.js', './app.css' ],
+  passwordReset: [ './password-reset/app.js' ]
 };
 
 // Add static pages.


### PR DESCRIPTION
Client-side part of u-wave/api#89.

This adds a new app entry point under the `src/password-reset` folder. This app only renders a form to enter a new password.

The development server logs password reset email contents to the console.