### PR TITLE
Play media on full volume on mobile, fixes #878.

### DIFF
--- a/src/mobile/containers/Video.js
+++ b/src/mobile/containers/Video.js
@@ -10,7 +10,7 @@ import {
 import {
   historyIDSelector,
   mediaSelector,
-  playbackVolumeSelector,
+  mobilePlaybackVolumeSelector,
   timeElapsedSelector,
 } from '../../selectors/boothSelectors';
 import { currentVoteStatsSelector } from '../../selectors/voteSelectors';
@@ -20,7 +20,7 @@ const mapStateToProps = createStructuredSelector({
   historyID: historyIDSelector,
   media: mediaSelector,
   seek: timeElapsedSelector,
-  volume: playbackVolumeSelector,
+  volume: mobilePlaybackVolumeSelector,
   voteStats: currentVoteStatsSelector,
 });
 

--- a/src/selectors/boothSelectors.js
+++ b/src/selectors/boothSelectors.js
@@ -45,6 +45,8 @@ export const mediaProgressSelector = createSelector(
   (duration, elapsed) => (
     duration
       // Ensure that the result is between 0 and 1
+      // It can be outside this range if a network or server hiccup
+      // results in an advance event getting delayed.
       ? Math.max(0, Math.min(1, elapsed / duration))
       : 0
   ),
@@ -76,10 +78,21 @@ export const canSkipSelector = createSelector(
   },
 );
 
-export const playbackVolumeSelector = createSelector(
-  volumeSelector,
+// Playback should be muted when the user requested it,
+// and when a media preview dialog is open. (Otherwise their audio will interfere.)
+const playbackMutedSelector = createSelector(
   isMutedSelector,
   isPreviewMediaDialogOpenSelector,
-  (volume, isMuted, isPreviewMediaDialogOpen) =>
-    (isMuted || isPreviewMediaDialogOpen ? 0 : volume),
+  (isMuted, isPreviewMediaDialogOpen) => isMuted || isPreviewMediaDialogOpen,
+);
+
+export const playbackVolumeSelector = createSelector(
+  volumeSelector,
+  playbackMutedSelector,
+  (volume, isMuted) => (isMuted ? 0 : volume),
+);
+
+export const mobilePlaybackVolumeSelector = createSelector(
+  playbackMutedSelector,
+  isMuted => (isMuted ? 0 : 100),
 );


### PR DESCRIPTION
Seems like very few mobile apps have a slider. This patch changes the
mobile video to only have to volume states: on (100%) and off (0%). It
defaults to on.

Can add a mute button to the vote buttons overlay once that's back.