### PR TITLE
Use qs-stringify to simplify building the soundcloud embed URL.

### DIFF
--- a/src/sources/soundcloud/PreviewPlayer.js
+++ b/src/sources/soundcloud/PreviewPlayer.js
@@ -1,19 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import qsStringify from 'qs-stringify';
 
-const createEmbedUrl = sourceID => `
-  https://w.soundcloud.com/player/
-  ?url=${encodeURIComponent(`https://api.soundcloud.com/tracks/${sourceID}`)}
-  &color=55B9FF
-  &auto_play=true
-  &hide_related=true
-  &buying=false
-  &liking=false
-  &download=false
-  &sharing=false
-  &show_comments=false
-  &visual=true
-`.replace(/\s+/g, '');
+const createEmbedUrl = sourceID =>
+  `https://w.soundcloud.com/player/?${qsStringify({
+    url: `https://api.soundcloud.com/tracks/${sourceID}`,
+    color: '55B9FF',
+    auto_play: true,
+    hide_related: true,
+    buying: false,
+    liking: false,
+    download: false,
+    sharing: false,
+    show_comments: false,
+    visual: true,
+  })}`;
 
 const PreviewPlayer = ({ media }) => (
   <iframe


### PR DESCRIPTION
It's already included and makes this bit a bit nicer :woman_shrugging: 