### PR TITLE
youtube: Fix previous video restarting in the background when switching media source

### DIFF
--- a/src/sources/youtube/PlayerEmbed.js
+++ b/src/sources/youtube/PlayerEmbed.js
@@ -16,7 +16,7 @@ export default class YouTubePlayerEmbed extends React.Component {
   };
 
   handleYTPause = (event) => {
-    if (!this.props.controllable) {
+    if (!this.props.controllable && this.props.active) {
       event.target.playVideo();
     }
   };


### PR DESCRIPTION
The force-play-on-pause code was calling `playVideo` even when we explicitly called `stopVideo` because the next media was on a different media source. This didn't use to be a problem, I think the old YT player didn't emit the pause event when `stopVideo` was called. Anyway, this only unpauses the video if the current media is from YouTube, which fixes the problem.