### PR TITLE
Fix crashes when volume is way up

### DIFF
--- a/src/components/HeaderBar/Slider.js
+++ b/src/components/HeaderBar/Slider.js
@@ -255,9 +255,11 @@ class Slider extends React.Component {
 
     const { min, max, step, value, reverse, vertical } = this.props;
 
-    const percent = reverse
-      ? 100 - calculatePercent(event, vertical)
-      : calculatePercent(event, vertical);
+    const percent = normalizeValue(
+      reverse
+        ? 100 - calculatePercent(event, vertical)
+        : calculatePercent(event, vertical),
+      min, max);
 
     const newValue = roundToStep({
       currentValue: value,
@@ -337,9 +339,11 @@ class Slider extends React.Component {
 
     const { min, max, step, value, reverse, vertical } = this.props;
 
-    const percent = reverse
-      ? 100 - calculatePercent(event, vertical)
-      : calculatePercent(event, vertical);
+    const percent = normalizeValue(
+      reverse
+        ? 100 - calculatePercent(event, vertical)
+        : calculatePercent(event, vertical),
+      min, max);
 
     const newValue = roundToStep({
       currentValue: value,

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -1,8 +1,18 @@
 import merge from 'deepmerge';
+import compose from 'recompose/compose';
 import {
   LOAD_SETTINGS,
   CHANGE_SETTING,
 } from '../constants/actionTypes/settings';
+
+// Some people have >100% volumes stored in their localStorage settings
+// because of a bug in üWave 1.4. This ensures that _everyone's_ volume
+// is between 0 and 100.
+function fixVolume(state) {
+  if (state.volume < 0) return { ...state, volume: 0 };
+  if (state.volume > 100) return { ...state, volume: 100 };
+  return state;
+}
 
 const initialState = {
   language: null,
@@ -19,7 +29,7 @@ const initialState = {
   },
 };
 
-export default function reduce(state = initialState, action = {}) {
+function reduce(state = initialState, action = {}) {
   const { type, payload } = action;
   switch (type) {
     case LOAD_SETTINGS:
@@ -41,3 +51,5 @@ export default function reduce(state = initialState, action = {}) {
       return state;
   }
 }
+
+export default compose(fixVolume, reduce);


### PR DESCRIPTION
The page would crash if the volume was changed to something > 100%, because the SoundCloud and YouTube players don't accept values that high. Of course it should not be possible to change the volume to >100%, but sometimes the slider did it anyway. That's what we get for copy pasting code from a WIP upstream PR :)

This fixes crashes in situations where the volume would be changed from <100% to >100%

 - Moving the slider all the way to the right
 - Unmuting when the volume is >100%
 - Closing a preview dialog when the volume is >100%