### PR TITLE
deps: truncate-url → shorten-url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14887,6 +14887,11 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "shorten-url": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shorten-url/-/shorten-url-1.0.0.tgz",
+      "integrity": "sha512-dqMa3Vppygf1xo20oxJv3l1z46fpTXg+TlqnfE+4iN3l8DQ51BTVqmoMmZ+7ra+6lUfYNZeSmTjW27nVf9B3mw=="
+    },
     "sigmund": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
@@ -15939,11 +15944,6 @@
           }
         }
       }
-    },
-    "truncate-url": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/truncate-url/-/truncate-url-1.0.0.tgz",
-      "integrity": "sha1-hiGabDV12bch04aRvwjISqWtqkI="
     },
     "tryit": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -61,9 +61,9 @@
     "reselect": "^3.0.0",
     "router": "^1.3.2",
     "screenfull": "^3.3.1",
+    "shorten-url": "^1.0.0",
     "splitargs": "0.0.7",
     "trumpet": "^1.7.2",
-    "truncate-url": "^1.0.0",
     "u-wave-parse-chat-markup": "^2.1.0",
     "whatwg-fetch": "^2.0.0",
     "yamlify": "^0.2.0"

--- a/src/components/Chat/Markup/Link.js
+++ b/src/components/Chat/Markup/Link.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import truncate from 'truncate-url';
+import shortenUrl from 'shorten-url';
 
 const Link = ({ children, href, ...props }) => (
   <a
@@ -10,7 +10,7 @@ const Link = ({ children, href, ...props }) => (
     rel="noopener noreferrer"
     {...props}
   >
-    {truncate(children, 60)}
+    {shortenUrl(children, 60)}
   </a>
 );
 


### PR DESCRIPTION
This one's a bit smaller and faster. This way we don't include the node
url and querystring modules anymore.

Like #771 but `shorten-url` does keep the `https?://` scheme in front.