### PR TITLE
Animate scroll down button in and out on keyboard focus.

### DIFF
--- a/locale/en.yaml
+++ b/locale/en.yaml
@@ -42,6 +42,7 @@ uwave:
     selfSkipReason: "{{username}} skipped their turn: {{reason}}"
     rolesAdded: "{{username}} is now a {{roles}}"
     rolesRemoved: "{{username}} is no longer a {{roles}}"
+    scrollDown: Scroll down to read new messages
 
   dialogs:
     confirm:

--- a/src/components/Chat/ChatMessages.css
+++ b/src/components/Chat/ChatMessages.css
@@ -40,7 +40,7 @@
   transition: margin-top 140ms ease-in;
   margin: auto;
   margin-top: 55px;
-  @nest .ChatMessages-scrollDown.is-visible & {
+  @nest .ChatMessages-scrollDown.is-visible &, &:focus {
     transition: margin-top 140ms ease-out;
     margin-top: 0;
   }

--- a/src/components/Chat/ScrollDownNotice.js
+++ b/src/components/Chat/ScrollDownNotice.js
@@ -1,16 +1,20 @@
 import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { translate } from 'react-i18next';
 import Button from '@material-ui/core/Button';
 import ScrollDownIcon from '@material-ui/icons/ArrowDownward';
 
-const ScrollNotice = ({ show, onClick }) => (
+const enhance = translate();
+
+const ScrollNotice = ({ t, show, onClick }) => (
   <div className={cx('ChatMessages-scrollDown', show && 'is-visible')}>
     <Button
       className="ChatMessages-scrollDownButton"
       variant="fab"
       mini
       color="primary"
+      aria-label={t('chat.scrollDown')}
       onClick={onClick}
     >
       <ScrollDownIcon />
@@ -19,8 +23,9 @@ const ScrollNotice = ({ show, onClick }) => (
 );
 
 ScrollNotice.propTypes = {
+  t: PropTypes.func.isRequired,
   show: PropTypes.bool.isRequired,
   onClick: PropTypes.func.isRequired,
 };
 
-export default ScrollNotice;
+export default enhance(ScrollNotice);

--- a/src/components/Chat/ScrollDownNotice.js
+++ b/src/components/Chat/ScrollDownNotice.js
@@ -6,11 +6,15 @@ import ScrollDownIcon from '@material-ui/icons/ArrowDownward';
 
 const ScrollNotice = ({ show, onClick }) => (
   <div className={cx('ChatMessages-scrollDown', show && 'is-visible')}>
-    <div className="ChatMessages-scrollDownButton">
-      <Button variant="fab" mini color="primary" onClick={onClick}>
-        <ScrollDownIcon />
-      </Button>
-    </div>
+    <Button
+      className="ChatMessages-scrollDownButton"
+      variant="fab"
+      mini
+      color="primary"
+      onClick={onClick}
+    >
+      <ScrollDownIcon />
+    </Button>
   </div>
 );
 


### PR DESCRIPTION
This also fixes an issue where the button would keep showing even
after the button was no longer keyboard-focused.