### PR TITLE
Lazy load overlay code.

### DIFF
--- a/src/components/LazyOverlay/index.css
+++ b/src/components/LazyOverlay/index.css
@@ -1,0 +1,16 @@
+@import "../../vars.css";
+
+.LoadingOverlay {
+}
+
+.LoadingOverlay-body {
+  background: color(var(--background-color) alpha(* 96%));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.LoadingOverlay-spinner {
+  min-width: 250px;
+  min-height: 250px;
+}

--- a/src/components/LazyOverlay/index.js
+++ b/src/components/LazyOverlay/index.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import compose from 'recompose/compose';
+import nest from 'recompose/nest';
+import { connect } from 'react-redux';
+import { translate } from 'react-i18next';
+import loadable from 'react-loadable';
+import { CircularProgress } from 'material-ui/Progress';
+import Overlay from '../Overlay';
+import OverlayContent from '../Overlay/Content';
+import OverlayHeader from '../Overlay/Header';
+import { closeAll } from '../../actions/OverlayActionCreators';
+
+export default function createLazyOverlay({
+  loader,
+  title,
+  OverlayComponent = Overlay,
+}) {
+  if (typeof loader !== 'function') throw new TypeError('loader must be a function');
+
+  const enhance = compose(
+    translate(),
+    connect(null, {
+      onCloseOverlay: closeAll,
+    }),
+  );
+
+  const LoadingOverlay = ({
+    t,
+    pastDelay,
+    onCloseOverlay,
+  }) => (
+    <React.Fragment>
+      <OverlayHeader
+        title={title ? title(t) : '...'}
+        onCloseOverlay={onCloseOverlay}
+      />
+      <OverlayContent className="LoadingOverlay-body">
+        {pastDelay && (
+          <CircularProgress
+            className="LoadingOverlay-spinner"
+            thickness={1.6}
+          />
+        )}
+      </OverlayContent>
+    </React.Fragment>
+  );
+
+  LoadingOverlay.propTypes = {
+    t: PropTypes.func.isRequired,
+    pastDelay: PropTypes.bool.isRequired,
+    onCloseOverlay: PropTypes.func.isRequired,
+  };
+
+  const LazyOverlay = loadable({
+    loader,
+    loading: enhance(LoadingOverlay),
+  });
+
+  return nest(OverlayComponent, LazyOverlay);
+}

--- a/src/components/Overlay/index.css
+++ b/src/components/Overlay/index.css
@@ -33,6 +33,10 @@
   }
 }
 
+.Overlay-loading {
+  background: color(var(--background-color) alpha(* 96%));
+}
+
 /* Animations!.. */
 .Overlay-enter {
   overflow-y: hidden;

--- a/src/components/index.css
+++ b/src/components/index.css
@@ -11,6 +11,7 @@
 @import "./FooterBar/index.css";
 @import "./Form/index.css";
 @import "./HeaderBar/index.css";
+@import "./LazyOverlay/index.css";
 @import "./LoadingScreen/index.css";
 @import "./MediaList/index.css";
 @import "./Overlay/index.css";

--- a/src/containers/PlaylistManager.js
+++ b/src/containers/PlaylistManager.js
@@ -1,11 +1,9 @@
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
-import nest from 'recompose/nest';
 import { selectedPlaylistSelector } from '../selectors/playlistSelectors';
 import { showSearchResultsSelector } from '../selectors/searchSelectors';
 import { showImportPanelSelector } from '../selectors/importSelectors';
-import Overlay from '../components/Overlay';
-import PlaylistManager from '../components/PlaylistManager';
+import createLazyOverlay from '../components/LazyOverlay';
 
 const mapStateToProps = createStructuredSelector({
   selectedPlaylist: selectedPlaylistSelector,
@@ -13,4 +11,12 @@ const mapStateToProps = createStructuredSelector({
   showSearchResults: showSearchResultsSelector,
 });
 
-export default connect(mapStateToProps)(nest(Overlay, PlaylistManager));
+
+const enhance = connect(mapStateToProps);
+
+const PlaylistManager = createLazyOverlay({
+  loader: () => import('../components/PlaylistManager' /* webpackChunkName: "playlists" */),
+  title: t => t('playlists.title'),
+});
+
+export default enhance(PlaylistManager);

--- a/src/containers/RoomHistory.js
+++ b/src/containers/RoomHistory.js
@@ -1,13 +1,12 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
-import nest from 'recompose/nest';
 import withProps from 'recompose/withProps';
 import { openPreviewMediaDialog } from '../actions/DialogActionCreators';
 import { addMediaMenu } from '../actions/PlaylistActionCreators';
 import { roomHistoryWithVotesSelector } from '../selectors/roomHistorySelectors';
 import Overlay from '../components/Overlay';
-import RoomHistory from '../components/RoomHistory';
+import createLazyOverlay from '../components/LazyOverlay';
 
 const selectionOrOne = (media, selection) => {
   // History entries store the played media on their `.media` property
@@ -28,5 +27,14 @@ const mapDispatchToProps = dispatch => bindActionCreators({
   onOpenPreviewMediaDialog: openPreviewMediaDialog,
 }, dispatch);
 
-const OverlayFromTop = withProps({ direction: 'top' })(Overlay);
-export default connect(mapStateToProps, mapDispatchToProps)(nest(OverlayFromTop, RoomHistory));
+const enhance = connect(mapStateToProps, mapDispatchToProps);
+
+const RoomHistory = createLazyOverlay({
+  loader: () => import('../components/RoomHistory' /* webpackChunkName: "history" */),
+  title: t => t('history.title'),
+  OverlayComponent: withProps({
+    direction: 'top',
+  })(Overlay),
+});
+
+export default enhance(RoomHistory);

--- a/src/containers/SettingsManager.js
+++ b/src/containers/SettingsManager.js
@@ -1,7 +1,6 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
-import nest from 'recompose/nest';
 import {
   set as setSetting,
   setLanguage,
@@ -10,8 +9,7 @@ import { doChangeUsername } from '../actions/UserActionCreators';
 import { logout } from '../actions/LoginActionCreators';
 import { currentUserSelector } from '../selectors/userSelectors';
 import { settingsSelector } from '../selectors/settingSelectors';
-import Overlay from '../components/Overlay';
-import SettingsManager from '../components/SettingsManager';
+import createLazyOverlay from '../components/LazyOverlay';
 
 const mapStateToProps = createStructuredSelector({
   settings: settingsSelector,
@@ -25,4 +23,11 @@ const mapDispatchToProps = dispatch => bindActionCreators({
   onLogout: logout,
 }, dispatch);
 
-export default connect(mapStateToProps, mapDispatchToProps)(nest(Overlay, SettingsManager));
+const enhance = connect(mapStateToProps, mapDispatchToProps);
+
+const SettingsManager = createLazyOverlay({
+  loader: () => import('../components/SettingsManager' /* webpackChunkName: "settings" */),
+  title: t => t('settings.title'),
+});
+
+export default enhance(SettingsManager);


### PR DESCRIPTION
Only load the necessary code once the Settings, Playlist Manager, or Room History panels are opened. 

Would be cool to add more parts of the desktop UI here later so we can have a smaller mobile bundle (takes some time to run the almost 1MB of unzipped code on mobile)