### PR TITLE
Add max width to mobile drawers.

### DIFF
--- a/src/mobile/components/DrawerMenu/index.css
+++ b/src/mobile/components/DrawerMenu/index.css
@@ -1,0 +1,3 @@
+.DrawerMenu {
+  max-width: 90vw;
+}

--- a/src/mobile/components/DrawerMenu/index.js
+++ b/src/mobile/components/DrawerMenu/index.js
@@ -7,6 +7,7 @@ import Drawer from 'material-ui/Drawer';
 import { MenuList, MenuItem } from 'material-ui/Menu';
 import { ListItemIcon, ListSubheader, ListItemText } from 'material-ui/List';
 import Divider from 'material-ui/Divider';
+import Typography from 'material-ui/Typography';
 import ActiveIcon from '@material-ui/icons/Check';
 import UserCard from '../../../components/UserCard/UserCard';
 
@@ -33,6 +34,10 @@ const enhance = compose(
   }),
 );
 
+const paperProps = {
+  className: 'DrawerMenu',
+};
+
 const DrawerMenu = ({
   t,
   user,
@@ -45,7 +50,7 @@ const DrawerMenu = ({
   onShowPlaylist,
   onDrawerClose,
 }) => (
-  <Drawer open={open} onClose={onDrawerClose}>
+  <Drawer open={open} onClose={onDrawerClose} PaperProps={paperProps}>
     {user && <UserCard user={user} />}
     <MenuList>
       {hasAboutPage && <MenuItem onClick={onShowAbout}>{t('about.about')}</MenuItem>}
@@ -70,7 +75,9 @@ const DrawerMenu = ({
               <ActiveIcon />
             </ListItemIcon>
           )}
-          <ListItemText primary={playlist.name} />
+          <ListItemText noTypography>
+            <Typography noWrap variant="subheading">{playlist.name}</Typography>
+          </ListItemText>
         </MenuItem>
       ))}
     </MenuList>

--- a/src/mobile/components/UsersDrawer/index.css
+++ b/src/mobile/components/UsersDrawer/index.css
@@ -1,1 +1,5 @@
 @import "./WaitlistPosition.css";
+
+.UsersDrawer {
+  max-width: 90vw;
+}

--- a/src/mobile/components/UsersDrawer/index.js
+++ b/src/mobile/components/UsersDrawer/index.js
@@ -3,6 +3,10 @@ import PropTypes from 'prop-types';
 import Drawer from 'material-ui/Drawer';
 import UserList from './UserList';
 
+const paperProps = {
+  className: 'UsersDrawer',
+};
+
 const UsersDrawer = ({
   currentDJ,
   users,
@@ -19,6 +23,7 @@ const UsersDrawer = ({
     anchor="right"
     open={open}
     onClose={onDrawerClose}
+    PaperProps={paperProps}
   >
     <UserList
       currentDJ={currentDJ}

--- a/src/mobile/components/index.css
+++ b/src/mobile/components/index.css
@@ -1,4 +1,5 @@
 @import "./App/index.css";
+@import "./DrawerMenu/index.css";
 @import "./MainView/index.css";
 @import "./MediaList/index.css";
 @import "./RoomHistory/index.css";


### PR DESCRIPTION
Previously if you had a really long playlist name, the drawer could be
wider than the screen. Now playlist names are truncated at 90% of the
viewport width.