### PR TITLE
Fix "Scroll to Bottom" button visibility, fixes #792

### DIFF
--- a/src/components/Chat/ChatMessages.css
+++ b/src/components/Chat/ChatMessages.css
@@ -32,6 +32,7 @@
   height: 55px;
   pointer-events: none;
   overflow: hidden;
+  z-index: 1;
 }
 
 .ChatMessages-scrollDownButton {


### PR DESCRIPTION
Ensure it shows up on top of chat messages instead of behind them.