### PR TITLE
search: auto-switch sources for recognisable URLs

### DIFF
--- a/src/actions/SearchActionCreators.js
+++ b/src/actions/SearchActionCreators.js
@@ -1,3 +1,4 @@
+import find from 'array-find';
 import {
   SET_SEARCH_SOURCE,
   SHOW_SEARCH_RESULTS,
@@ -41,4 +42,22 @@ export function search(query) {
       payload: error
     })
   });
+}
+
+export function searchInRecommendedSource(sources, query) {
+  const sourceNames = Object.keys(sources);
+  const matchName = find(sourceNames, (sourceName) => {
+    const source = sources[sourceName];
+    if (!source || typeof source.isSourceQuery !== 'function') {
+      return false;
+    }
+    return source.isSourceQuery(query);
+  });
+
+  return (dispatch) => {
+    if (matchName) {
+      dispatch(setSource(matchName));
+    }
+    return dispatch(search(query));
+  };
 }

--- a/src/containers/MediaSearchBar.js
+++ b/src/containers/MediaSearchBar.js
@@ -1,8 +1,12 @@
+import PropTypes from 'prop-types';
 import { createStructuredSelector } from 'reselect';
 import { connect } from 'react-redux';
+import compose from 'recompose/compose';
+import getContext from 'recompose/getContext';
+import withProps from 'recompose/withProps';
 import SearchBar from '../components/PlaylistManager/Header/SearchBar';
 import {
-  search,
+  searchInRecommendedSource,
   setSource
 } from '../actions/SearchActionCreators';
 import {
@@ -14,8 +18,17 @@ const mapStateToProps = createStructuredSelector({
 });
 
 const mapDispatchToProps = {
-  onSubmit: search,
+  onSubmit: searchInRecommendedSource,
   onSourceChange: setSource
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(SearchBar);
+const enhance = compose(
+  connect(mapStateToProps, mapDispatchToProps),
+  getContext({ uwave: PropTypes.object }),
+  withProps(props => ({
+    // Add media sources to `onSubmit` handler.
+    onSubmit: query => props.onSubmit(props.uwave.sources, query)
+  }))
+);
+
+export default enhance(SearchBar);

--- a/src/sources/soundcloud/index.js
+++ b/src/sources/soundcloud/index.js
@@ -1,3 +1,3 @@
 export Player from './PlayerWrapper';
-
+export isSourceQuery from './isSourceQuery';
 export logo from '../../../assets/img/soundcloud.png';

--- a/src/sources/soundcloud/isSourceQuery.js
+++ b/src/sources/soundcloud/isSourceQuery.js
@@ -1,0 +1,3 @@
+export default function isSourceQuery(text) {
+  return /https?:\/\/soundcloud\.com/.test(text);
+}

--- a/src/sources/youtube/index.js
+++ b/src/sources/youtube/index.js
@@ -1,8 +1,6 @@
 export Player from './Player';
-
-export logo from '../../../assets/img/youtube.png';
-
+export isSourceQuery from './isSourceQuery';
 export ImportForm from './ImportForm';
 export ImportPanel from './ImportPanel';
-
 export reducer from './reducer';
+export logo from '../../../assets/img/youtube.png';

--- a/src/sources/youtube/isSourceQuery.js
+++ b/src/sources/youtube/isSourceQuery.js
@@ -1,0 +1,5 @@
+export default function isSourceQuery(text) {
+  // matching youtu.be, youtube.com, youtube-nocookie
+  return /https?:\/\/.*?youtu\.?be.*?\//.test(text);
+}
+


### PR DESCRIPTION
When you paste a youtube or soundcloud link into the search field, you
don't have to also manually switch sources.

This adds an `isSourceQuery` method to the media source interface. It
receives a string search query, and can return `true` if the search
query can in all likelihood only be fulfilled by this media source.
üWave then auto-selects that search source before actually executing the
search.