### PR TITLE
Fix mobile UsersDrawer docking to the left.

### DIFF
--- a/src/mobile/components/DrawerMenu/index.js
+++ b/src/mobile/components/DrawerMenu/index.js
@@ -34,8 +34,8 @@ const enhance = compose(
   }),
 );
 
-const paperProps = {
-  className: 'DrawerMenu',
+const classes = {
+  paper: 'DrawerMenu',
 };
 
 const DrawerMenu = ({
@@ -50,7 +50,7 @@ const DrawerMenu = ({
   onShowPlaylist,
   onDrawerClose,
 }) => (
-  <Drawer open={open} onClose={onDrawerClose} PaperProps={paperProps}>
+  <Drawer open={open} onClose={onDrawerClose} classes={classes}>
     {user && <UserCard user={user} />}
     <MenuList>
       {hasAboutPage && <MenuItem onClick={onShowAbout}>{t('about.about')}</MenuItem>}

--- a/src/mobile/components/UsersDrawer/index.js
+++ b/src/mobile/components/UsersDrawer/index.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import Drawer from 'material-ui/Drawer';
 import UserList from './UserList';
 
-const paperProps = {
-  className: 'UsersDrawer',
+const classes = {
+  paper: 'UsersDrawer',
 };
 
 const UsersDrawer = ({
@@ -23,7 +23,7 @@ const UsersDrawer = ({
     anchor="right"
     open={open}
     onClose={onDrawerClose}
-    PaperProps={paperProps}
+    classes={classes}
   >
     <UserList
       currentDJ={currentDJ}


### PR DESCRIPTION
The `PaperProps` className was overriding the classNames added by the
Drawer. Drawer also exposes a `classes.paper` prop which does what we
need without conflicts.