### PR TITLE
Use CSS variables for theming.

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -11,7 +11,9 @@ module.exports = (options) => {
         features: {
           // Force enable custom properties so they can be used in color()
           // function calls even if the target browser does not support them.
-          customProperties: true,
+          customProperties: {
+            preserve: true,
+          },
         },
       },
       cssnano: env === 'production' && {

--- a/src/actions/ThemeActionCreators.js
+++ b/src/actions/ThemeActionCreators.js
@@ -1,0 +1,9 @@
+import { RESET_THEME, APPLY_THEME } from '../constants/ActionTypes';
+
+export function debugResetTheme() {
+  return { type: RESET_THEME };
+}
+
+export function debugApplyTheme(newValues) {
+  return { type: APPLY_THEME, payload: newValues };
+}

--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,5 @@
 import Uwave from './Uwave';
+import experimentalThemePlugin from './experimentalThemePlugin';
 import youTubeSource from './sources/youtube';
 import soundCloudSource from './sources/soundcloud';
 
@@ -11,6 +12,9 @@ function readApplicationConfig() {
 }
 
 const uw = new Uwave(readApplicationConfig());
+
+// Add experimental theming API.
+uw.use(experimentalThemePlugin);
 
 // Configure the Media sources to be used by this üWave client instance.
 uw.source(youTubeSource());

--- a/src/components/Chat/Input/Suggestion.css
+++ b/src/components/Chat/Input/Suggestion.css
@@ -2,6 +2,6 @@
 
 .SuggestionItem {
   &:hover, &.is-focused {
-    background-color: color(var(--text-color) a(* 10%));
+    background-color: var(--chat-suggestion-selected);
   }
 }

--- a/src/components/Chat/Message.css
+++ b/src/components/Chat/Message.css
@@ -33,7 +33,7 @@
 }
 
 .ChatMessage-timestamp {
-  color: color(var(--text-color) blend(#777777 33%));
+  color: var(--chat-timestamp-text-color);
 }
 
 .ChatMessage-avatar {

--- a/src/components/FooterBar/WaitlistButton.css
+++ b/src/components/FooterBar/WaitlistButton.css
@@ -25,7 +25,7 @@
 
 .WaitlistButton--locked {
   width: 140px;
-  color: color(var(--text-color) alpha(* 70%));
+  color: var(--waitlist-locked-text-color);
 }
 
 .WaitlistButton-icon {

--- a/src/components/LazyOverlay/index.css
+++ b/src/components/LazyOverlay/index.css
@@ -4,7 +4,7 @@
 }
 
 .LoadingOverlay-body {
-  background: color(var(--background-color) alpha(* 96%));
+  background: var(--overlay-background);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/MediaList/Row.css
+++ b/src/components/MediaList/Row.css
@@ -11,7 +11,7 @@
   }
 
   &.is-selected {
-    background: color(var(--highlight-color) alpha(* 70%));
+    background: var(--selected-media-row-color);
   }
 }
 

--- a/src/components/Overlay/index.css
+++ b/src/components/Overlay/index.css
@@ -40,7 +40,7 @@
 }
 
 .Overlay-loading {
-  background: color(var(--background-color) alpha(* 96%));
+  background: var(--overlay-background);
 }
 
 /* Animations!.. */

--- a/src/components/PlaylistManager/Menu/index.css
+++ b/src/components/PlaylistManager/Menu/index.css
@@ -2,7 +2,7 @@
 @import "./Row.css";
 
 .PlaylistMenu {
-  background: color(var(--background-color) alpha(* 96%));
+  background: var(--overlay-background);
   height: 100%;
   overflow-y: auto;
 }

--- a/src/components/PlaylistManager/Panel/index.css
+++ b/src/components/PlaylistManager/Panel/index.css
@@ -5,7 +5,7 @@
 @import "./PlaylistItemRow.css";
 
 .PlaylistPanel {
-  background: color(var(--background-color) alpha(* 96%));
+  background: var(--overlay-background);
   height: 100%;
   width: 100%;
 }

--- a/src/components/RoomHistory/index.css
+++ b/src/components/RoomHistory/index.css
@@ -9,7 +9,7 @@
 }
 
 .RoomHistory-body {
-  background: color(var(--background-color) alpha(* 96%));
+  background: var(--overlay-background);
 }
 
 .RoomHistory-list {

--- a/src/components/SettingsManager/index.css
+++ b/src/components/SettingsManager/index.css
@@ -15,5 +15,5 @@
 
 .SettingsManager-body {
   overflow-y: scroll;
-  background: color(var(--background-color) alpha(* 96%));
+  background: var(--overlay-background);
 }

--- a/src/constants/ActionTypes.js
+++ b/src/constants/ActionTypes.js
@@ -11,6 +11,7 @@ export * from './actionTypes/playlists';
 export * from './actionTypes/request';
 export * from './actionTypes/search';
 export * from './actionTypes/settings';
+export * from './actionTypes/theme';
 export * from './actionTypes/time';
 export * from './actionTypes/users';
 export * from './actionTypes/votes';

--- a/src/constants/actionTypes/theme.js
+++ b/src/constants/actionTypes/theme.js
@@ -1,0 +1,2 @@
+export const RESET_THEME = 'uwave/debug/RESET_THEME';
+export const APPLY_THEME = 'uwave/debug/APPLY_THEME';

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import nest from 'recompose/nest';
 import { connect } from 'react-redux';
@@ -60,14 +61,31 @@ class AppContainer extends React.Component {
     };
   }
 
+  componentDidMount() {
+    this.applyThemeProperties();
+  }
+
   componentDidUpdate(prevProps) {
     if (this.props.language !== prevProps.language) {
       this.props.locale.changeLanguage(this.props.language);
+    }
+
+    if (this.props.theme !== prevProps.theme) {
+      this.applyThemeProperties();
     }
   }
 
   componentDidCatch(error) {
     this.setState({ error });
+  }
+
+  applyThemeProperties() {
+    const { theme } = this.props;
+    const root = ReactDOM.findDOMNode(this); // eslint-disable-line react/no-find-dom-node
+
+    Object.keys(theme.cssProperties).forEach((prop) => {
+      root.style.setProperty(prop, theme.cssProperties[prop]);
+    });
   }
 
   renderApp = () => (

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import nest from 'recompose/nest';
 import { connect } from 'react-redux';
@@ -81,7 +80,7 @@ class AppContainer extends React.Component {
 
   applyThemeProperties() {
     const { theme } = this.props;
-    const root = ReactDOM.findDOMNode(this); // eslint-disable-line react/no-find-dom-node
+    const root = document.body;
 
     Object.keys(theme.cssProperties).forEach((prop) => {
       root.style.setProperty(prop, theme.cssProperties[prop]);

--- a/src/demo.js
+++ b/src/demo.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Uwave from './Uwave';
+import experimentalThemePlugin from './experimentalThemePlugin';
 import youTubeSource from './sources/youtube';
 import soundCloudSource from './sources/soundcloud';
 
@@ -8,6 +9,9 @@ const uw = new Uwave({
   socketUrl: 'wss://u-wave-demo.now.sh',
   emoji: {},
 });
+
+// Add experimental theming API.
+uw.use(experimentalThemePlugin);
 
 // Configure the Media sources to be used by this üWave client instance.
 uw.source(youTubeSource());

--- a/src/experimentalThemePlugin.js
+++ b/src/experimentalThemePlugin.js
@@ -1,0 +1,14 @@
+import { bindActionCreators } from 'redux';
+import { debugApplyTheme, debugResetTheme } from './actions/ThemeActionCreators';
+
+export default function experimentalThemePlugin(instance) {
+  // `.store` will not yet be available when this is .use()d.
+  function dispatchProxy(...args) {
+    return instance.store.dispatch(...args);
+  }
+
+  Object.assign(instance, bindActionCreators({
+    debugApplyTheme,
+    debugResetTheme,
+  }, dispatchProxy));
+}

--- a/src/reducers/theme.js
+++ b/src/reducers/theme.js
@@ -1,7 +1,14 @@
+import merge from 'deepmerge';
+import { RESET_THEME, APPLY_THEME } from '../constants/ActionTypes';
 import initialState from '../theme';
 
-// eslint-disable-next-line no-unused-vars
 export default function reduce(state = initialState, action = {}) {
-  // Nothing for now!
-  return state;
+  switch (action.type) {
+    case RESET_THEME:
+      return initialState;
+    case APPLY_THEME:
+      return merge(state, action.payload);
+    default:
+      return state;
+  }
 }

--- a/src/selectors/settingSelectors.js
+++ b/src/selectors/settingSelectors.js
@@ -1,7 +1,7 @@
 /* global window */
 import { createSelector } from 'reselect';
-import { createMuiTheme } from '@material-ui/core/styles';
 import { availableLanguages } from '../locale';
+import createTheme from '../utils/createTheme';
 
 function getAvailableLanguage(languages) {
   return languages.find(lang => (
@@ -23,7 +23,7 @@ const settingsBaseSelector = state => state.settings;
 
 export const themeSelector = createSelector(
   state => state.theme,
-  base => createMuiTheme(base),
+  base => createTheme(base),
 );
 
 export const volumeSelector = createSelector(

--- a/src/sources/soundcloud/Player.css
+++ b/src/sources/soundcloud/Player.css
@@ -32,7 +32,7 @@
 }
 
 .src-soundcloud-Player-meta {
-  background: color(var(--background-color) alpha(* 20%));
+  background: var(--soundcloud-meta-background);
   position: relative;
   padding: var(--sc-margins);
   z-index: 3;

--- a/src/theme.js
+++ b/src/theme.js
@@ -9,9 +9,27 @@ export default {
     background: {
       paper: '#303030',
     },
+    text: {
+      secondary: '#777',
+    },
   },
   typography: {
     fontFamily: '"Open Sans", Roboto, Arial, sans-serif',
+  },
+  // üWave specific colours
+  uwave: {
+    scrollbar: '#5f5f5f',
+    background: '#151515',
+    backgroundHover: '#111',
+    link: '#c72e6c',
+    sidePanel: {
+      background: '#1b1b1b',
+      alternate: '#222222',
+    },
+    mediaList: {
+      background: 'transparent',
+      alternate: '#303036',
+    },
   },
   overrides: {
     MuiIconButton: {

--- a/src/utils/createTheme.js
+++ b/src/utils/createTheme.js
@@ -1,5 +1,28 @@
 import { createMuiTheme } from '@material-ui/core/styles';
-import { fade } from '@material-ui/core/styles/colorManipulator';
+import { fade, decomposeColor, recomposeColor } from '@material-ui/core/styles/colorManipulator';
+
+const AVERAGE_COLOR = 'rgb(127, 127, 127)';
+
+// Taken from the color module:
+// https://github.com/Qix-/color/blob/99266cebff6d898fc6a783a483812e322b03d5fa/index.js#L366
+// Without the alpha stuff
+function blend(a, b, weight) {
+  const aColor = decomposeColor(a);
+  const bColor = decomposeColor(b);
+
+  const w = (2 * weight) - 1;
+  const w1 = (w + 1) / 2.0;
+  const w2 = 1 - w1;
+
+  const values = [
+    (w1 * aColor.values[0]) + (w2 * bColor.values[0]),
+    (w1 * aColor.values[1]) + (w2 * bColor.values[1]),
+    (w1 * aColor.values[2]) + (w2 * bColor.values[2]),
+    aColor.values[3] || 1,
+  ];
+
+  return recomposeColor({ type: 'rgba', values });
+}
 
 export default function createTheme(base) {
   const muiTheme = createMuiTheme(base);
@@ -47,6 +70,9 @@ export default function createTheme(base) {
       '--overlay-background': fade(uwave.background, 0.96),
       '--chat-suggestion-selected': fade('#fff', 0.1),
       '--soundcloud-meta-background': fade(uwave.background, 0.3),
+      '--waitlist-locked-text-color': fade(palette.text.primary, 0.7),
+      '--selected-media-row-color': fade(palette.primary.main, 0.7),
+      '--chat-timestamp-text-color': blend(palette.text.primary, AVERAGE_COLOR, 0.7),
     },
   };
 }

--- a/src/utils/createTheme.js
+++ b/src/utils/createTheme.js
@@ -1,0 +1,52 @@
+import { createMuiTheme } from '@material-ui/core/styles';
+import { fade } from '@material-ui/core/styles/colorManipulator';
+
+export default function createTheme(base) {
+  const muiTheme = createMuiTheme(base);
+
+  const { palette, uwave } = muiTheme;
+
+  return {
+    ...muiTheme,
+    cssProperties: {
+      '--text-color': palette.text.primary,
+      '--muted-text-color': palette.text.secondary,
+      '--background-color': uwave.background,
+      '--background-hover-color': uwave.backgroundHover,
+      '--highlight-color': palette.primary.main,
+      '--highbright-color': palette.primary.light,
+      '--scrollbar-color': uwave.scrollbar,
+      '--canvas-color': palette.background.paper,
+
+      // Link colors
+      '--link-color': uwave.link,
+      '--link-visited-color': uwave.link,
+
+      // Footer colours
+      '--footer-border-color': '#303036',
+
+      // Chat colours
+      '--chat-background-color': uwave.sidePanel.background,
+      '--chat-background-color2': uwave.sidePanel.alternate,
+      '--chat-border-color': 'var(--footer-border-color)',
+
+      // User related colours
+      '--user-list-color': uwave.sidePanel.background,
+      '--user-list-alternate-color': uwave.sidePanel.alternate,
+
+      // Playlist colours
+      '--media-list-color': 'transparent',
+      // TODO Name this in some other way. It's used as the menu item focus colour
+      // in various places.
+      '--media-list-alternate-color': fade(uwave.mediaList.alternate, 0.3),
+
+      // Settings panel colours
+      '--settings-help-text-color': palette.text.hint,
+
+      // Computed values, can't do these in CSS
+      '--overlay-background': fade(uwave.background, 0.96),
+      '--chat-suggestion-selected': fade('#fff', 0.1),
+      '--soundcloud-meta-background': fade(uwave.background, 0.3),
+    },
+  };
+}

--- a/src/vars.css
+++ b/src/vars.css
@@ -47,4 +47,11 @@
   /* Form colours & sizes */
   --forms-element-margin: 16px;
   --forms-textfield-size: 50px;
+
+  /* Misc computed */
+  /* We can't use color(var()) because var()s are preserved. Instead these values are hardcoded. */
+  /* In modern browsers with var() support, these values are defined in src/utils/createTheme.js. */
+  --selected-media-row-color: color(#9d2053 alpha(* 70%));
+  --waitlist-locked-text-color: color(#fff alpha(* 70%));
+  --chat-timestamp-text-color: color(#fff blend(#777777 33%));
 }

--- a/src/vars.css
+++ b/src/vars.css
@@ -52,6 +52,9 @@
   /* We can't use color(var()) because var()s are preserved. Instead these values are hardcoded. */
   /* In modern browsers with var() support, these values are defined in src/utils/createTheme.js. */
   --selected-media-row-color: color(#9d2053 alpha(* 70%));
+  --chat-suggestion-selected: color(#fff  alpha(* 10%));
+  --overlay-background: color(#151515 alpha(* 96%));
+  --soundcloud-meta-background: color(#151515 alpha(* 30%));
   --waitlist-locked-text-color: color(#fff alpha(* 70%));
   --chat-timestamp-text-color: color(#fff blend(#777777 33%));
 }


### PR DESCRIPTION
In modern browsers with CSS variable support, variables are defined in JavaScript based on the material-ui theme. This theme can be made to be customisable in the future. In browsers lacking CSS variable support, they will fall back to the default theme.

There is a console API that you can use to change the theme at runtime. `uw.debugApplyTheme()` merges an object into the material-ui theme [(this one)](https://github.com/u-wave/web/blob/master/src/theme.js) and `uw.debugResetTheme()` reverts to the default theme.

This monstrosity, for example, is the result of a few `uw.debugApplyTheme()` calls:

![image](https://user-images.githubusercontent.com/1006268/42135692-d0af9d4a-7d4e-11e8-8970-4b08b6cda344.png)

There are most likely some hardcoded values left, but this is a start. At least it makes the existing variables configurable :)