### PR TITLE
Rename HeaderHistoryButton → HistoryButton.

### DIFF
--- a/src/components/HeaderBar/HistoryButton.css
+++ b/src/components/HeaderBar/HistoryButton.css
@@ -1,9 +1,6 @@
-@import "../../vars.css";
-
-.HeaderHistoryButton {
+.HistoryButton {
   /* above the progress bar, video backdrop, etc. */
   z-index: 7;
-  color: var(--text-color);
   height: 100%;
   width: 100%;
 }

--- a/src/components/HeaderBar/HistoryButton.js
+++ b/src/components/HeaderBar/HistoryButton.js
@@ -7,14 +7,19 @@ import Tooltip from '@material-ui/core/Tooltip';
 import IconButton from '@material-ui/core/IconButton';
 import HistoryIcon from '@material-ui/icons/History';
 
+const enhance = compose(
+  translate(),
+  pure,
+);
+
 const HistoryButton = ({ t, onClick }) => (
   <Tooltip title={t('history.title')} position="bottom">
     <IconButton
       aria-label={t('history.title')}
-      className="HeaderHistoryButton"
+      className="HistoryButton"
       onClick={onClick}
     >
-      <HistoryIcon className="HeaderHistoryButton-icon" />
+      <HistoryIcon className="HistoryButton-icon" />
     </IconButton>
   </Tooltip>
 );
@@ -24,7 +29,4 @@ HistoryButton.propTypes = {
   onClick: PropTypes.func.isRequired,
 };
 
-export default compose(
-  translate(),
-  pure,
-)(HistoryButton);
+export default enhance(HistoryButton);

--- a/src/components/HeaderBar/index.css
+++ b/src/components/HeaderBar/index.css
@@ -1,6 +1,6 @@
 @import "../../vars.css";
 @import "./AppTitle.css";
-@import "./HeaderHistoryButton.css";
+@import "./HistoryButton.css";
 @import "./Progress.css";
 @import "./Volume.css";
 


### PR DESCRIPTION
The `Header` part is not relevant.