### PR TITLE
socket: Ignore `error` actions, fixes #775.

### DIFF
--- a/src/store/socket.js
+++ b/src/store/socket.js
@@ -211,7 +211,13 @@ export default function middleware({ url = defaultUrl() } = {}) {
     }
 
     return next => (action) => {
-      const { type, payload } = action;
+      const { type, payload, error } = action;
+
+      if (error) {
+        next(action);
+        return;
+      }
+
       switch (type) {
       case SOCKET_RECONNECT:
         if (socket) {


### PR DESCRIPTION
We were trying to send the authentication token to the socket whenever the `LOGIN_COMPLETE` action came in, even if it was a failed login. In that case we would send `undefined` and mark the authentication as complete, so once a login attempt was successful, we would not send the correct token.