### PR TITLE
Adapt top bar to logo size

### DIFF
--- a/src/components/HeaderBar/AppTitle.css
+++ b/src/components/HeaderBar/AppTitle.css
@@ -7,11 +7,11 @@
 }
 
 .AppTitle-logo {
-  line-height: var(--header-height);
-  height: var(--header-height);
+  line-height: calc(var(--header-height) - 20px);
+  height: calc(var(--header-height) - 20px);
   display: flex;
   align-items: center;
-  margin-left: 10px;
+  margin: 10px 0 10px 10px;
   font-size: 0;
   flex-grow: 2;
 }

--- a/src/components/HeaderBar/AppTitle.css
+++ b/src/components/HeaderBar/AppTitle.css
@@ -9,13 +9,16 @@
 .AppTitle-logo {
   line-height: var(--header-height);
   height: var(--header-height);
-  background-image: url(../../../assets/img/logo-white.png);
-  background-repeat: no-repeat;
-  background-position: center center;
-  background-size: contain;
+  display: flex;
+  align-items: center;
   margin-left: 10px;
   font-size: 0;
   flex-grow: 2;
+}
+
+.AppTitle-logoImage {
+  max-height: 100%;
+  max-width: 100%;
 }
 
 .AppTitle-button {}

--- a/src/components/HeaderBar/AppTitle.js
+++ b/src/components/HeaderBar/AppTitle.js
@@ -3,6 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import IconButton from 'material-ui/IconButton';
 import AboutIcon from 'material-ui/svg-icons/navigation/arrow-drop-down';
+import logo from '../../../assets/img/logo-white.png';
 
 const AppTitle = ({
   className,
@@ -11,7 +12,13 @@ const AppTitle = ({
   onClick
 }) => (
   <div className={cx('AppTitle', className, hasAboutPage && 'AppTitle--hasAboutPage')}>
-    <h1 className="AppTitle-logo">{children}</h1>
+    <h1 className="AppTitle-logo">
+      <img
+        className="AppTitle-logoImage"
+        alt={children}
+        src={logo}
+      />
+    </h1>
     {hasAboutPage && (
       <IconButton className="AppTitle-button" onClick={onClick}>
         <AboutIcon />

--- a/src/components/HeaderBar/index.css
+++ b/src/components/HeaderBar/index.css
@@ -5,50 +5,43 @@
 @import "./Volume.css";
 
 .HeaderBar {
-  position: relative;
+  display: flex;
   height: 100%;
   width: 100%;
   z-index: 4; /* below overlays, above video */
 }
 
 .HeaderBar-title {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 240px;
   margin: 0;
+  flex-shrink: 0;
 }
 
 .HeaderBar-volume {
-  position: absolute;
-  right: var(--header-height);
   top: 0;
+  flex-shrink: 0;
   width: 200px;
   padding: 15px;
 }
 
 .HeaderBar-history {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
   width: var(--header-height);
+  height: var(--header-height);
+  flex-shrink: 0;
   background: #111;
 }
 
-.HeaderBar-now-playing {
-  position: absolute;
-  top: 5px;
-  left: 250px;
-  right: calc(200px + var(--header-height));
+.HeaderBar-nowPlaying {
+  flex-grow: 1;
+  flex-shrink: 1;
+  overflow: hidden;
+}
+
+.HeaderBar-media {
+  margin-top: 5px;
   line-height: 25px;
 }
 
 .HeaderBar-dj {
-  position: absolute;
-  top: 30px;
-  left: 250px;
-  right: 200px;
   font-size: 80%;
   color: var(--muted-text-color);
 }

--- a/src/components/HeaderBar/index.js
+++ b/src/components/HeaderBar/index.js
@@ -36,8 +36,10 @@ const HeaderBar = ({
     >
       {title}
     </AppTitle>
-    <CurrentMedia className="HeaderBar-now-playing" media={media} />
-    {dj && <CurrentDJ className="HeaderBar-dj" dj={dj} />}
+    <div className="HeaderBar-nowPlaying">
+      <CurrentMedia className="HeaderBar-media" media={media} />
+      {dj && <CurrentDJ className="HeaderBar-dj" dj={dj} />}
+    </div>
     {media && (
       <Progress
         className="HeaderBar-progress"


### PR DESCRIPTION
So we can swap our long horizontal WE ♥ KPOP logo for the squarish S3 one. This removes some hardcoded pixel sizes and instead uses flexbox for the top bar. It reserves space for the logo, volume bar and history button, and lets the current song title take up the rest.

Changed the logo to be a real `<img />` instead of a background image, this way it will take up space in the flexbox layout without having to give a hardcoded width and height to the tag.