### PR TITLE
Enable mobile vote button area once media is playing.

### DIFF
--- a/src/components/Player/index.js
+++ b/src/components/Player/index.js
@@ -15,6 +15,7 @@ class Player extends React.Component {
     isMuted: PropTypes.bool,
     media: PropTypes.object,
     seek: PropTypes.number,
+    onPlay: PropTypes.func,
   };
 
   shouldComponentUpdate(nextProps) {
@@ -30,6 +31,7 @@ class Player extends React.Component {
       isMuted,
       media,
       seek,
+      onPlay,
     } = this.props;
 
     if (!media) {
@@ -42,6 +44,7 @@ class Player extends React.Component {
       seek,
       mode: size,
       volume: isMuted ? 0 : volume,
+      onPlay,
     };
 
     const sources = getAllMediaSources();

--- a/src/mobile/components/Video/index.css
+++ b/src/mobile/components/Video/index.css
@@ -25,10 +25,3 @@
   z-index: 5;
   pointer-events: none;
 }
-
-/* The buttonTrigger is currently blocking access to the video element,
- * so you can't tap it to start playing. */
-/* TODO Remove this rule once that is fixed. */
-.Video-buttonTrigger, .Video-buttons {
-  display: none;
-}

--- a/src/mobile/components/Video/index.js
+++ b/src/mobile/components/Video/index.js
@@ -7,6 +7,7 @@ import VoteButtons from './VoteButtons';
 class Video extends React.Component {
   static propTypes = {
     media: PropTypes.shape({
+      sourceType: PropTypes.string.isRequired,
       thumbnail: PropTypes.string.isRequired,
     }),
     voteStats: PropTypes.shape({
@@ -20,7 +21,21 @@ class Video extends React.Component {
     onFavorite: PropTypes.func.isRequired,
   };
 
+  static getDerivedStateFromProps(nextProps, prevState) {
+    const { sourceType } = nextProps.media || {};
+    // Switching to a different source type may require an autoplay tap again.
+    // Disable the vote buttons until the media source reports playback started.
+    if (sourceType !== prevState.sourceType) {
+      return {
+        enableOverlay: sourceType === undefined,
+        sourceType,
+      };
+    }
+    return null;
+  }
+
   state = {
+    sourceType: undefined, // eslint-disable-line react/no-unused-state
     enableOverlay: false,
     showVoteButtons: false,
   };

--- a/src/mobile/components/Video/index.js
+++ b/src/mobile/components/Video/index.js
@@ -21,6 +21,7 @@ class Video extends React.Component {
   };
 
   state = {
+    enableOverlay: false,
     showVoteButtons: false,
   };
 
@@ -28,6 +29,11 @@ class Video extends React.Component {
     this.setState(s => ({
       showVoteButtons: !s.showVoteButtons,
     }));
+  };
+
+  // Add the vote buttons tap-trap once autoplay permission is granted.
+  handlePlay = () => {
+    this.setState({ enableOverlay: true });
   };
 
   render() {
@@ -39,7 +45,7 @@ class Video extends React.Component {
       onFavorite,
       ...props
     } = this.props;
-    const { showVoteButtons } = this.state;
+    const { enableOverlay, showVoteButtons } = this.state;
 
     return (
       <div className="Video">
@@ -49,13 +55,16 @@ class Video extends React.Component {
             {...props}
             media={media}
             size="large"
+            onPlay={this.handlePlay}
           />
         </div>
-        <button
-          className="Video-buttonTrigger"
-          onClick={this.handleClick}
-          aria-label="Show vote buttons"
-        />
+        {enableOverlay && (
+          <button
+            className="Video-buttonTrigger"
+            onClick={this.handleClick}
+            aria-label="Show vote buttons"
+          />
+        )}
         {showVoteButtons && (
           <div className="Video-buttons">
             <VoteButtons

--- a/src/sources/soundcloud/Player.js
+++ b/src/sources/soundcloud/Player.js
@@ -40,6 +40,7 @@ class SoundCloudPlayer extends React.Component {
     media: PropTypes.object,
     seek: PropTypes.number,
     volume: PropTypes.number,
+    onPlay: PropTypes.func,
   };
 
   state = {
@@ -93,6 +94,9 @@ class SoundCloudPlayer extends React.Component {
       if (res && res.then) res.catch(this.handleError);
       debug('currentTime', this.props.seek);
       this.audio.addEventListener('canplaythrough', doSeek, false);
+      if (this.props.onPlay) {
+        this.audio.addEventListener('play', this.props.onPlay, false);
+      }
     } else {
       this.stop();
     }

--- a/src/sources/youtube/Player.js
+++ b/src/sources/youtube/Player.js
@@ -11,6 +11,7 @@ const YouTubePlayer = ({
   media,
   seek,
   volume,
+  onPlay,
 }) => {
   const modeClass = `src-youtube-Player--${mode}`;
 
@@ -23,6 +24,7 @@ const YouTubePlayer = ({
           seek={Math.round(seek)}
           volume={volume}
           controllable={mode === 'preview'}
+          onPlay={onPlay}
         />
       )}
     </div>
@@ -37,6 +39,7 @@ YouTubePlayer.propTypes = {
   media: PropTypes.object,
   seek: PropTypes.number,
   volume: PropTypes.number,
+  onPlay: PropTypes.func,
 };
 
 export default YouTubePlayer;

--- a/src/sources/youtube/PlayerEmbed.js
+++ b/src/sources/youtube/PlayerEmbed.js
@@ -9,10 +9,17 @@ export default class YouTubePlayerEmbed extends React.Component {
     seek: PropTypes.number,
     volume: PropTypes.number,
     controllable: PropTypes.bool,
+    onPlay: PropTypes.func,
   };
 
   static defaultProps = {
     controllable: false,
+  };
+
+  handleYTPlay = () => {
+    if (this.props.onPlay) {
+      this.props.onPlay();
+    }
   };
 
   handleYTPause = (event) => {
@@ -47,6 +54,7 @@ export default class YouTubePlayerEmbed extends React.Component {
         startSeconds={(seek || 0) + (media.start || 0)}
         endSeconds={media.end || media.duration}
         onPause={this.handleYTPause}
+        onPlaying={this.handleYTPlay}
       />
     );
   }


### PR DESCRIPTION
So people can tap to start playing, and then tap again to see vote
buttons.

- [x] TODO implement for soundcloud