### PR TITLE
Update u-wave-parse-chat-markup.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8804,7 +8804,8 @@
     "ip-regex": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz",
-      "integrity": "sha1-3FiQdvZZ9BnCIgOaMzFvHHOH7/0="
+      "integrity": "sha1-3FiQdvZZ9BnCIgOaMzFvHHOH7/0=",
+      "dev": true
     },
     "ipaddr.js": {
       "version": "1.6.0",
@@ -19751,11 +19752,6 @@
       "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=",
       "dev": true
     },
-    "tlds": {
-      "version": "1.199.0",
-      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.199.0.tgz",
-      "integrity": "sha512-NM0jUhibJjEX4g0+1ETxOhuODIDpyvCC0A2BjxrTfMUMZ+uRZc6ZnJl9SmFtAW1s5iQgQIxezFpUij6/6OiRbg=="
-    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -19955,12 +19951,11 @@
       "dev": true
     },
     "u-wave-parse-chat-markup": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/u-wave-parse-chat-markup/-/u-wave-parse-chat-markup-2.1.0.tgz",
-      "integrity": "sha512-o4dW9YXZCaaPBJnUltEVoDJdrNZpjp5SfR/Ge2Ns2uFOkSnT9Eip2QXaCP/t2WpYSo7R1WrnVAFPC0uY/MTGRQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/u-wave-parse-chat-markup/-/u-wave-parse-chat-markup-2.2.0.tgz",
+      "integrity": "sha512-jlBpf9uUfQeMyO3v4/WAMJmDu50wyKcXWXcDp265nLUI0BZyfD7/oHWqSOoBBB+bAgdzEsUjywuYjtuZXZuAOg==",
       "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "url-regex": "^4.0.0"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "u-wave-web-emojione": {
@@ -20417,15 +20412,6 @@
       "dev": true,
       "requires": {
         "prepend-http": "^1.0.1"
-      }
-    },
-    "url-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-4.1.1.tgz",
-      "integrity": "sha512-ViSDgDPNKkrQHI81GLCjdDN+Rsk3tAW/uLXlBOJxtcHzWZjta58Z0APXhfXzS89YszsheMnEvXeDXsWUB53wwA==",
-      "requires": {
-        "ip-regex": "^1.0.1",
-        "tlds": "^1.187.0"
       }
     },
     "url-to-options": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "dependencies": {
     "@babel/runtime": "7.0.0-beta.44",
     "@f/cookies-enabled": "^1.1.1",
-    "@material-ui/icons": "^1.0.0",
     "@material-ui/core": "^1.0.0",
+    "@material-ui/icons": "^1.0.0",
     "@u-wave/react-server-list": "^2.0.0",
     "@u-wave/react-youtube": "^0.4.2",
     "array-find": "^1.0.0",
@@ -79,7 +79,7 @@
     "screenfull": "^3.3.2",
     "shorten-url": "^1.0.0",
     "splitargs": "0.0.7",
-    "u-wave-parse-chat-markup": "^2.1.0",
+    "u-wave-parse-chat-markup": "^2.2.0",
     "upper-case-first": "^1.1.2",
     "whatwg-fetch": "^2.0.0",
     "yamlify": "^0.2.0"


### PR DESCRIPTION
No longer uses a TLD whitelist. This saves some 4KB after gzip.