### PR TITLE
Implement skip notifications

### DIFF
--- a/locale/en.yaml
+++ b/locale/en.yaml
@@ -29,6 +29,10 @@ uwave:
     userJoin: "{{username}} joined the room"
     userLeave: "{{username}} left the room"
     userNameChanged: "{{username}} changed their nickname to {{newUsername}}"
+    modSkip: "{{username}} skipped {{djName}}'s turn"
+    modSkipReason: "{{username}} skipped {{djName}}'s turn: {{reason}}"
+    selfSkip: "{{username}} skipped their turn"
+    selfSkipReason: "{{username}} skipped their turn: {{reason}}"
 
   dialogs:
     confirm:

--- a/src/actions/BoothActionCreators.js
+++ b/src/actions/BoothActionCreators.js
@@ -1,5 +1,6 @@
 import {
   ADVANCE,
+  BOOTH_SKIP,
   LOAD_HISTORY_START, LOAD_HISTORY_COMPLETE
 } from '../constants/actionTypes/booth';
 import { flattenPlaylistItem } from './PlaylistActionCreators';
@@ -56,6 +57,21 @@ export function skipSelf(opts = {}) {
       return dispatch(post('/booth/skip', { remove }));
     }
     return Promise.reject(new Error('You\'re not currently playing.'));
+  };
+}
+
+export function skipped({ userID, moderatorID, reason }) {
+  return (dispatch, getState) => {
+    const users = usersSelector(getState());
+    dispatch({
+      type: BOOTH_SKIP,
+      payload: {
+        user: users[userID],
+        moderator: users[moderatorID],
+        reason,
+        timestamp: Date.now()
+      }
+    });
   };
 }
 

--- a/src/components/Chat/ChatMessages.js
+++ b/src/components/Chat/ChatMessages.js
@@ -1,21 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import LogMessage from './LogMessage';
 import Message from './Message';
-import JoinMessage from './NotificationMessages/JoinMessage';
-import LeaveMessage from './NotificationMessages/LeaveMessage';
-import NameChangedMessage from './NotificationMessages/NameChangedMessage';
-import SkipMessage from './NotificationMessages/SkipMessage';
 import Motd from './Motd';
 import ScrollDownNotice from './ScrollDownNotice';
-
-const specialTypes = {
-  log: LogMessage,
-  userJoin: JoinMessage,
-  userLeave: LeaveMessage,
-  userNameChanged: NameChangedMessage,
-  skip: SkipMessage
-};
+import specialMessages from './specialMessages';
 
 export default class ChatMessages extends React.Component {
   static propTypes = {
@@ -109,7 +97,7 @@ export default class ChatMessages extends React.Component {
   }
 
   renderMessage(msg) {
-    const SpecialMessage = specialTypes[msg.type];
+    const SpecialMessage = specialMessages[msg.type];
     if (SpecialMessage) {
       return (
         <SpecialMessage

--- a/src/components/Chat/ChatMessages.js
+++ b/src/components/Chat/ChatMessages.js
@@ -5,6 +5,7 @@ import Message from './Message';
 import JoinMessage from './NotificationMessages/JoinMessage';
 import LeaveMessage from './NotificationMessages/LeaveMessage';
 import NameChangedMessage from './NotificationMessages/NameChangedMessage';
+import SkipMessage from './NotificationMessages/SkipMessage';
 import Motd from './Motd';
 import ScrollDownNotice from './ScrollDownNotice';
 
@@ -12,7 +13,8 @@ const specialTypes = {
   log: LogMessage,
   userJoin: JoinMessage,
   userLeave: LeaveMessage,
-  userNameChanged: NameChangedMessage
+  userNameChanged: NameChangedMessage,
+  skip: SkipMessage
 };
 
 export default class ChatMessages extends React.Component {

--- a/src/components/Chat/NotificationMessages/SkipMessage.js
+++ b/src/components/Chat/NotificationMessages/SkipMessage.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { translate } from 'react-i18next';
 import PropTypes from 'prop-types';
 import Username from '../../Username';
 import UserNotificationMessage from './UserNotificationMessage';
@@ -14,7 +15,10 @@ const getLangKey = (hasModerator, hasReason) => {
   return hasModerator ? 'chat.modSkip' : 'chat.selfSkip';
 };
 
+const enhance = translate();
+
 const SkipMessage = ({
+  t,
   user,
   moderator,
   reason,
@@ -26,16 +30,17 @@ const SkipMessage = ({
     i18nKey={getLangKey(!!moderator, !!reason)}
     user={moderator || user}
     djName={toUsername(user)}
-    reason={reason}
+    reason={reason ? t(`booth.skip.reasons.${reason}`) : undefined}
     timestamp={timestamp}
   />
 );
 
 SkipMessage.propTypes = {
+  t: PropTypes.func.isRequired,
   user: PropTypes.object.isRequired,
   moderator: PropTypes.object,
   timestamp: PropTypes.number.isRequired,
   reason: PropTypes.string
 };
 
-export default SkipMessage;
+export default enhance(SkipMessage);

--- a/src/components/Chat/NotificationMessages/SkipMessage.js
+++ b/src/components/Chat/NotificationMessages/SkipMessage.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Username from '../../Username';
+import UserNotificationMessage from './UserNotificationMessage';
+
+const toUsername = user => (
+  <Username user={user} />
+);
+
+const getLangKey = (hasModerator, hasReason) => {
+  if (hasReason) {
+    return hasModerator ? 'chat.modSkipReason' : 'chat.selfSkipReason';
+  }
+  return hasModerator ? 'chat.modSkip' : 'chat.selfSkip';
+};
+
+const SkipMessage = ({
+  user,
+  moderator,
+  reason,
+  timestamp
+}) => (
+  <UserNotificationMessage
+    type="skip"
+    className="ChatMessage--skip"
+    i18nKey={getLangKey(!!moderator, !!reason)}
+    user={moderator || user}
+    djName={toUsername(user)}
+    reason={reason}
+    timestamp={timestamp}
+  />
+);
+
+SkipMessage.propTypes = {
+  user: PropTypes.object.isRequired,
+  moderator: PropTypes.object,
+  timestamp: PropTypes.number.isRequired,
+  reason: PropTypes.string
+};
+
+export default SkipMessage;

--- a/src/components/Chat/specialMessages.js
+++ b/src/components/Chat/specialMessages.js
@@ -1,0 +1,13 @@
+import LogMessage from './LogMessage';
+import JoinMessage from './NotificationMessages/JoinMessage';
+import LeaveMessage from './NotificationMessages/LeaveMessage';
+import NameChangedMessage from './NotificationMessages/NameChangedMessage';
+import SkipMessage from './NotificationMessages/SkipMessage';
+
+export default {
+  log: LogMessage,
+  userJoin: JoinMessage,
+  userLeave: LeaveMessage,
+  userNameChanged: NameChangedMessage,
+  skip: SkipMessage
+};

--- a/src/constants/actionTypes/booth.js
+++ b/src/constants/actionTypes/booth.js
@@ -1,4 +1,5 @@
 export const ADVANCE = 'booth/ADVANCE';
+export const BOOTH_SKIP = 'booth/SKIP';
 export const LOAD_HISTORY_START = 'booth/LOAD_HISTORY_START';
 export const LOAD_HISTORY_COMPLETE = 'booth/LOAD_HISTORY_COMPLETE';
 

--- a/src/reducers/chat/notifications.js
+++ b/src/reducers/chat/notifications.js
@@ -1,4 +1,5 @@
 import {
+  BOOTH_SKIP,
   USER_JOIN,
   USER_LEAVE,
   CHANGE_USERNAME
@@ -26,6 +27,15 @@ export default function reduceNotifications(state, { type, payload }) {
       _id: `userNameChanged-${payload.userID}-${payload.timestamp}`,
       user: payload.user,
       newUsername: payload.username,
+      timestamp: payload.timestamp
+    } ]);
+  case BOOTH_SKIP:
+    return state.concat([ {
+      type: 'skip',
+      _id: `skip-${payload.timestamp}`,
+      user: payload.user,
+      moderator: payload.moderator,
+      reason: payload.reason,
       timestamp: payload.timestamp
     } ]);
   default:

--- a/src/store/socket.js
+++ b/src/store/socket.js
@@ -16,7 +16,10 @@ import {
   DO_DOWNVOTE
 } from '../constants/actionTypes/votes';
 
-import { advance } from '../actions/BoothActionCreators';
+import {
+  advance,
+  skipped
+} from '../actions/BoothActionCreators';
 import {
   receive as chatReceive,
   removeMessage,
@@ -80,6 +83,9 @@ const actions = {
   },
   advance(booth) {
     return advance(booth);
+  },
+  skip({ userID, moderatorID, reason }) {
+    return skipped({ userID, moderatorID, reason });
   },
   favorite({ userID, historyID }) {
     return favorited({ userID, historyID });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1006268/34051445-ef5444d4-e1be-11e7-8b83-4cb8cea5ffc6.png)

If a reason is given, it's shown in the message. just as a single word though, not as a nice string. might be possible to add that since the nice strings are in the language files for use in the skip reason list.

the dj's name is not clickable if the dj was skipped by a moderator, this might be possible later but it's kinda hard right now.