### PR TITLE
Use transforms for overlay transitions.

### DIFF
--- a/src/components/App/Overlays.js
+++ b/src/components/App/Overlays.js
@@ -4,6 +4,15 @@ import find from 'array-find';
 import CSSTransition from 'react-transition-group/CSSTransition';
 import TransitionGroup from 'react-transition-group/TransitionGroup';
 
+// Use the css transitionend event to mark the finish of a transition.
+// Using this instead of a timeout prop so that we don't have to define
+// the timeout in multiple places, and it also fixes a small visual
+// glitch in Firefox where a scrollbar would appear for a split second
+// when the enter transition was almost complete.
+function addTransitionEndListener(node, done) {
+  node.addEventListener('transitionend', done, false);
+}
+
 const Overlays = ({ children, active }) => {
   let view;
   if (Array.isArray(children)) {
@@ -20,7 +29,7 @@ const Overlays = ({ children, active }) => {
         mountOnEnter
         unmountOnExit
         classNames="Overlay"
-        timeout={180}
+        addEndListener={addTransitionEndListener}
       >
         {view}
       </CSSTransition>

--- a/src/components/Overlay/index.css
+++ b/src/components/Overlay/index.css
@@ -11,9 +11,15 @@
   top: auto;
   bottom: 0;
 }
+.Overlay--from-bottom .Overlay-body {
+  transform: translateY(100%);
+}
 .Overlay--from-top {
   top: 0;
   bottom: auto;
+}
+.Overlay--from-top .Overlay-body {
+  transform: translateY(-100%);
 }
 
 .Overlay-body {
@@ -38,20 +44,20 @@
 }
 
 /* Animations!.. */
-.Overlay-enter {
-  overflow-y: hidden;
-  height: 0%;
-}
-.Overlay-enter-active {
-  transition: height 180ms ease-out;
-  height: 100%;
-}
 
+/* Enable transitions during enter/exit. */
+.Overlay-enter,
 .Overlay-exit {
   overflow-y: hidden;
-  height: 100%;
 }
-.Overlay-exit-active {
-  transition: height 180ms ease-in;
-  height: 0%;
+.Overlay-enter .Overlay-body {
+  transition: transform 180ms ease-out;
+}
+.Overlay-exit .Overlay-body {
+  transition: transform 180ms ease-in;
+}
+/* The target (open) state. */
+.Overlay-enter-active .Overlay-body,
+.Overlay-enter-done .Overlay-body {
+  transform: translateY(0);
 }


### PR DESCRIPTION
This makes them faster. Now, the .Overlay-body element is the one being
animated.  The .Overlay element sets `overflow-y: hidden` to prevent a
scrollbar when transitioning elements are halfway off the page.