### PR TITLE
Reduce store dispatches on load.

### DIFF
--- a/src/actions/BoothActionCreators.js
+++ b/src/actions/BoothActionCreators.js
@@ -2,10 +2,9 @@ import {
   ADVANCE,
   BOOTH_SKIP,
   LOAD_HISTORY_START, LOAD_HISTORY_COMPLETE,
-} from '../constants/actionTypes/booth';
+} from '../constants/ActionTypes';
 import { flattenPlaylistItem } from './PlaylistActionCreators';
 import { get, post } from './RequestActionCreators';
-
 import { historyIDSelector, isCurrentDJSelector } from '../selectors/boothSelectors';
 import { currentPlaySelector } from '../selectors/roomHistorySelectors';
 import { usersSelector } from '../selectors/userSelectors';

--- a/src/actions/ChatActionCreators.js
+++ b/src/actions/ChatActionCreators.js
@@ -8,19 +8,15 @@ import {
   RECEIVE_MOTD,
   SET_MOTD_START,
   SET_MOTD_COMPLETE,
-
   SEND_MESSAGE,
   RECEIVE_MESSAGE,
-
   LOG,
-
   REMOVE_MESSAGE,
   REMOVE_USER_MESSAGES,
   REMOVE_ALL_MESSAGES,
-
   MUTE_USER,
   UNMUTE_USER,
-} from '../constants/actionTypes/chat';
+} from '../constants/ActionTypes';
 import { put } from './RequestActionCreators';
 import { execute } from '../utils/ChatCommands';
 import {
@@ -36,7 +32,6 @@ import {
   currentUserHasRoleSelector,
 } from '../selectors/userSelectors';
 import { currentTimeSelector } from '../selectors/timeSelectors';
-
 import {
   getAvailableGroupMentions,
   resolveMentions,

--- a/src/actions/DialogActionCreators.js
+++ b/src/actions/DialogActionCreators.js
@@ -3,7 +3,7 @@ import {
   OPEN_EDIT_MEDIA_DIALOG, CLOSE_EDIT_MEDIA_DIALOG,
   OPEN_PREVIEW_MEDIA_DIALOG, CLOSE_PREVIEW_MEDIA_DIALOG,
   OPEN_LOGIN_DIALOG, CLOSE_LOGIN_DIALOG,
-} from '../constants/actionTypes/dialogs';
+} from '../constants/ActionTypes';
 
 export function openEditMediaDialog(playlistID, media) {
   return {

--- a/src/actions/ErrorActionCreators.js
+++ b/src/actions/ErrorActionCreators.js
@@ -1,4 +1,4 @@
-import { ERROR_DISMISS } from '../constants/actionTypes/errors';
+import { ERROR_DISMISS } from '../constants/ActionTypes';
 
 // eslint-disable-next-line import/prefer-default-export
 export function dismiss() {

--- a/src/actions/ImportActionCreators.js
+++ b/src/actions/ImportActionCreators.js
@@ -3,7 +3,7 @@ import {
   HIDE_IMPORT_PANEL,
   SHOW_IMPORT_SOURCE_PANEL,
   HIDE_IMPORT_SOURCE_PANEL,
-} from '../constants/actionTypes/imports';
+} from '../constants/ActionTypes';
 
 export function showImportPanel() {
   return {

--- a/src/actions/LoginActionCreators.js
+++ b/src/actions/LoginActionCreators.js
@@ -3,7 +3,6 @@ import {
   INIT_STATE,
   SOCKET_CONNECT,
   SOCKET_RECONNECT,
-
   AUTH_STRATEGIES,
   REGISTER_START,
   REGISTER_COMPLETE,
@@ -12,20 +11,15 @@ import {
   SET_TOKEN,
   LOGOUT_START,
   LOGOUT_COMPLETE,
-
   RESET_PASSWORD_COMPLETE,
-} from '../constants/actionTypes/auth';
-import { LOAD_ALL_PLAYLISTS_START } from '../constants/actionTypes/playlists';
+  LOAD_ALL_PLAYLISTS_START,
+} from '../constants/ActionTypes';
 import * as Session from '../utils/Session';
 import { get, post, del } from './RequestActionCreators';
 import { advance, loadHistory } from './BoothActionCreators';
-import { receiveMotd } from './ChatActionCreators';
-import { setPlaylists, selectPlaylist, activatePlaylistComplete } from './PlaylistActionCreators';
+import { setPlaylists, loadPlaylist } from './PlaylistActionCreators';
 import { syncTimestamps } from './TickerActionCreators';
 import { closeLoginDialog } from './DialogActionCreators';
-import { setUsers } from './UserActionCreators';
-import { setVoteStats } from './VoteActionCreators';
-import { setWaitList } from './WaitlistActionCreators';
 import { tokenSelector } from '../selectors/userSelectors';
 
 const debug = createDebug('uwave:actions:login');
@@ -65,20 +59,9 @@ export function loadedState(state) {
       type: INIT_STATE,
       payload: state,
     });
-    if (state.motd) {
-      dispatch(receiveMotd(state.motd));
-    }
-    dispatch(setAuthenticationStrategies(state.authStrategies));
-    dispatch(setUsers(state.users || []));
-    dispatch(setPlaylists(state.playlists || []));
-    dispatch(setWaitList({
-      waitlist: state.waitlist,
-      locked: state.waitlistLocked,
-    }));
     if (state.booth && state.booth.historyID) {
       // TODO don't set this when logging in _after_ entering the page?
       dispatch(advance(state.booth));
-      dispatch(setVoteStats(state.booth.stats));
     }
     if (state.user) {
       const token = tokenSelector(getState());
@@ -89,8 +72,7 @@ export function loadedState(state) {
       }));
     }
     if (state.activePlaylist) {
-      dispatch(activatePlaylistComplete(state.activePlaylist));
-      dispatch(selectPlaylist(state.activePlaylist));
+      dispatch(loadPlaylist(state.activePlaylist));
     }
   };
 }

--- a/src/actions/ModerationActionCreators.js
+++ b/src/actions/ModerationActionCreators.js
@@ -1,5 +1,5 @@
+import { del, post, put } from './RequestActionCreators';
 import { djSelector } from '../selectors/boothSelectors';
-
 import {
   SKIP_DJ_START, SKIP_DJ_COMPLETE,
   MOVE_USER_START, MOVE_USER_COMPLETE,
@@ -9,10 +9,8 @@ import {
   BAN_USER_START, BAN_USER_COMPLETE,
   ADD_USER_ROLES_START, ADD_USER_ROLES_COMPLETE,
   REMOVE_USER_ROLES_START, REMOVE_USER_ROLES_COMPLETE,
-} from '../constants/actionTypes/moderation';
-
+} from '../constants/ActionTypes';
 import { removeMessage, removeMessagesByUser, removeAllMessages } from './ChatActionCreators';
-import { del, post, put } from './RequestActionCreators';
 
 export function skipCurrentDJ(reason = '', shouldRemove = false) {
   return (dispatch, getState) => {

--- a/src/actions/OverlayActionCreators.js
+++ b/src/actions/OverlayActionCreators.js
@@ -1,4 +1,4 @@
-import { OPEN_OVERLAY, CLOSE_OVERLAY, TOGGLE_OVERLAY } from '../constants/actionTypes/overlay';
+import { OPEN_OVERLAY, CLOSE_OVERLAY, TOGGLE_OVERLAY } from '../constants/ActionTypes';
 
 export function openOverlay(overlay) {
   return {

--- a/src/actions/PanelSelectActionCreators.js
+++ b/src/actions/PanelSelectActionCreators.js
@@ -1,4 +1,4 @@
-import { SELECT_PANEL } from '../constants/actionTypes/panel';
+import { SELECT_PANEL } from '../constants/ActionTypes';
 
 // eslint-disable-next-line import/prefer-default-export
 export function selectPanel(name) {

--- a/src/actions/PlaybackActionCreators.js
+++ b/src/actions/PlaybackActionCreators.js
@@ -3,7 +3,7 @@ import { settingsSelector } from '../selectors/settingSelectors';
 import {
   ENTER_FULLSCREEN,
   EXIT_FULLSCREEN,
-} from '../constants/actionTypes/booth';
+} from '../constants/ActionTypes';
 
 export function setVolume(volume) {
   return set('volume', volume);

--- a/src/actions/PlaylistActionCreators.js
+++ b/src/actions/PlaylistActionCreators.js
@@ -15,11 +15,9 @@ import {
   MOVE_MEDIA_START, MOVE_MEDIA_COMPLETE,
   UPDATE_MEDIA_START, UPDATE_MEDIA_COMPLETE,
   SHUFFLE_PLAYLIST_START, SHUFFLE_PLAYLIST_COMPLETE,
-} from '../constants/actionTypes/playlists';
-
+} from '../constants/ActionTypes';
 import { openEditMediaDialog } from './DialogActionCreators';
 import { del, get, post, put } from './RequestActionCreators';
-
 import {
   playlistsSelector,
   playlistItemsSelector,

--- a/src/actions/RequestActionCreators.js
+++ b/src/actions/RequestActionCreators.js
@@ -1,7 +1,7 @@
 import {
   REQUEST_START,
   REQUEST_COMPLETE,
-} from '../constants/actionTypes/request';
+} from '../constants/ActionTypes';
 
 let requestID = 0;
 function request(method, url, opts = {}) {

--- a/src/actions/SearchActionCreators.js
+++ b/src/actions/SearchActionCreators.js
@@ -1,11 +1,11 @@
+import { get } from './RequestActionCreators';
 import {
   SET_SEARCH_SOURCE,
   SHOW_SEARCH_RESULTS,
   SEARCH_START,
   SEARCH_COMPLETE,
   SEARCH_DELETE,
-} from '../constants/actionTypes/search';
-import { get } from './RequestActionCreators';
+} from '../constants/ActionTypes';
 
 export function setSource(source) {
   return {

--- a/src/actions/SettingsActionCreators.js
+++ b/src/actions/SettingsActionCreators.js
@@ -2,7 +2,7 @@ import setPath from 'lodash/set';
 import {
   LOAD_SETTINGS,
   CHANGE_SETTING,
-} from '../constants/actionTypes/settings';
+} from '../constants/ActionTypes';
 
 export function loadSettings(obj) {
   return {

--- a/src/actions/TickerActionCreators.js
+++ b/src/actions/TickerActionCreators.js
@@ -1,6 +1,5 @@
 import { get } from './RequestActionCreators';
-
-import { SET_TIMER, OFFSET } from '../constants/actionTypes/time';
+import { SET_TIMER, OFFSET } from '../constants/ActionTypes';
 import { timerSelector } from '../selectors/timeSelectors';
 
 export function syncTimestamps(clientTimeBefore, serverTime) {

--- a/src/actions/UserActionCreators.js
+++ b/src/actions/UserActionCreators.js
@@ -1,3 +1,4 @@
+import { put } from './RequestActionCreators';
 import {
   LOAD_ONLINE_USERS,
   USER_JOIN,
@@ -10,12 +11,11 @@ import {
 
   DO_CHANGE_USERNAME_START,
   DO_CHANGE_USERNAME_COMPLETE,
-} from '../constants/actionTypes/users';
+} from '../constants/ActionTypes';
 import {
   currentUserSelector,
   usersSelector,
 } from '../selectors/userSelectors';
-import { put } from './RequestActionCreators';
 
 export function setUsers(users) {
   return {

--- a/src/actions/VoteActionCreators.js
+++ b/src/actions/VoteActionCreators.js
@@ -1,16 +1,14 @@
 import { post } from './RequestActionCreators';
 import { historyIDSelector } from '../selectors/boothSelectors';
 import { playlistsSelector } from '../selectors/playlistSelectors';
-
-import { OPEN_ADD_MEDIA_MENU } from '../constants/actionTypes/playlists';
 import {
+  OPEN_ADD_MEDIA_MENU,
   LOAD_VOTES,
   FAVORITE, UPVOTE, DOWNVOTE,
   DO_FAVORITE_START, DO_FAVORITE_COMPLETE,
   DO_UPVOTE, DO_DOWNVOTE,
-} from '../constants/actionTypes/votes';
+} from '../constants/ActionTypes';
 import mergeIncludedModels from '../utils/mergeIncludedModels';
-
 import { flattenPlaylistItem } from './PlaylistActionCreators';
 
 export function setVoteStats(voteStats) {

--- a/src/actions/WaitlistActionCreators.js
+++ b/src/actions/WaitlistActionCreators.js
@@ -1,3 +1,4 @@
+import { del, post, put } from './RequestActionCreators';
 import {
   WAITLIST_LOAD,
   WAITLIST_LOCK,
@@ -10,8 +11,7 @@ import {
   DO_LEAVE_START, DO_LEAVE_COMPLETE,
   DO_LOCK_START, DO_LOCK_COMPLETE,
   DO_CLEAR_START, DO_CLEAR_COMPLETE,
-} from '../constants/actionTypes/waitlist';
-import { del, post, put } from './RequestActionCreators';
+} from '../constants/ActionTypes';
 import { currentUserSelector } from '../selectors/userSelectors';
 
 export function setWaitList(data) {

--- a/src/reducers/activeOverlay.js
+++ b/src/reducers/activeOverlay.js
@@ -1,4 +1,4 @@
-import { OPEN_OVERLAY, CLOSE_OVERLAY, TOGGLE_OVERLAY } from '../constants/actionTypes/overlay';
+import { OPEN_OVERLAY, CLOSE_OVERLAY, TOGGLE_OVERLAY } from '../constants/ActionTypes';
 
 const initialState = null;
 

--- a/src/reducers/addToPlaylistMenu.js
+++ b/src/reducers/addToPlaylistMenu.js
@@ -1,4 +1,4 @@
-import { OPEN_ADD_MEDIA_MENU, CLOSE_ADD_MEDIA_MENU } from '../constants/actionTypes/playlists';
+import { OPEN_ADD_MEDIA_MENU, CLOSE_ADD_MEDIA_MENU } from '../constants/ActionTypes';
 
 const initialState = {
   open: false,

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -1,10 +1,12 @@
 import {
+  INIT_STATE,
   AUTH_STRATEGIES,
   RESET_PASSWORD_COMPLETE,
   REGISTER_COMPLETE,
-  LOGIN_COMPLETE, SET_TOKEN,
+  LOGIN_COMPLETE,
+  SET_TOKEN,
   LOGOUT_COMPLETE,
-} from '../constants/actionTypes/auth';
+} from '../constants/ActionTypes';
 
 const initialState = {
   strategies: ['local'],
@@ -16,6 +18,11 @@ const initialState = {
 export default function reduce(state = initialState, action = {}) {
   const { type, payload, error: isError } = action;
   switch (type) {
+    case INIT_STATE:
+      return {
+        ...state,
+        strategies: payload.authStrategies,
+      };
     case AUTH_STRATEGIES:
       return {
         ...state,

--- a/src/reducers/booth.js
+++ b/src/reducers/booth.js
@@ -2,7 +2,7 @@ import {
   ADVANCE,
   ENTER_FULLSCREEN,
   EXIT_FULLSCREEN,
-} from '../constants/actionTypes/booth';
+} from '../constants/ActionTypes';
 
 const initialState = {
   historyID: null,

--- a/src/reducers/chat.js
+++ b/src/reducers/chat.js
@@ -1,5 +1,6 @@
 import except from 'except';
 import {
+  INIT_STATE,
   RECEIVE_MOTD,
   RECEIVE_MESSAGE,
   SEND_MESSAGE,
@@ -42,6 +43,11 @@ export default function reduce(state = initialState, action = {}) {
   const { type, payload } = action;
   const { messages } = state;
   switch (type) {
+    case INIT_STATE:
+      return {
+        ...state,
+        motd: payload.motd,
+      };
     case RECEIVE_MOTD:
       return {
         ...state,

--- a/src/reducers/config.js
+++ b/src/reducers/config.js
@@ -1,4 +1,4 @@
-import { INIT_STATE } from '../constants/actionTypes/auth';
+import { INIT_STATE } from '../constants/ActionTypes';
 
 const initialState = {};
 

--- a/src/reducers/dialogs.js
+++ b/src/reducers/dialogs.js
@@ -2,7 +2,7 @@ import {
   OPEN_EDIT_MEDIA_DIALOG, CLOSE_EDIT_MEDIA_DIALOG,
   OPEN_PREVIEW_MEDIA_DIALOG, CLOSE_PREVIEW_MEDIA_DIALOG,
   OPEN_LOGIN_DIALOG, CLOSE_LOGIN_DIALOG,
-} from '../constants/actionTypes/dialogs';
+} from '../constants/ActionTypes';
 
 const initialState = {
   editMedia: {

--- a/src/reducers/imports.js
+++ b/src/reducers/imports.js
@@ -2,9 +2,9 @@ import {
   SHOW_IMPORT_PANEL,
   SHOW_IMPORT_SOURCE_PANEL,
   HIDE_IMPORT_SOURCE_PANEL,
-} from '../constants/actionTypes/imports';
-import { SELECT_PLAYLIST } from '../constants/actionTypes/playlists';
-import { SHOW_SEARCH_RESULTS } from '../constants/actionTypes/search';
+  SELECT_PLAYLIST,
+  SHOW_SEARCH_RESULTS,
+} from '../constants/ActionTypes';
 
 const initialState = {
   showPanel: false,

--- a/src/reducers/mediaSearch.js
+++ b/src/reducers/mediaSearch.js
@@ -1,12 +1,12 @@
-import { SHOW_IMPORT_PANEL } from '../constants/actionTypes/imports';
-import { SELECT_PLAYLIST } from '../constants/actionTypes/playlists';
 import {
+  SHOW_IMPORT_PANEL,
+  SELECT_PLAYLIST,
   SET_SEARCH_SOURCE,
   SHOW_SEARCH_RESULTS,
   SEARCH_START,
   SEARCH_COMPLETE,
   SEARCH_DELETE,
-} from '../constants/actionTypes/search';
+} from '../constants/ActionTypes';
 import { IDLE, LOADING, LOADED } from '../constants/LoadingStates';
 
 const initialState = {

--- a/src/reducers/playlists.js
+++ b/src/reducers/playlists.js
@@ -6,6 +6,8 @@ import indexBy from 'index-by';
 import mapObj from 'object.map';
 
 import {
+  INIT_STATE,
+
   LOAD_ALL_PLAYLISTS_COMPLETE,
   LOAD_PLAYLIST_START,
   LOAD_PLAYLIST_COMPLETE,
@@ -29,12 +31,12 @@ import {
   UPDATE_MEDIA_COMPLETE,
   FILTER_PLAYLIST_ITEMS,
   FILTER_PLAYLIST_ITEMS_COMPLETE,
-} from '../constants/actionTypes/playlists';
-import { DO_FAVORITE_COMPLETE } from '../constants/actionTypes/votes';
-import {
+
+  DO_FAVORITE_COMPLETE,
+
   SEARCH_START,
   SEARCH_DELETE,
-} from '../constants/actionTypes/search';
+} from '../constants/ActionTypes';
 
 const initialState = {
   playlists: {},
@@ -163,6 +165,21 @@ export default function reduce(state = initialState, action = {}) {
   } = action;
 
   switch (type) {
+    case INIT_STATE:
+      return {
+        ...state,
+        playlists: indexBy(payload.playlists.map(playlist => ({
+          ...playlist,
+          active: playlist._id === payload.activePlaylist,
+          selected: playlist._id === payload.activePlaylist,
+        })), '_id'),
+        playlistItems: payload.activePlaylist && payload.firstActivePlaylistItem ? {
+          ...state.playlistItems,
+          [payload.activePlaylist]: [payload.firstActivePlaylistItem],
+        } : state.playlistItems,
+        activePlaylistID: payload.activePlaylist,
+        selectedPlaylistID: payload.activePlaylist,
+      };
     case LOAD_ALL_PLAYLISTS_COMPLETE:
       return {
         ...state,

--- a/src/reducers/roomHistory.js
+++ b/src/reducers/roomHistory.js
@@ -1,4 +1,4 @@
-import { ADVANCE, LOAD_HISTORY_COMPLETE } from '../constants/actionTypes/booth';
+import { ADVANCE, LOAD_HISTORY_COMPLETE } from '../constants/ActionTypes';
 
 const initialState = [];
 

--- a/src/reducers/selectedPanel.js
+++ b/src/reducers/selectedPanel.js
@@ -1,4 +1,4 @@
-import { SELECT_PANEL } from '../constants/actionTypes/panel';
+import { SELECT_PANEL } from '../constants/ActionTypes';
 
 const initialState = 'chat';
 

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -3,7 +3,7 @@ import compose from 'recompose/compose';
 import {
   LOAD_SETTINGS,
   CHANGE_SETTING,
-} from '../constants/actionTypes/settings';
+} from '../constants/ActionTypes';
 
 // Some people have >100% volumes stored in their localStorage settings
 // because of a bug in üWave 1.4. This ensures that _everyone's_ volume

--- a/src/reducers/time.js
+++ b/src/reducers/time.js
@@ -1,4 +1,4 @@
-import { SET_TIMER, OFFSET } from '../constants/actionTypes/time';
+import { SET_TIMER, OFFSET } from '../constants/ActionTypes';
 
 const initialState = {
   timer: 0,

--- a/src/reducers/users.js
+++ b/src/reducers/users.js
@@ -1,18 +1,16 @@
 import except from 'except';
 import indexBy from 'index-by';
 import { combineReducers } from 'redux';
-
-import { INIT_STATE } from '../constants/actionTypes/auth';
 import {
+  INIT_STATE,
   LOAD_ONLINE_USERS,
   USER_JOIN,
   USER_LEAVE,
   CHANGE_USERNAME,
   USER_ADD_ROLES,
   USER_REMOVE_ROLES,
-
   RECEIVE_GUEST_COUNT,
-} from '../constants/actionTypes/users';
+} from '../constants/ActionTypes';
 
 function updateUser(state, userID, update) {
   if (state[userID]) {
@@ -37,6 +35,7 @@ function guestsReducer(state = 0, action = {}) {
 function usersReducer(state = {}, action = {}) {
   const { type, payload } = action;
   switch (type) {
+    case INIT_STATE: // fall through
     case LOAD_ONLINE_USERS:
     // this is merged in instead of replacing the state, because sometimes the
     // JOIN event from the current user comes in before the LOAD event, and then

--- a/src/reducers/votes.js
+++ b/src/reducers/votes.js
@@ -1,9 +1,12 @@
-import { ADVANCE } from '../constants/actionTypes/booth';
 import {
+  ADVANCE,
   LOAD_VOTES,
-  FAVORITE, UPVOTE, DOWNVOTE,
-  DO_FAVORITE_START, DO_FAVORITE_COMPLETE,
-} from '../constants/actionTypes/votes';
+  FAVORITE,
+  UPVOTE,
+  DOWNVOTE,
+  DO_FAVORITE_START,
+  DO_FAVORITE_COMPLETE,
+} from '../constants/ActionTypes';
 
 const initialState = {
   upvotes: [],
@@ -15,6 +18,14 @@ export default function reduce(state = initialState, action = {}) {
   const { type, payload } = action;
   switch (type) {
     case ADVANCE:
+      if (payload && payload.stats) {
+        return {
+          ...state,
+          upvotes: payload.stats.upvotes,
+          downvotes: payload.stats.downvotes,
+          favorites: payload.stats.favorites,
+        };
+      }
       return initialState;
     case LOAD_VOTES:
       return {

--- a/src/reducers/waitlist.js
+++ b/src/reducers/waitlist.js
@@ -1,11 +1,12 @@
 import {
+  INIT_STATE,
   WAITLIST_LOAD,
   WAITLIST_LOCK,
   WAITLIST_CLEAR,
   WAITLIST_UPDATE,
   WAITLIST_JOIN,
   WAITLIST_LEAVE,
-} from '../constants/actionTypes/waitlist';
+} from '../constants/ActionTypes';
 
 const initialState = {
   waitlist: [],
@@ -15,6 +16,12 @@ const initialState = {
 export default function reduce(state = initialState, action = {}) {
   const { type, payload } = action;
   switch (type) {
+    case INIT_STATE:
+      return {
+        ...state,
+        waitlist: payload.waitlist,
+        locked: payload.waitlistLocked,
+      };
     case WAITLIST_LOAD:
       return {
         ...state,

--- a/src/store/request.js
+++ b/src/store/request.js
@@ -1,7 +1,6 @@
 import assign from 'object-assign';
 import qsStringify from 'qs-stringify';
-
-import { REQUEST_START } from '../constants/actionTypes/request';
+import { REQUEST_START } from '../constants/ActionTypes';
 import {
   requestComplete,
   requestCompleteError,

--- a/src/store/socket.js
+++ b/src/store/socket.js
@@ -1,6 +1,5 @@
 import createDebug from 'debug';
 import WebSocket from 'reconnecting-websocket';
-
 import {
   LOGIN_COMPLETE,
   LOGOUT_START,
@@ -8,13 +7,10 @@ import {
   SOCKET_RECONNECT,
   SOCKET_DISCONNECTED,
   SOCKET_CONNECTED,
-} from '../constants/actionTypes/auth';
-import { SEND_MESSAGE } from '../constants/actionTypes/chat';
-import {
+  SEND_MESSAGE,
   DO_UPVOTE,
   DO_DOWNVOTE,
-} from '../constants/actionTypes/votes';
-
+} from '../constants/ActionTypes';
 import { getSocketAuthToken } from '../actions/LoginActionCreators';
 import {
   advance,

--- a/test/reducers/addToPlaylistMenu.js
+++ b/test/reducers/addToPlaylistMenu.js
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-
 import createStore from '../../src/store/configureStore';
 import { addMediaMenu, closeAddMediaMenu } from '../../src/actions/PlaylistActionCreators';
 import * as s from '../../src/selectors/addToPlaylistMenuSelectors';

--- a/test/reducers/auth.js
+++ b/test/reducers/auth.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { LOGIN_COMPLETE } from '../../src/constants/actionTypes/auth';
+import { LOGIN_COMPLETE } from '../../src/constants/ActionTypes';
 import createStore from '../../src/store/configureStore';
 import * as s from '../../src/selectors/userSelectors';
 import { loginComplete, setSessionToken } from '../../src/actions/LoginActionCreators';

--- a/test/reducers/booth.js
+++ b/test/reducers/booth.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { ADVANCE } from '../../src/constants/actionTypes/booth';
+import { ADVANCE } from '../../src/constants/ActionTypes';
 import { advanceToEmpty } from '../../src/actions/BoothActionCreators';
 import booth from '../../src/reducers/booth';
 

--- a/test/reducers/dialogs.js
+++ b/test/reducers/dialogs.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import {
   OPEN_EDIT_MEDIA_DIALOG, CLOSE_EDIT_MEDIA_DIALOG,
   OPEN_LOGIN_DIALOG, CLOSE_LOGIN_DIALOG,
-} from '../../src/constants/actionTypes/dialogs';
+} from '../../src/constants/ActionTypes';
 import dialogs from '../../src/reducers/dialogs';
 
 const closedDialog = {

--- a/test/reducers/playlists.js
+++ b/test/reducers/playlists.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import fetch from 'fetch-mock';
-
 import createStore from '../../src/store/configureStore';
 import * as a from '../../src/actions/PlaylistActionCreators';
 import { favoriteMediaComplete } from '../../src/actions/VoteActionCreators';

--- a/test/reducers/roomHistory.js
+++ b/test/reducers/roomHistory.js
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-
 import createStore from '../../src/store/configureStore';
 import { setUsers } from '../../src/actions/UserActionCreators';
 import { advance, loadHistoryComplete } from '../../src/actions/BoothActionCreators';

--- a/test/reducers/settings.js
+++ b/test/reducers/settings.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import {
   LOAD_SETTINGS,
   CHANGE_SETTING,
-} from '../../src/constants/actionTypes/settings';
+} from '../../src/constants/ActionTypes';
 import settings from '../../src/reducers/settings';
 
 describe('reducers/settings', () => {


### PR DESCRIPTION
This makes some reducers more self contained, so they no longer rely on
the `initState` action dispatching all kinds of other actions.

Additionally moved to importing action constants from a single
ActionTypes file, for consistent casing with other constants modules.