### PR TITLE
Fix @babel/runtime useBuiltIns configuration.

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -35,7 +35,7 @@ module.exports = (api, envOverride) => {
       ['@babel/plugin-proposal-class-properties', { loose }],
       ['@babel/plugin-transform-runtime', {
         polyfill: false,
-        useBuiltIns: false,
+        useBuiltIns: true,
       }]
     ]
   };


### PR DESCRIPTION
I accidentally set this to the wrong value. We don't need the the
runtime to use polyfills here.

Saves a few kB after compression. Gains will be even better when
dependencies start switching to Babel 7 too.