### PR TITLE
Fix alias for ES modules version of material-ui icons.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -263,7 +263,7 @@ module.exports = {
   resolve: {
     alias: {
       'material-ui': path.join(__dirname, 'node_modules/material-ui/es/'),
-      'material-ui-icons': path.join(__dirname, 'node_modules/material-ui-icons/es/'),
+      '@material-ui/icons': path.join(__dirname, 'node_modules/@material-ui/icons/es/'),
     },
     mainFields: [
       'browser',


### PR DESCRIPTION
Forgot to update this in the earlier PR.