### PR TITLE
build: Add common-shake.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - 8
   - 7
   - 6
-  - 4
 
 before_install:
   - npm install -g npm@latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -2725,6 +2725,28 @@
         "graceful-readlink": "1.0.1"
       }
     },
+    "common-shake": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/common-shake/-/common-shake-2.0.2.tgz",
+      "integrity": "sha512-FS+V3q90bmUYGAJrZ1azUBFxQtLrtoeEyALuRnlzTHnAY0LXLk0RQlJKp4QlttmtxEFDbdwKy14HVbFOYUz6nA==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.1.1",
+        "debug": "2.6.9",
+        "escope": "3.6.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -4721,11 +4743,6 @@
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
       }
-    },
-    "es6-promise": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
-      "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
     },
     "es6-set": {
       "version": "0.1.5",
@@ -7441,6 +7458,11 @@
         "svgo": "0.7.2"
       }
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -8330,6 +8352,14 @@
       "requires": {
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2"
+      }
+    },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+      "requires": {
+        "immediate": "3.0.6"
       }
     },
     "liftoff": {
@@ -17071,6 +17101,18 @@
             "webpack-sources": "1.0.1"
           }
         }
+      }
+    },
+    "webpack-common-shake": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/webpack-common-shake/-/webpack-common-shake-1.5.3.tgz",
+      "integrity": "sha512-TsOcSYbE6eSmVudGvlo4LRTggJ26Q/U0jEA0yaRP+L4nKknAjCq2Ps5A6me2pcWvKgronALMcEkAcKQNbRCy2w==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.1.1",
+        "common-shake": "2.0.2",
+        "webpack": "3.5.5",
+        "webpack-sources": "1.0.1"
       }
     },
     "webpack-dev-middleware": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "classnames": "^2.2.4",
     "debug": "^3.0.1",
     "deepmerge": "^1.5.1",
-    "es6-promise": "^4.1.1",
     "escape-string-regexp": "^1.0.3",
     "except": "^0.1.3",
     "format-duration": "^1.0.0",
@@ -27,6 +26,7 @@
     "index-by": "0.0.1",
     "is-equal-shallow": "^0.1.3",
     "item-selection": "^1.0.0",
+    "lie": "^3.1.1",
     "load-script2": "^1.0.0",
     "lodash": "^4.12.0",
     "material-ui": "^0.19.0",
@@ -142,6 +142,7 @@
     "u-wave-web-emojione": "^2.0.0",
     "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
     "webpack": "^3.5.5",
+    "webpack-common-shake": "^1.5.3",
     "webpack-dev-middleware": "^1.12.0",
     "webpack-hot-middleware": "^2.18.2",
     "yaml-loader": "^0.5.0"

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
     "html-webpack-plugin": "^2.30.1",
     "http-proxy-middleware": "^0.17.4",
     "image-webpack-loader": "^3.2.0",
-    "json-loader": "^0.5.7",
     "lodash-webpack-plugin": "^0.11.1",
     "loud-rejection": "^1.6.0",
     "mocha": "^3.5.0",

--- a/src/Uwave.js
+++ b/src/Uwave.js
@@ -1,6 +1,6 @@
 // Polyfills for browsers that might not yet support Promises or the Fetch API
 // (newer & better XMLHttpRequest).
-import 'es6-promise';
+import 'lie/polyfill';
 import 'whatwg-fetch';
 
 import React from 'react';

--- a/src/locale.js
+++ b/src/locale.js
@@ -1,5 +1,5 @@
 import i18next from 'i18next';
-import en from '../locale/en.yaml';
+import * as en from '../locale/en.yaml';
 
 const resources = {
   cs: () => import('../locale/cs.yaml'),

--- a/tasks/utils/jsonLoader.js
+++ b/tasks/utils/jsonLoader.js
@@ -1,0 +1,16 @@
+/**
+ * A JSON loader that outputs ES modules.
+ */
+
+module.exports = function jsonLoader (source) {
+  this.cacheable();
+
+  const object = JSON.parse(source);
+  const output = [];
+
+  Object.entries(object).forEach(([ key, value ]) => {
+    output.push(`export const ${key} = ${JSON.stringify(value, null, 2)};`);
+  });
+
+  return output.join('\n\n');
+}

--- a/tasks/utils/jsonLoader.js
+++ b/tasks/utils/jsonLoader.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * A JSON loader that outputs ES modules.
  */

--- a/tasks/utils/jsonLoader.js
+++ b/tasks/utils/jsonLoader.js
@@ -2,7 +2,7 @@
  * A JSON loader that outputs ES modules.
  */
 
-module.exports = function jsonLoader (source) {
+module.exports = function jsonLoader(source) {
   this.cacheable();
 
   const object = JSON.parse(source);
@@ -13,4 +13,4 @@ module.exports = function jsonLoader (source) {
   });
 
   return output.join('\n\n');
-}
+};

--- a/tasks/utils/jsonLoader.js
+++ b/tasks/utils/jsonLoader.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * A JSON loader that outputs ES modules.
  */
@@ -8,7 +10,8 @@ module.exports = function jsonLoader(source) {
   const object = JSON.parse(source);
   const output = [];
 
-  Object.entries(object).forEach(([ key, value ]) => {
+  Object.keys(object).forEach((key) => {
+    const value = object[key];
     output.push(`export const ${key} = ${JSON.stringify(value, null, 2)};`);
   });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,11 +80,7 @@ if (nodeEnv === 'production') {
       minimize: true,
       debug: false
     }),
-    new CommonShakePlugin({
-      onExportDelete(resource, property) {
-        console.log('rm', resource, property);
-      }
-    }),
+    new CommonShakePlugin(),
     new UglifyJsPlugin({
       sourceMap: true,
       uglifyOptions: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -72,12 +72,18 @@ if (nodeEnv === 'production') {
   const OccurrenceOrderPlugin = require('webpack').optimize.OccurrenceOrderPlugin;
   const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
   const ModuleConcatenationPlugin = require('webpack').optimize.ModuleConcatenationPlugin;
+  const CommonShakePlugin = require('webpack-common-shake').Plugin;
 
   plugins.push(
     new OccurrenceOrderPlugin(),
     new LoaderOptionsPlugin({
       minimize: true,
       debug: false
+    }),
+    new CommonShakePlugin({
+      onExportDelete(resource, property) {
+        console.log('rm', resource, property);
+      }
     }),
     new UglifyJsPlugin({
       sourceMap: true,
@@ -174,11 +180,7 @@ module.exports = {
       },
       {
         test: /\.yaml$/,
-        use: [ 'json-loader', 'yaml-loader' ]
-      },
-      {
-        test: /\.json$/,
-        use: [ 'json-loader' ]
+        use: [ require.resolve('./tasks/utils/jsonLoader'), 'yaml-loader' ]
       },
       // JS loader for dependencies that use ES2015+:
       {


### PR DESCRIPTION
Saves a decent amount of bytes in the output by tree-shaking CommonJS modules, in addition to Webpack's tree-shaking of ES modules.

Replaces `es6-promise` with `lie` which has the same functionality but does not use `require()` in a way that makes common-shake bail out.