### PR TITLE
Fix/settingspanel design

### DIFF
--- a/src/components/SettingsManager/Profile.css
+++ b/src/components/SettingsManager/Profile.css
@@ -1,8 +1,27 @@
 .SettingsPanelProfile-username {
   font-size: 120%;
   font-weight: normal;
+  display:block;
+  margin: 0;
 }
 .SettingsPanelProfile-avatar {
-  width: 120px;
-  height: 120px;
+  width: 80px;
+  height: 80px;
+}
+
+.SettingsPanelProfile-textblock{
+  display:inline-block;
+  padding-left: 20px;
+  vertical-align: top;
+}
+
+.SettingsPanelProfile-date {
+  line-height: 1.5;
+  color: #aaa;
+  margin: 0;
+}
+
+.SettingsPanelProfile-role {
+  line-height: 1.5;
+  margin: 0;
 }

--- a/src/components/SettingsManager/Profile.css
+++ b/src/components/SettingsManager/Profile.css
@@ -1,7 +1,7 @@
 .SettingsPanelProfile-username {
   font-size: 120%;
   font-weight: normal;
-  display:block;
+  display: block;
   margin: 0;
 }
 .SettingsPanelProfile-avatar {
@@ -9,8 +9,8 @@
   height: 80px;
 }
 
-.SettingsPanelProfile-textblock{
-  display:inline-block;
+.SettingsPanelProfile-textblock {
+  display: inline-block;
   padding-left: 20px;
   vertical-align: top;
 }

--- a/src/components/SettingsManager/Profile.js
+++ b/src/components/SettingsManager/Profile.js
@@ -4,19 +4,52 @@ import PropTypes from 'prop-types';
 import Avatar from '../Avatar';
 import ChangeUsernameButton from './ChangeUsernameButton';
 
+const tempRoleIDToReadableName = [
+  'User',
+  'Special',
+  'Moderator',
+  'Manager',
+  'Admin'
+];
+
+const formatJoinDate = date => new Date(date).toLocaleString([], {
+  year: 'numeric',
+  month: 'numeric',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric'
+});
+
+// MuiTheme needs still to be implemented for SettingsPanel Profiles
+// const tempRoleIDToRoleName = {
+//   0: 'default',
+//   1: 'special',
+//   2: 'moderator',
+//   3: 'manager',
+//   4: 'admin'
+// };
+
 const Profile = ({ className, user, onChangeUsername }) => (
   <div className={cx('SettingsPanelProfile', className)}>
     <Avatar
       className="SettingsPanelProfile-avatar"
       user={user}
     />
-    <h2 className="SettingsPanelProfile-username">
-      {user.username}
-      <ChangeUsernameButton
-        onChangeUsername={onChangeUsername}
-        initialUsername={user.username}
-      />
-    </h2>
+    <div className="SettingsPanelProfile-textblock">
+      <h2 className="SettingsPanelProfile-username">
+        {user.username}
+        <ChangeUsernameButton
+          onChangeUsername={onChangeUsername}
+          initialUsername={user.username}
+        />
+      </h2>
+      <a className="SettingsPanelProfile-role">
+        {tempRoleIDToReadableName[user.role]}
+      </a>
+      <p className="SettingsPanelProfile-date">
+        {formatJoinDate(user.createdAt)}
+      </p>
+    </div>
   </div>
 );
 

--- a/src/components/SettingsManager/Profile.js
+++ b/src/components/SettingsManager/Profile.js
@@ -1,8 +1,11 @@
+import muiThemeable from 'material-ui/styles/muiThemeable';
 import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import Avatar from '../Avatar';
 import ChangeUsernameButton from './ChangeUsernameButton';
+
+const enhance = muiThemeable();
 
 const tempRoleIDToReadableName = [
   'User',
@@ -20,16 +23,17 @@ const formatJoinDate = date => new Date(date).toLocaleString([], {
   minute: 'numeric'
 });
 
-// MuiTheme needs still to be implemented for SettingsPanel Profiles
-// const tempRoleIDToRoleName = {
-//   0: 'default',
-//   1: 'special',
-//   2: 'moderator',
-//   3: 'manager',
-//   4: 'admin'
-// };
 
-const Profile = ({ className, user, onChangeUsername }) => (
+const tempRoleIDToRoleName = {
+  0: 'default',
+  1: 'special',
+  2: 'moderator',
+  3: 'manager',
+  4: 'admin'
+};
+
+
+const Profile = ({ className, user, onChangeUsername, muiTheme }) => (
   <div className={cx('SettingsPanelProfile', className)}>
     <Avatar
       className="SettingsPanelProfile-avatar"
@@ -43,9 +47,9 @@ const Profile = ({ className, user, onChangeUsername }) => (
           initialUsername={user.username}
         />
       </h2>
-      <a className="SettingsPanelProfile-role">
+      <p style={{ color: muiTheme.rankColors[tempRoleIDToRoleName[user.role]] }} className="SettingsPanelProfile-role">
         {tempRoleIDToReadableName[user.role]}
-      </a>
+      </p>
       <p className="SettingsPanelProfile-date">
         {formatJoinDate(user.createdAt)}
       </p>
@@ -57,7 +61,8 @@ Profile.propTypes = {
   className: PropTypes.string,
   user: PropTypes.object.isRequired,
 
-  onChangeUsername: PropTypes.func.isRequired
+  onChangeUsername: PropTypes.func.isRequired,
+  muiTheme: PropTypes.object.isRequired
 };
 
-export default Profile;
+export default enhance(Profile);

--- a/src/components/SettingsManager/SettingsPanel.js
+++ b/src/components/SettingsManager/SettingsPanel.js
@@ -85,6 +85,9 @@ class SettingsPanel extends React.Component {
               />
             </LabeledControl>
           </div>
+          <hr className="SettingsPanel-divider" />
+          <Links />
+          <hr className="SettingsPanel-divider" />
           <LogoutButton onLogout={onLogout} />
         </div>
         <div className="SettingsPanel-column SettingsPanel-column--right">
@@ -93,7 +96,6 @@ class SettingsPanel extends React.Component {
             onSettingChange={this.props.onSettingChange}
           />
           <hr className="SettingsPanel-divider" />
-          <Links />
         </div>
       </div>
     );


### PR DESCRIPTION
This PR includes a small overhaul of the settings panel. 
That includes: 

- aligned the settings content to the left side
- seperating the Sign Out Button from everything else
- smaller Avatar
- user information next to the avatar, based on the usercard design