### PR TITLE
Fix UserCards opening slowly near window edge.

### DIFF
--- a/src/components/UserCard/index.js
+++ b/src/components/UserCard/index.js
@@ -18,11 +18,11 @@ class UserCardWrapper extends React.Component {
   };
 
   componentDidMount() {
-    this.fitInsideWindow();
+    this.shouldFit = true;
   }
 
   componentDidUpdate() {
-    this.fitInsideWindow();
+    this.shouldFit = true;
   }
 
   fitInsideWindow() {
@@ -35,13 +35,16 @@ class UserCardWrapper extends React.Component {
     const offsetBottom = window.innerHeight - rect.bottom;
     if (offsetBottom < 0) {
       this.setState({
-        positionDiffY: offsetBottom
+        positionDiffY: offsetBottom - 1
       });
     }
   }
 
   refContainer = (container) => {
     this.container = container;
+    if (this.shouldFit && container) {
+      this.fitInsideWindow();
+    }
   };
 
   render() {


### PR DESCRIPTION
Leaves a little margin at the bottom so the it'll definitely fit on the next calculation.

A better fix would be to only call `fitInsideWindow` if the current update was not triggered by `setState`… may switch this PR to do that later on