### PR TITLE
Fix ResponseButtons not covering the full FooterBar height.

### DIFF
--- a/src/components/FooterBar/Responses/Bar.css
+++ b/src/components/FooterBar/Responses/Bar.css
@@ -1,57 +1,7 @@
-@import "../../../vars.css";
-
 .AudienceResponse {
   height: 100%;
   width: 100%;
   display: flex;
   justify-content: space-around;
   align-items: center;
-}
-
-.ResponseButton-wrap {
-  height: 100%;
-}
-
-.ResponseButton {
-  height: 100%;
-  border: 0;
-  background: none;
-  flex-grow: 0.334;
-  padding: 0;
-
-  cursor: pointer;
-  &:hover {
-    background-color: var(--background-hover-color);
-  }
-}
-
-.ResponseButton--disabled, .ResponseButton--static {
-  cursor: default;
-  &:hover {
-    background-color: transparent;
-  }
-}
-
-.ResponseButton-content {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0 15px;
-  position: relative;
-}
-
-.ResponseButton-icon {
-  height: 36px;
-  width: 36px;
-  padding: 6px 12px 6px 0px;
-}
-
-.ResponseButton-icon--favorite {
-  color: var(--highlight-color);
-}
-.ResponseButton-icon--downvoted {
-  color: #b64b4b;
-}
-.ResponseButton-icon--upvoted {
-  color: #4bb64b;
 }

--- a/src/components/FooterBar/Responses/Bar.css
+++ b/src/components/FooterBar/Responses/Bar.css
@@ -8,6 +8,10 @@
   align-items: center;
 }
 
+.ResponseButton-wrap {
+  height: 100%;
+}
+
 .ResponseButton {
   height: 100%;
   border: 0;

--- a/src/components/FooterBar/Responses/Button.css
+++ b/src/components/FooterBar/Responses/Button.css
@@ -1,0 +1,50 @@
+@import "../../../vars.css";
+
+.ResponseButton-wrap {
+  height: 100%;
+}
+
+.ResponseButton {
+  height: 100%;
+  border: 0;
+  background: none;
+  flex-grow: 0.334;
+  padding: 0;
+
+  cursor: pointer;
+  &:hover {
+    background-color: var(--background-hover-color);
+  }
+}
+
+.ResponseButton--disabled, .ResponseButton--static {
+  cursor: default;
+  &:hover {
+    background-color: transparent;
+  }
+}
+
+.ResponseButton-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 15px;
+  position: relative;
+}
+
+.ResponseButton-icon {
+  height: 36px;
+  width: 36px;
+  padding: 6px 12px 6px 0px;
+}
+
+.ResponseButton-icon--favorite {
+  color: var(--highlight-color);
+}
+.ResponseButton-icon--downvoted {
+  color: #b64b4b;
+}
+.ResponseButton-icon--upvoted {
+  color: #4bb64b;
+}
+

--- a/src/components/FooterBar/Responses/Button.js
+++ b/src/components/FooterBar/Responses/Button.js
@@ -13,7 +13,7 @@ const Button = ({
 }) => (
   // Wrapped in a <div> so the tooltip can listen for mouse events.
   <Tooltip title={tooltip} placement="top">
-    <div>
+    <div className="ResponseButton-wrap">
       <button
         className={cx('ResponseButton', disabled && 'ResponseButton--disabled')}
         disabled={disabled}

--- a/src/components/FooterBar/Responses/index.css
+++ b/src/components/FooterBar/Responses/index.css
@@ -1,1 +1,2 @@
 @import "./Bar.css";
+@import "./Button.css";


### PR DESCRIPTION
The wrapping divs that are used to allow the Tooltip to listen to hover
events were causing the buttons to be smaller.