### PR TITLE
Fix favouriting into existing playlist.

### DIFF
--- a/src/components/AddToPlaylistMenu/PlaylistsMenu.js
+++ b/src/components/AddToPlaylistMenu/PlaylistsMenu.js
@@ -23,8 +23,7 @@ class PlaylistsMenu extends React.Component {
     }),
   };
 
-  handleSelect = (e, item) => {
-    const playlistID = item.props.value;
+  handleSelect = (e, playlistID) => {
     this.props.onClose();
     this.props.onSelect(find(this.props.playlists, pl => pl._id === playlistID));
   };
@@ -54,7 +53,7 @@ class PlaylistsMenu extends React.Component {
             <MenuItem
               className="AddToPlaylistMenu-playlist"
               key={playlist._id}
-              onClick={this.handleSelect}
+              onClick={event => this.handleSelect(event, playlist._id)}
             >
               {!!playlist.active && (
                 <ListItemIcon>


### PR DESCRIPTION
Previously this event handler was on the Menu component, where material-ui@0.x gave it the clicked item. Now it is not so we have to pass the playlist ID in manually.