### PR TITLE
Fix HMR rerendering (work around webpack bug I guess?)

### DIFF
--- a/src/Uwave.js
+++ b/src/Uwave.js
@@ -41,9 +41,10 @@ export default class Uwave {
       this.getComponent = () => (
         <HotContainer>{this._getComponent()}</HotContainer>
       );
+      const uw = this;
       module.hot.accept('./containers/App', () => {
-        if (this.renderTarget) {
-          this.renderToDOM(this.renderTarget);
+        if (uw.renderTarget) {
+          uw.renderToDOM(uw.renderTarget);
         }
       });
     }


### PR DESCRIPTION
Webpack would rewrite the `accept` callback to a normal function,
breaking the `this` binding.