### PR TITLE
Fix overlays diffing internally when switching between them

### DIFF
--- a/src/components/App/Overlays.js
+++ b/src/components/App/Overlays.js
@@ -12,8 +12,11 @@ const Overlays = ({ children, active }) => {
     view = children;
   }
   if (view) {
+    // Pass on the `view.key` so that overlays are mounted and unmounted correctly
+    // when switching from one to the other.
     view = (
       <CSSTransition
+        key={view.key}
         mountOnEnter
         unmountOnExit
         classNames="Overlay"


### PR DESCRIPTION
Instead, ensure that the previous one is unmounted, and the new one is
mounted, by setting a `key` on the transition.