### PR TITLE
Allow overriding MediaList rowComponent, fixes drag-drop in playlists.

### DIFF
--- a/src/components/MediaList/index.js
+++ b/src/components/MediaList/index.js
@@ -1,8 +1,8 @@
-import withProps from 'recompose/withProps';
+import defaultProps from 'recompose/defaultProps';
 import Base from './BaseMediaList';
 import Row from './Row';
 
-const MediaList = withProps({
+const MediaList = defaultProps({
   listComponent: 'div',
   rowComponent: Row,
 })(Base);


### PR DESCRIPTION
The PlaylistManager was accidentally just using a normal MediaList instead of a draggable one.