### PR TITLE
Fix CSS className generation for anonymous components

### DIFF
--- a/src/Uwave.js
+++ b/src/Uwave.js
@@ -11,7 +11,7 @@ import JssProvider from 'react-jss/lib/JssProvider';
 import createLocale from './locale';
 import AppContainer from './containers/App';
 import { get as readSession } from './utils/Session';
-import generateClassName from './utils/generateClassName';
+import createGenerateClassName from './utils/createGenerateClassName';
 import configureStore from './store/configureStore';
 import { initState, socketConnect, setSessionToken } from './actions/LoginActionCreators';
 import { languageSelector } from './selectors/settingSelectors';
@@ -28,6 +28,7 @@ export default class Uwave {
   aboutPageComponent = null;
 
   jss = createJss(jssPreset());
+  generateClassName = createGenerateClassName();
 
   constructor(options = {}, session = readSession()) {
     this.options = options;
@@ -125,7 +126,7 @@ export default class Uwave {
   getComponent() {
     return (
       <Provider store={this.store}>
-        <JssProvider jss={this.jss} generateClassName={generateClassName}>
+        <JssProvider jss={this.jss} generateClassName={this.generateClassName}>
           <AppContainer
             mediaSources={this.sources}
             locale={this.locale}

--- a/src/utils/createGenerateClassName.js
+++ b/src/utils/createGenerateClassName.js
@@ -1,0 +1,18 @@
+export default function createGenerateClassName() {
+  let counter = 0;
+
+  function getNextUnknownName() {
+    counter += 1;
+    return `Component${counter}`;
+  }
+
+  function generateClassName(rule, styleSheet) {
+    const componentName = styleSheet.options.name || getNextUnknownName();
+    if (rule.key === 'root') {
+      return componentName;
+    }
+    return `${componentName}-${rule.key}`;
+  }
+
+  return generateClassName;
+}

--- a/src/utils/generateClassName.js
+++ b/src/utils/generateClassName.js
@@ -1,8 +1,0 @@
-export default function generateClassName(rule, styleSheet) {
-  const componentName = styleSheet.options.name;
-  if (rule.key === 'root') {
-    return componentName;
-  }
-  return `${componentName}-${rule.key}`;
-}
-

--- a/tasks/utils/prerender.js
+++ b/tasks/utils/prerender.js
@@ -7,10 +7,11 @@ const jss = require('jss');
 
 module.exports = function prerender(element) {
   const theme = require('../../src/theme').default;
-  const generateClassName = require('../../src/utils/generateClassName').default;
+  const createGenerateClassName = require('../../src/utils/createGenerateClassName').default;
 
   const styles = jss.create(jssPreset());
   const registry = new SheetsRegistry();
+  const generateClassName = createGenerateClassName();
 
   const markup = renderToStaticMarkup(h(
     JssProvider, { jss: styles, registry, generateClassName },


### PR DESCRIPTION
Fixes #967

The TabIndicator is not assigned a name in its `withStyles()` call. This
patch defaults to `ComponentN` as the component name for such components.