### PR TITLE
Fix duplicate `onSubmit` calls in PromptDialog.

### DIFF
--- a/src/components/Dialogs/PromptDialog/index.js
+++ b/src/components/Dialogs/PromptDialog/index.js
@@ -80,6 +80,8 @@ export default class PromptDialog extends React.Component {
       contentClassName,
       titleClassName,
 
+      onSubmit,
+
       ...props
     } = this.props;
     const {


### PR DESCRIPTION
PromptDialogs call `onSubmit` with the input value inside their
`handleSubmit` methods, but also pass all `props` including `onSubmit`
through to their `<Dialog />` instance. This was causing `onSubmit` to
be called twice; once by `handleSubmit`, and once by the Dialog. The
Dialog calls it with a synthetic events instance, causing errors down
the line.

This patch prevents `onSubmit` being passed to the Dialog.