### PR TITLE
Extract second timer from App container.

### DIFF
--- a/src/actions/TickerActionCreators.js
+++ b/src/actions/TickerActionCreators.js
@@ -18,6 +18,12 @@ export function sync() {
   });
 }
 
+/**
+ * Create an auto-syncing timer that ticks once each second.
+ *
+ * When dispatched, the action returns an array. Functions pushed
+ * to this array will be called on each tick.
+ */
 export function createTimer() {
   return (dispatch) => {
     const callbacks = [];

--- a/src/components/ClockProvider/index.js
+++ b/src/components/ClockProvider/index.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { createTimer, stopTimer } from '../../actions/TickerActionCreators';
+
+const mapDispatchToProps = {
+  createTimer,
+  stopTimer,
+};
+
+const enhance = connect(null, mapDispatchToProps);
+
+class ClockProvider extends React.Component {
+  static propTypes = {
+    createTimer: PropTypes.func.isRequired,
+    stopTimer: PropTypes.func.isRequired,
+    children: PropTypes.node.isRequired,
+  };
+
+  static childContextTypes = {
+    timerCallbacks: PropTypes.arrayOf(PropTypes.func),
+  };
+
+  getChildContext() {
+    return {
+      timerCallbacks: this.timerCallbacks,
+    };
+  }
+
+  // TODO move this to constructor?
+  componentWillMount() {
+    // Start the clock! üWave stores the current time in the application state
+    // primarily to make sure that different timers in the UI update simultaneously.
+    this.timerCallbacks = this.props.createTimer();
+  }
+
+  componentWillUnmount() {
+    this.timerCallbacks = [];
+    this.props.stopTimer();
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
+
+export default enhance(ClockProvider);


### PR DESCRIPTION
Makes the app container deal with fewer things, and makes the clock
stuff reusable in other client frontends.