### PR TITLE
Strip HTML from static markdown page titles.

### DIFF
--- a/tasks/utils/loadStaticHtmlTemplate.js
+++ b/tasks/utils/loadStaticHtmlTemplate.js
@@ -10,7 +10,8 @@ module.exports = function loadStaticHtmlTemplate(source) {
   const parentTemplate = require.resolve('../../src/markdown.prod.html');
 
   // Extract the likely title from the document.
-  const title = source.split(/<h1[^>]*>|<\/h1>/)[1];
+  const title = source.split(/<h1[^>]*>|<\/h1>/)[1]
+    .replace(/<.*?>/g, '').trim(); // strip html tags
 
   fs.readFile(parentTemplate, 'utf8', (err, templateSource) => {
     if (err) {


### PR DESCRIPTION
fixes:
![image](https://user-images.githubusercontent.com/1006268/35576905-81311eb4-05e0-11e8-8f94-a621a852fa59.png)
