### PR TITLE
deps: truncate-url → crop-url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2860,6 +2860,11 @@
         "sha.js": "2.4.9"
       }
     },
+    "crop-url": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crop-url/-/crop-url-1.0.0.tgz",
+      "integrity": "sha512-DZZnuMlURBo6a0lYhGf9o7+APdh73YA5BUZUNtDPXr/JPOtu5l6upfWQ8iUh1RQVDrsiBdU3+OsHjHFF57XJ0w=="
+    },
     "cross-env": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "array-findindex": "^0.1.0",
     "classnames": "^2.2.4",
     "connect-gzip-static": "^2.1.1",
+    "crop-url": "^1.0.0",
     "debug": "^3.1.0",
     "deepmerge": "^1.5.2",
     "escape-string-regexp": "^1.0.3",

--- a/src/components/Chat/Markup/Link.js
+++ b/src/components/Chat/Markup/Link.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import truncate from 'truncate-url';
+import cropUrl from 'crop-url';
 
 const Link = ({ children, href, ...props }) => (
   <a
@@ -10,7 +10,7 @@ const Link = ({ children, href, ...props }) => (
     rel="noopener noreferrer"
     {...props}
   >
-    {truncate(children, 60)}
+    {cropUrl(children, 60)}
   </a>
 );
 


### PR DESCRIPTION
This one's a bit smaller and faster. This way we don't include the node
url and querystring modules anymore.