### PR TITLE
Fix vote icon alignment in user rows.

### DIFF
--- a/src/components/UserList/UserRow.css
+++ b/src/components/UserList/UserRow.css
@@ -3,7 +3,6 @@
   width: 100%;
   line-height: 30px;
   padding: 5px 0;
-  display: block;
   text-decoration: none;
 }
 


### PR DESCRIPTION
material-ui expects these elements to be `display: flex` instead.