### PR TITLE
Split some of the hacky webpack parts into separate files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20958,6 +20958,15 @@
         "uuid": "^3.1.0"
       }
     },
+    "webpack-merge": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.1.2.tgz",
+      "integrity": "sha512-/0QYwW/H1N/CdXYA2PNPVbsxO3u2Fpz34vs72xm03SRfg6bMNGfMJIQEpQjKRvkG2JvT6oRJFpDtSrwbX8Jzvw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.5"
+      }
+    },
     "webpack-pwa-manifest": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/webpack-pwa-manifest/-/webpack-pwa-manifest-3.6.2.tgz",

--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
     "webpack-bundle-analyzer": "^2.11.2",
     "webpack-dev-middleware": "^3.1.3",
     "webpack-hot-middleware": "^2.22.1",
+    "webpack-merge": "^4.1.2",
     "webpack-pwa-manifest": "^3.6.2",
     "webpack-subresource-integrity": "^1.1.0-rc.4",
     "yaml-loader": "^0.5.0"

--- a/tasks/utils/htmlMinifierOptions.js
+++ b/tasks/utils/htmlMinifierOptions.js
@@ -1,0 +1,13 @@
+// Minification options for html-minifier.
+module.exports = {
+  removeComments: true,
+  collapseWhitespace: true,
+  collapseBooleanAttributes: true,
+  removeTagWhitespace: true,
+  removeAttributeQuotes: true,
+  removeRedundantAttributes: true,
+  removeScriptTypeAttributes: true,
+  removeStyleLinkTypeAttributes: true,
+  removeOptionalTags: true,
+  minifyCSS: true,
+};

--- a/tasks/webpack/analyze.js
+++ b/tasks/webpack/analyze.js
@@ -1,0 +1,17 @@
+import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
+
+export default function analyze(mode) {
+  const openOptions = {
+    analyzerMode: 'server',
+  };
+  const staticOptions = {
+    analyzerMode: 'static',
+    openAnalyzer: false,
+  };
+
+  return {
+    plugins: [
+      new BundleAnalyzerPlugin(mode === 'open' ? openOptions : staticOptions),
+    ],
+  };
+}

--- a/tasks/webpack/compileDependencies.js
+++ b/tasks/webpack/compileDependencies.js
@@ -1,0 +1,36 @@
+// List of dependency paths that need to be compiled.
+const es2015Deps = [
+  /format-duration/,
+  /object-values/,
+  /@material-ui\/core\/es/,
+  /@material-ui\/icons\/es/,
+];
+
+export default function compileDependencies() {
+  const babelConfig = {
+    loader: 'babel-loader',
+    query: {
+      babelrc: false,
+      presets: [
+        ['@babel/preset-env', {
+          modules: false,
+          // Don't assume dependencies are OK with being run in loose mode
+          loose: false,
+          forceAllTransforms: true,
+        }],
+      ],
+    },
+  };
+
+  return {
+    module: {
+      rules: [
+        {
+          test: /\.js$/,
+          include: es2015Deps,
+          use: [babelConfig],
+        },
+      ],
+    },
+  };
+}

--- a/tasks/webpack/compress.js
+++ b/tasks/webpack/compress.js
@@ -1,0 +1,30 @@
+import CompressionPlugin from 'compression-webpack-plugin';
+import brotli from 'brotli/compress';
+
+const compressible = /\.(js|css|svg|mp3)$/;
+
+export default function compress() {
+  return {
+    plugins: [
+      // Add Gzip-compressed files.
+      new CompressionPlugin({
+        test: compressible,
+        asset: '[path].gz[query]',
+        algorithm: 'gzip',
+      }),
+      // Add Brotli-compressed files.
+      new CompressionPlugin({
+        test: compressible,
+        asset: '[path].br[query]',
+        algorithm(buffer, opts, cb) {
+          const result = brotli(buffer);
+          if (result) {
+            cb(null, Buffer.from(result));
+          } else {
+            cb(null, buffer);
+          }
+        },
+      }),
+    ],
+  };
+}

--- a/tasks/webpack/staticPages.js
+++ b/tasks/webpack/staticPages.js
@@ -1,0 +1,80 @@
+import path from 'path';
+import HtmlPlugin from 'html-webpack-plugin';
+import merge from 'webpack-merge';
+import htmlMinifierOptions from '../utils/htmlMinifierOptions';
+
+const context = path.join(__dirname, '../../src');
+
+export default function staticPages(pages, production) {
+  // Add static pages.
+  const staticFiles = [];
+
+  const pageConfigs = Object.entries(pages).map(([name, pathname]) => {
+    const fullPath = path.join(__dirname, '../../', pathname);
+    const config = {
+      entry: {
+        [name]: [
+          path.relative(context, fullPath),
+          './markdown.css',
+        ],
+      },
+      plugins: [
+        production ? (
+          // When compiling static pages in production mode, we use the static page
+          // contents as the template, and wrap it in the _actual_ template using a
+          // custom loader.
+          // This is very hacky indeed.
+          // The problem is that we need to insert compiled Markdown and any
+          // potential CSS into the HTML using the HtmlPlugin, but it's really hard
+          // to find the compiled markdown when you're just in a template.
+          // This could use a better alternative :p
+          new HtmlPlugin({
+            chunks: [name],
+            filename: `${name}.html`,
+            template: [
+              require.resolve('../utils/loadStaticHtmlTemplate'),
+              'extract-loader',
+              fullPath,
+            ].join('!'),
+            inject: false,
+            minify: htmlMinifierOptions,
+          })
+        ) : (
+          new HtmlPlugin({
+            chunks: [name],
+            template: './markdown.dev.html',
+            filename: `${name}.html`,
+          })
+        ),
+      ],
+    };
+
+    staticFiles.push(fullPath);
+
+    return config;
+  });
+
+  const loaders = {
+    module: {
+      rules: [
+        !production && {
+          // Hot reload static pages in development mode.
+          test: staticFiles,
+          use: require.resolve('../utils/insertHtml'),
+        },
+        {
+          test: /\.md$/,
+          use: [
+            'html-loader',
+            require.resolve('../utils/renderMarkdown'),
+          ],
+        },
+      ].filter(Boolean),
+    },
+  };
+
+  return merge([
+    ...pageConfigs,
+    loaders,
+  ]);
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -204,6 +204,7 @@ module.exports = {
   // Quit if there are errors.
   bail: nodeEnv === 'production',
   devtool: nodeEnv === 'production' ? 'source-map' : 'inline-source-map',
+
   output: {
     publicPath: '/',
     path: path.join(__dirname, 'public'),
@@ -211,10 +212,13 @@ module.exports = {
     chunkFilename: nodeEnv === 'production' ? '[name]_[chunkhash:7].js' : '[name]_dev.js',
     crossOriginLoading: 'anonymous',
   },
+
   optimization,
   plugins,
+
   module: {
     rules: [
+      // Static files and resources.
       {
         test: /\.mp3$/,
         use: [
@@ -228,6 +232,15 @@ module.exports = {
           { loader: 'image-webpack-loader', query: { bypassOnDebug: true } },
         ],
       },
+
+      // Locale files.
+      {
+        test: /\.yaml$/,
+        type: 'json',
+        use: 'yaml-loader',
+      },
+
+      // Stylesheets.
       {
         test: /\.css$/,
         use: [
@@ -236,11 +249,7 @@ module.exports = {
           'postcss-loader',
         ],
       },
-      {
-        test: /\.yaml$/,
-        type: 'json',
-        use: 'yaml-loader',
-      },
+
       // JS loader for dependencies that use ES2015+:
       {
         test: /\.js$/,
@@ -267,6 +276,8 @@ module.exports = {
           },
         ].filter(Boolean),
       },
+
+      // Static pages.
       nodeEnv !== 'production' && {
         // Hot reload static pages in development mode.
         test: staticFiles,
@@ -283,6 +294,7 @@ module.exports = {
   },
   resolve: {
     alias: {
+      // Use the ES modules versions of some packages.
       '@material-ui/core': path.join(__dirname, 'node_modules/@material-ui/core/es/'),
       '@material-ui/icons': path.join(__dirname, 'node_modules/@material-ui/icons/es/'),
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,8 @@ const HtmlPlugin = require('html-webpack-plugin');
 const HtmlSiblingChunksPlugin = require('html-webpack-include-sibling-chunks-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
 const ManifestPlugin = require('webpack-pwa-manifest');
+const merge = require('webpack-merge');
+const htmlMinifierOptions = require('./tasks/utils/htmlMinifierOptions');
 
 const nodeEnv = process.env.NODE_ENV || 'development';
 
@@ -15,42 +17,27 @@ const nodeEnv = process.env.NODE_ENV || 'development';
 require('@babel/register').default({
   only: [
     new RegExp(escapeStringRegExp(path.join(__dirname, 'src'))),
+    new RegExp(escapeStringRegExp(path.join(__dirname, 'tasks/webpack'))),
   ],
-  plugins: ['@babel/plugin-transform-modules-commonjs'],
+  plugins: [
+    ['@babel/plugin-transform-modules-commonjs', { lazy: true }],
+  ],
 });
 
-const staticPages = {
-  privacy: './static/privacy.md',
-};
-
-// Minification options used in production mode.
-const htmlMinifierOptions = {
-  removeComments: true,
-  collapseWhitespace: true,
-  collapseBooleanAttributes: true,
-  removeTagWhitespace: true,
-  removeAttributeQuotes: true,
-  removeRedundantAttributes: true,
-  removeScriptTypeAttributes: true,
-  removeStyleLinkTypeAttributes: true,
-  removeOptionalTags: true,
-  minifyCSS: true,
-};
-
-const noConfigBabelLoader = {
-  loader: 'babel-loader',
-  query: {
-    babelrc: false,
-    presets: [
-      ['@babel/preset-env', {
-        modules: false,
-        // Don't assume dependencies are OK with being run in loose mode
-        loose: false,
-        forceAllTransforms: true,
-      }],
-    ],
-  },
-};
+// Most webpack configuration is in this file. A few things are split up to make the
+// core stuff easier to grasp.
+//
+// Other parts of the build are in the ./tasks/webpack/ folder:
+//  - compileDependencies: Compiles dependencies that only ship ES2015+ to code that
+//    works in all our browser targets.
+const compileDependencies = require('./tasks/webpack/compileDependencies').default;
+//  - compress: Emits precompressed gzip and brotli versions of static assets.
+const compress = require('./tasks/webpack/compress').default;
+//  - staticPages: Compiles static markdown pages to HTML.
+const staticPages = require('./tasks/webpack/staticPages').default;
+//  - analyze: Optionally generates a bundle size statistics page using
+//    webpack-bundle-analyzer.
+const analyze = require('./tasks/webpack/analyze').default;
 
 const plugins = [
   new CopyPlugin([
@@ -81,12 +68,8 @@ const plugins = [
 let optimization;
 
 if (nodeEnv === 'production') {
-  const CompressionPlugin = require('compression-webpack-plugin');
-  const brotli = require('brotli/compress');
   const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
   const SriPlugin = require('webpack-subresource-integrity');
-
-  const compressible = /\.(js|css|svg|mp3)$/;
 
   optimization = {
     runtimeChunk: 'single',
@@ -114,92 +97,18 @@ if (nodeEnv === 'production') {
       filename: '[name]_[contenthash:7].css',
       chunkFilename: '[name]_[contenthash:7].css',
     }),
-    // Add Gzip-compressed files.
-    new CompressionPlugin({
-      test: compressible,
-      asset: '[path].gz[query]',
-      algorithm: 'gzip',
-    }),
-    // Add Brotli-compressed files.
-    new CompressionPlugin({
-      test: compressible,
-      asset: '[path].br[query]',
-      algorithm(buffer, opts, cb) {
-        const result = brotli(buffer);
-        if (result) {
-          cb(null, Buffer.from(result));
-        } else {
-          cb(null, buffer);
-        }
-      },
-    }),
     new SriPlugin({
       hashFuncNames: ['sha512'],
     }),
   );
 }
 
-if (process.env.ANALYZE) {
-  const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
-  const openOptions = {
-    analyzerMode: 'server',
-  };
-  const staticOptions = {
-    analyzerMode: 'static',
-    openAnalyzer: false,
-  };
-  plugins.push(new BundleAnalyzerPlugin(process.env.ANALYZE === 'open' ? openOptions : staticOptions));
-}
-
-const context = path.join(__dirname, 'src');
-const entries = {
-  app: ['./app.js', './app.css'],
-  passwordReset: ['./password-reset/app.js'],
-};
-
-// Add static pages.
-const staticFiles = [];
-Object.keys(staticPages).forEach((name) => {
-  const fullPath = path.join(__dirname, staticPages[name]);
-  entries[name] = [
-    path.relative(context, fullPath),
-    './markdown.css',
-  ];
-
-  staticFiles.push(fullPath);
-
-  if (nodeEnv === 'production') {
-    // When compiling static pages in production mode, we use the static page
-    // contents as the template, and wrap it in the _actual_ template using a
-    // custom loader.
-    // This is very hacky indeed.
-    // The problem is that we need to insert compiled Markdown and any
-    // potential CSS into the HTML using the HtmlPlugin, but it's really hard
-    // to find the compiled markdown when you're just in a template.
-    // This could use a better alternative :p
-    plugins.push(new HtmlPlugin({
-      chunks: [name],
-      filename: `${name}.html`,
-      template: [
-        require.resolve('./tasks/utils/loadStaticHtmlTemplate'),
-        'extract-loader',
-        fullPath,
-      ].join('!'),
-      inject: false,
-      minify: htmlMinifierOptions,
-    }));
-  } else {
-    plugins.push(new HtmlPlugin({
-      chunks: [name],
-      template: './markdown.dev.html',
-      filename: `${name}.html`,
-    }));
-  }
-});
-
-module.exports = {
-  context,
-  entry: entries,
+const base = {
+  context: path.join(__dirname, 'src'),
+  entry: {
+    app: ['./app.js', './app.css'],
+    passwordReset: ['./password-reset/app.js'],
+  },
   mode: nodeEnv === 'production' ? 'production' : 'development',
   // Quit if there are errors.
   bail: nodeEnv === 'production',
@@ -250,20 +159,6 @@ module.exports = {
         ],
       },
 
-      // JS loader for dependencies that use ES2015+:
-      {
-        test: /\.js$/,
-        include: [
-          /url-regex/,
-          /format-duration/,
-          /object-values/,
-          /material-ui\/es/,
-          /material-ui-icons\/es/,
-        ],
-        use: [
-          noConfigBabelLoader,
-        ],
-      },
       // JS loader for our own code:
       {
         test: /\.js$/,
@@ -275,20 +170,6 @@ module.exports = {
             query: { cache: true },
           },
         ].filter(Boolean),
-      },
-
-      // Static pages.
-      nodeEnv !== 'production' && {
-        // Hot reload static pages in development mode.
-        test: staticFiles,
-        use: require.resolve('./tasks/utils/insertHtml'),
-      },
-      {
-        test: /\.md$/,
-        use: [
-          'html-loader',
-          require.resolve('./tasks/utils/renderMarkdown'),
-        ],
       },
     ].filter(Boolean),
   },
@@ -306,3 +187,13 @@ module.exports = {
     ],
   },
 };
+
+module.exports = merge([
+  base,
+  compileDependencies(),
+  staticPages({
+    privacy: './static/privacy.md',
+  }, nodeEnv === 'production'),
+  nodeEnv === 'production' && compress(),
+  process.env.ANALYZE && analyze(process.env.ANALYZE),
+].filter(Boolean));


### PR DESCRIPTION
This should make the base config a bit easier to understand. 9 out of 10 times you don't need to change how static pages work, so its dozens of lines of hacks were usually in the way.