### PR TITLE
 Add a screen for empty playlists. 

### DIFF
--- a/locale/en.yaml
+++ b/locale/en.yaml
@@ -101,6 +101,9 @@ uwave:
     shuffle: Shuffle
     filter: Filter
     rename: Rename
+    playlist:
+      empty: This playlist is empty
+      emptySub: Search for songs or import a playlist.
     import:
       title: Import
     search:

--- a/src/components/PlaylistManager/NoPlaylists.js
+++ b/src/components/PlaylistManager/NoPlaylists.js
@@ -3,15 +3,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { translate } from 'react-i18next';
 
-const EmptyPanel = ({ t, className }) => (
+const enhance = translate();
+
+const NoPlaylists = ({ t, className }) => (
   <div className={cx('PlaylistPanel', 'PlaylistPanel--empty', className)}>
     {t('playlists.noPlaylists')}
   </div>
 );
 
-EmptyPanel.propTypes = {
+NoPlaylists.propTypes = {
   t: PropTypes.func.isRequired,
   className: PropTypes.string,
 };
 
-export default translate()(EmptyPanel);
+export default enhance(NoPlaylists);

--- a/src/components/PlaylistManager/Panel/PlaylistEmpty.css
+++ b/src/components/PlaylistManager/Panel/PlaylistEmpty.css
@@ -1,0 +1,19 @@
+.PlaylistPanel-empty {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  height: calc(100% - 54px);
+  padding: 0 20%;
+}
+
+.PlaylistPanel-emptyIcon {
+  width: 240px;
+  height: 240px;
+  max-height: 50%;
+  color: rgba(255, 255, 255, 0.2);
+}
+
+.PlaylistPanel-emptyHeader {
+  font-weight: bold;
+}

--- a/src/components/PlaylistManager/Panel/PlaylistEmpty.js
+++ b/src/components/PlaylistManager/Panel/PlaylistEmpty.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { translate } from 'react-i18next';
+import Typography from '@material-ui/core/Typography';
+import EmptyIcon from '@material-ui/icons/PlaylistAdd';
+
+const enhance = translate();
+
+const PlaylistEmpty = ({ t }) => (
+  <div className="PlaylistPanel-empty">
+    <EmptyIcon className="PlaylistPanel-emptyIcon" />
+    <Typography className="PlaylistPanel-emptyHeader">{t('playlists.playlist.empty')}</Typography>
+    <Typography>{t('playlists.playlist.emptySub')}</Typography>
+  </div>
+);
+
+PlaylistEmpty.propTypes = {
+  t: PropTypes.func.isRequired,
+};
+
+export default enhance(PlaylistEmpty);

--- a/src/components/PlaylistManager/Panel/index.css
+++ b/src/components/PlaylistManager/Panel/index.css
@@ -1,5 +1,6 @@
 @import "../../../vars.css";
 @import "./Meta.css";
+@import "./PlaylistEmpty.css";
 @import "./PlaylistFilter.css";
 @import "./PlaylistItemRow.css";
 

--- a/src/components/PlaylistManager/Panel/index.js
+++ b/src/components/PlaylistManager/Panel/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import MediaList from '../../MediaList';
 import PlaylistMeta from './Meta';
+import PlaylistEmpty from './PlaylistEmpty';
 import PlainItemRow from '../../MediaList/Row';
 import PlaylistItemRow from './PlaylistItemRow';
 import AddToPlaylistAction from '../../MediaList/Actions/AddToPlaylist';
@@ -75,6 +76,8 @@ const PlaylistPanel = (props) => {
         <CircularProgress size="100%" />
       </div>
     );
+  } else if (media.length === 0) {
+    list = <PlaylistEmpty />;
   } else {
     list = (
       <MediaList

--- a/src/components/PlaylistManager/index.js
+++ b/src/components/PlaylistManager/index.js
@@ -7,7 +7,7 @@ import PlaylistPanel from '../../containers/PlaylistManagerPanel';
 import PlaylistImport from '../../containers/PlaylistImportManager';
 import SearchResults from '../../containers/SearchResultsPanel';
 import PlaylistHeader from './Header';
-import PlaylistPanelEmpty from './Panel/Empty';
+import NoPlaylists from './NoPlaylists';
 
 const PlaylistManager = ({
   className,
@@ -36,7 +36,7 @@ const PlaylistManager = ({
     // selected playlist changes.
     panel = <PlaylistPanel key={selectedPlaylist._id} />;
   } else {
-    panel = <PlaylistPanelEmpty />;
+    panel = <NoPlaylists />;
   }
 
   return (


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1006268/42342946-e48ef92c-8097-11e8-99bc-7bb1448254b1.png)

the message is not _that_ helpful but I didn't want it to wrap even on small screens :/ At least it's better than a totally black area.