### PR TITLE
Optimize html responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3143,16 +3143,7 @@
     "css-what": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-      "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
-      "dev": true
-    },
-    "cssauron": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/cssauron/-/cssauron-1.4.0.tgz",
-      "integrity": "sha1-pmAt/34EqDBtwNuaVR6S6LVmKtg=",
-      "requires": {
-        "through": "2.3.8"
-      }
+      "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
     },
     "cssesc": {
       "version": "0.1.0",
@@ -3784,6 +3775,11 @@
         }
       }
     },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
+    },
     "deep-diff": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
@@ -3990,7 +3986,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
-      "dev": true,
       "requires": {
         "domelementtype": "1.1.3",
         "entities": "1.1.1"
@@ -3999,8 +3994,7 @@
         "domelementtype": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-          "dev": true
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
         }
       }
     },
@@ -4018,14 +4012,12 @@
     "domelementtype": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
-      "dev": true
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
     },
     "domhandler": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
       "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
-      "dev": true,
       "requires": {
         "domelementtype": "1.3.0"
       }
@@ -4034,7 +4026,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true,
       "requires": {
         "dom-serializer": "0.1.0",
         "domelementtype": "1.3.0"
@@ -4278,6 +4269,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+      "dev": true,
       "requires": {
         "readable-stream": "1.1.14"
       }
@@ -4445,8 +4437,7 @@
     "entities": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
-      "dev": true
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
     },
     "enzyme": {
       "version": "3.1.0",
@@ -7564,6 +7555,17 @@
       "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
+    "hstream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hstream/-/hstream-1.0.1.tgz",
+      "integrity": "sha512-C6SRBqYvqEW/GUs5MZOYDr4ELZmyOOIasUxayzNp/7sPh9FERct/O5et+NFxLSulOBVwcqxRhwurlWmcMxdRxg==",
+      "requires": {
+        "css-what": "2.1.0",
+        "dedent": "0.7.0",
+        "htmlparser2": "3.9.2",
+        "through2": "2.0.3"
+      }
+    },
     "html": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/html/-/html-1.0.0.tgz",
@@ -7622,73 +7624,6 @@
         "void-elements": "2.0.1"
       }
     },
-    "html-select": {
-      "version": "2.3.24",
-      "resolved": "https://registry.npmjs.org/html-select/-/html-select-2.3.24.tgz",
-      "integrity": "sha1-Rq1tcS5zLPMcZznV0BEKX6vxdYU=",
-      "requires": {
-        "cssauron": "1.4.0",
-        "duplexer2": "0.0.2",
-        "inherits": "2.0.3",
-        "minimist": "0.0.10",
-        "readable-stream": "1.1.14",
-        "split": "0.3.3",
-        "stream-splicer": "1.3.2",
-        "through2": "1.1.1"
-      },
-      "dependencies": {
-        "through2": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
-          "integrity": "sha1-CEfLxESfNAVXTb3M2buEG4OsNUU=",
-          "requires": {
-            "readable-stream": "1.1.14",
-            "xtend": "4.0.1"
-          }
-        }
-      }
-    },
-    "html-tokenize": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/html-tokenize/-/html-tokenize-1.2.5.tgz",
-      "integrity": "sha1-flupnstR75Buyaf83ubKMmfHiX4=",
-      "requires": {
-        "inherits": "2.0.3",
-        "minimist": "0.0.10",
-        "readable-stream": "1.0.34",
-        "through2": "0.4.2"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "through2": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-          "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
-          "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "2.1.2"
-          }
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "requires": {
-            "object-keys": "0.4.0"
-          }
-        }
-      }
-    },
     "html-webpack-plugin": {
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.30.1.tgz",
@@ -7727,7 +7662,6 @@
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
       "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
-      "dev": true,
       "requires": {
         "domelementtype": "1.3.0",
         "domhandler": "2.4.1",
@@ -7740,14 +7674,12 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -7762,7 +7694,6 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -8668,7 +8599,8 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -9750,11 +9682,6 @@
       "requires": {
         "brace-expansion": "1.1.8"
       }
-    },
-    "minimist": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
     },
     "mississippi": {
       "version": "1.3.0",
@@ -12256,11 +12183,6 @@
       "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
       "dev": true
     },
-    "object-keys": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
-    },
     "object-values": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/object-values/-/object-values-1.0.0.tgz",
@@ -14749,8 +14671,7 @@
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "progress": {
       "version": "2.0.0",
@@ -15325,19 +15246,12 @@
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
         "isarray": "0.0.1",
         "string_decoder": "0.10.31"
-      }
-    },
-    "readable-wrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz",
-      "integrity": "sha1-O1ohHGMeEjA6VJkcgGwX564ga/8=",
-      "requires": {
-        "readable-stream": "1.1.14"
       }
     },
     "readdirp": {
@@ -15956,8 +15870,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "samsam": {
       "version": "1.3.0",
@@ -16496,6 +16409,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
       "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "dev": true,
       "requires": {
         "through": "2.3.8"
       }
@@ -16840,30 +16754,6 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
-    "stream-splicer": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
-      "integrity": "sha1-PARBvhW5v04iYnXm3IOWR0VUZmE=",
-      "requires": {
-        "indexof": "0.0.1",
-        "inherits": "2.0.3",
-        "isarray": "0.0.1",
-        "readable-stream": "1.1.14",
-        "readable-wrap": "1.0.0",
-        "through2": "1.1.1"
-      },
-      "dependencies": {
-        "through2": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
-          "integrity": "sha1-CEfLxESfNAVXTb3M2buEG4OsNUU=",
-          "requires": {
-            "readable-stream": "1.1.14",
-            "xtend": "4.0.1"
-          }
-        }
-      }
-    },
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
@@ -16900,7 +16790,8 @@
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -17250,7 +17141,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-      "dev": true,
       "requires": {
         "readable-stream": "2.3.3",
         "xtend": "4.0.1"
@@ -17259,14 +17149,12 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -17281,7 +17169,6 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -17537,30 +17424,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.1.tgz",
       "integrity": "sha1-qf2LA5Swro//guBjOgo2zK1bX4Y="
-    },
-    "trumpet": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/trumpet/-/trumpet-1.7.2.tgz",
-      "integrity": "sha1-sCxp5GXRcfVeRJJL+bW90gl0yDA=",
-      "requires": {
-        "duplexer2": "0.0.2",
-        "html-select": "2.3.24",
-        "html-tokenize": "1.2.5",
-        "inherits": "2.0.3",
-        "readable-stream": "1.1.14",
-        "through2": "1.1.1"
-      },
-      "dependencies": {
-        "through2": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
-          "integrity": "sha1-CEfLxESfNAVXTb3M2buEG4OsNUU=",
-          "requires": {
-            "readable-stream": "1.1.14",
-            "xtend": "4.0.1"
-          }
-        }
-      }
     },
     "tryit": {
       "version": "1.0.3",
@@ -18159,8 +18022,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utila": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7718,6 +7718,43 @@
         }
       }
     },
+    "http-gzip-maybe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/http-gzip-maybe/-/http-gzip-maybe-1.0.0.tgz",
+      "integrity": "sha512-MyNypULe1yvh+zOOENm0LetaFJ84RKgTo3E7hzASEXl6Gk8ugT7Mf2P8TkGYlYgGdxKeEbuH7KCERvmFlis7Sg==",
+      "requires": {
+        "readable-stream": "2.3.3"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
     "http-proxy": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "flash-document-title": "^1.0.0",
     "format-duration": "^1.0.0",
     "hstream": "^1.0.1",
+    "http-gzip-maybe": "^1.0.0",
     "i18next": "^10.0.3",
     "index-by": "0.0.1",
     "is-equal-shallow": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "except": "^0.1.3",
     "flash-document-title": "^1.0.0",
     "format-duration": "^1.0.0",
+    "hstream": "^1.0.1",
     "i18next": "^10.0.3",
     "index-by": "0.0.1",
     "is-equal-shallow": "^0.1.3",
@@ -65,7 +66,6 @@
     "screenfull": "^3.3.1",
     "shorten-url": "^1.0.0",
     "splitargs": "0.0.7",
-    "trumpet": "^1.7.2",
     "u-wave-parse-chat-markup": "^2.1.0",
     "whatwg-fetch": "^2.0.0",
     "yamlify": "^0.2.0"

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -3,6 +3,7 @@ import defaultFs from 'fs';
 import hstream from 'hstream';
 import router from 'router';
 import serveStatic from 'connect-gzip-static';
+import gzip from 'http-gzip-maybe';
 
 export default function uwaveWebClient(uw, options = {}) {
   const {
@@ -16,6 +17,8 @@ export default function uwaveWebClient(uw, options = {}) {
 
   return clientRouter
     .get('/', (req, res) => {
+      res.setHeader('content-type', 'text/html');
+
       const transform = hstream({
         title,
         '#u-wave-config': JSON.stringify(clientOptions)
@@ -23,9 +26,12 @@ export default function uwaveWebClient(uw, options = {}) {
 
       fs.createReadStream(path.join(basePath, 'index.html'), 'utf8')
         .pipe(transform)
+        .pipe(gzip(req, res))
         .pipe(res);
     })
     .get('/reset/:key', (req, res) => {
+      res.setHeader('content-type', 'text/html');
+
       const transform = hstream({
         title,
         '#u-wave-config': JSON.stringify({ apiUrl: clientOptions.apiUrl }),
@@ -34,6 +40,7 @@ export default function uwaveWebClient(uw, options = {}) {
 
       fs.createReadStream(path.join(basePath, 'password-reset.html'), 'utf8')
         .pipe(transform)
+        .pipe(gzip(req, res))
         .pipe(res);
     })
     .get('/u-wave-web-config.json', (req, res) => {

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,26 +1,8 @@
-import * as path from 'path';
-import * as defaultFs from 'fs';
-import trumpet from 'trumpet';
+import path from 'path';
+import defaultFs from 'fs';
+import hstream from 'hstream';
 import router from 'router';
 import serveStatic from 'connect-gzip-static';
-
-function injectConfig(transform, config) {
-  transform.select('#u-wave-config')
-    .createWriteStream()
-    .end(JSON.stringify(config));
-}
-
-function injectTitle(transform, title) {
-  transform.select('title')
-    .createWriteStream()
-    .end(title);
-}
-
-function injectResetKey(transform, key) {
-  transform.select('#reset-data')
-    .createWriteStream()
-    .end(key);
-}
 
 export default function uwaveWebClient(uw, options = {}) {
   const {
@@ -34,19 +16,21 @@ export default function uwaveWebClient(uw, options = {}) {
 
   return clientRouter
     .get('/', (req, res) => {
-      const transform = trumpet();
-      injectTitle(transform, title);
-      injectConfig(transform, clientOptions);
+      const transform = hstream({
+        title,
+        '#u-wave-config': JSON.stringify(clientOptions)
+      });
 
       fs.createReadStream(path.join(basePath, 'index.html'), 'utf8')
         .pipe(transform)
         .pipe(res);
     })
     .get('/reset/:key', (req, res) => {
-      const transform = trumpet();
-      injectTitle(transform, title);
-      injectConfig(transform, { apiUrl: clientOptions.apiUrl });
-      injectResetKey(transform, req.params.key);
+      const transform = hstream({
+        title,
+        '#u-wave-config': JSON.stringify({ apiUrl: clientOptions.apiUrl }),
+        '#reset-data': req.params.key
+      });
 
       fs.createReadStream(path.join(basePath, 'password-reset.html'), 'utf8')
         .pipe(transform)


### PR DESCRIPTION
- Use hstream instead of trumpet. it is faster and more concise.
- Gzip dynamic responses too. looks like 50%+ size savings when using emojione. The main thing taking up space in the html is emoji definitions in the client config.