### PR TITLE
Refactor login, edit, preview dialogs.

### DIFF
--- a/src/components/Dialogs/EditMediaDialog/index.js
+++ b/src/components/Dialogs/EditMediaDialog/index.js
@@ -13,6 +13,7 @@ import TitleIcon from '@material-ui/icons/MusicNote';
 import StartIcon from '@material-ui/icons/PlayArrow';
 import EndIcon from '@material-ui/icons/Stop';
 import SwapArtistTitleIcon from '@material-ui/icons/SwapHoriz';
+import DialogCloseAnimation from '../../DialogCloseAnimation';
 import Form from '../../Form';
 import FormGroup from '../../Form/Group';
 import Button from '../../Form/Button';
@@ -130,133 +131,137 @@ class EditMediaDialog extends React.Component {
       end,
     } = this.state;
     const baseTabIndex = 1000;
-    let content = null;
-    if (open) {
-      const artistInput = (
-        <TextField
-          className="EditMediaDialogGroup-field"
-          placeholder={t(['dialogs.editMedia.artistLabel', 'media.artist'])}
-          value={artist}
-          onChange={this.handleChangeArtist}
-          icon={<ArtistIcon nativeColor="#9f9d9e" />}
-          tabIndex={baseTabIndex}
-          autoFocus
-        />
-      );
-      const artistTitleLabel = (
-        <div className="EditMediaDialogGroup-label">
-          <IconButton onClick={this.handleSwapArtistTitle}>
-            <SwapArtistTitleIcon nativeColor="#9f9d9e" />
-          </IconButton>
-        </div>
-      );
-      const titleInput = (
-        <TextField
-          className="EditMediaDialogGroup-field"
-          placeholder={t(['dialogs.editMedia.titleLabel', 'media.title'])}
-          value={title}
-          onChange={this.handleChangeTitle}
-          icon={<TitleIcon nativeColor="#9f9d9e" />}
-          tabIndex={baseTabIndex + 1}
-        />
-      );
 
-      const fromLabel = (
-        // eslint-disable-next-line jsx-a11y/label-has-for
-        <label htmlFor={this.labelStart} className="EditMediaDialogGroup-label">
-          {t('dialogs.editMedia.playFromLabel')}
-        </label>
-      );
-      const fromInput = (
-        <TextField
-          id={this.labelStart}
-          className="EditMediaDialogGroup-field"
-          placeholder="0:00"
-          value={start}
-          onChange={this.handleChangeStart}
-          icon={<StartIcon nativeColor="#9f9d9e" />}
-          tabIndex={baseTabIndex + 2}
-        />
-      );
-      const toLabel = (
-        // eslint-disable-next-line jsx-a11y/label-has-for
-        <label htmlFor={this.labelEnd} className="EditMediaDialogGroup-label">
-          {t('dialogs.editMedia.playToLabel')}
-        </label>
-      );
-      const toInput = (
-        <TextField
-          id={this.labelEnd}
-          className="EditMediaDialogGroup-field"
-          placeholder={formatDuration(media.duration)}
-          value={end}
-          onChange={this.handleChangeEnd}
-          icon={<EndIcon nativeColor="#9f9d9e" />}
-          tabIndex={baseTabIndex + 3}
-        />
-      );
-
-      content = (
-        <Form onSubmit={this.handleSubmit}>
-          {errors && errors.length > 0 && (
-            <FormGroup>
-              {errors.map(error => <div>{t(`dialogs.editMedia.errors.${error}`)}</div>)}
-            </FormGroup>
-          )}
-
-          <div className="EditMediaDialogForm">
-            <div className="EditMediaDialogForm-column">
-              <FormGroup className="EditMediaDialogGroup">
-                {artistInput}
-              </FormGroup>
-              <FormGroup className="EditMediaDialogGroup">
-                {fromLabel}
-                {fromInput}
-              </FormGroup>
-            </div>
-            <div className="EditMediaDialogForm-separator">
-              <FormGroup className="EditMediaDialogGroup">
-                {artistTitleLabel}
-              </FormGroup>
-              <FormGroup className="EditMediaDialogGroup">
-                {toLabel}
-              </FormGroup>
-            </div>
-            <div className="EditMediaDialogForm-column">
-              <FormGroup className="EditMediaDialogGroup">
-                {titleInput}
-              </FormGroup>
-              <FormGroup className="EditMediaDialogGroup">
-                {toInput}
-              </FormGroup>
-            </div>
-          </div>
-
-          <FormGroup className="FormGroup--noSpacing">
-            <Button className="EditMediaDialog-submit">
-              {t('dialogs.editMedia.save')}
-            </Button>
-          </FormGroup>
-        </Form>
-      );
+    if (!open) {
+      return <DialogCloseAnimation delay={450} />;
     }
 
+    const artistInput = (
+      <TextField
+        className="EditMediaDialogGroup-field"
+        placeholder={t(['dialogs.editMedia.artistLabel', 'media.artist'])}
+        value={artist}
+        onChange={this.handleChangeArtist}
+        icon={<ArtistIcon nativeColor="#9f9d9e" />}
+        tabIndex={baseTabIndex}
+        autoFocus
+      />
+    );
+    const artistTitleLabel = (
+      <div className="EditMediaDialogGroup-label">
+        <IconButton onClick={this.handleSwapArtistTitle}>
+          <SwapArtistTitleIcon nativeColor="#9f9d9e" />
+        </IconButton>
+      </div>
+    );
+    const titleInput = (
+      <TextField
+        className="EditMediaDialogGroup-field"
+        placeholder={t(['dialogs.editMedia.titleLabel', 'media.title'])}
+        value={title}
+        onChange={this.handleChangeTitle}
+        icon={<TitleIcon nativeColor="#9f9d9e" />}
+        tabIndex={baseTabIndex + 1}
+      />
+    );
+
+    const fromLabel = (
+      // eslint-disable-next-line jsx-a11y/label-has-for
+      <label htmlFor={this.labelStart} className="EditMediaDialogGroup-label">
+        {t('dialogs.editMedia.playFromLabel')}
+      </label>
+    );
+    const fromInput = (
+      <TextField
+        id={this.labelStart}
+        className="EditMediaDialogGroup-field"
+        placeholder="0:00"
+        value={start}
+        onChange={this.handleChangeStart}
+        icon={<StartIcon nativeColor="#9f9d9e" />}
+        tabIndex={baseTabIndex + 2}
+      />
+    );
+    const toLabel = (
+      // eslint-disable-next-line jsx-a11y/label-has-for
+      <label htmlFor={this.labelEnd} className="EditMediaDialogGroup-label">
+        {t('dialogs.editMedia.playToLabel')}
+      </label>
+    );
+    const toInput = (
+      <TextField
+        id={this.labelEnd}
+        className="EditMediaDialogGroup-field"
+        placeholder={formatDuration(media.duration)}
+        value={end}
+        onChange={this.handleChangeEnd}
+        icon={<EndIcon nativeColor="#9f9d9e" />}
+        tabIndex={baseTabIndex + 3}
+      />
+    );
+
+    const form = (
+      <Form onSubmit={this.handleSubmit}>
+        {errors && errors.length > 0 && (
+          <FormGroup>
+            {errors.map(error => <div>{t(`dialogs.editMedia.errors.${error}`)}</div>)}
+          </FormGroup>
+        )}
+
+        <div className="EditMediaDialogForm">
+          <div className="EditMediaDialogForm-column">
+            <FormGroup className="EditMediaDialogGroup">
+              {artistInput}
+            </FormGroup>
+            <FormGroup className="EditMediaDialogGroup">
+              {fromLabel}
+              {fromInput}
+            </FormGroup>
+          </div>
+          <div className="EditMediaDialogForm-separator">
+            <FormGroup className="EditMediaDialogGroup">
+              {artistTitleLabel}
+            </FormGroup>
+            <FormGroup className="EditMediaDialogGroup">
+              {toLabel}
+            </FormGroup>
+          </div>
+          <div className="EditMediaDialogForm-column">
+            <FormGroup className="EditMediaDialogGroup">
+              {titleInput}
+            </FormGroup>
+            <FormGroup className="EditMediaDialogGroup">
+              {toInput}
+            </FormGroup>
+          </div>
+        </div>
+
+        <FormGroup className="FormGroup--noSpacing">
+          <Button className="EditMediaDialog-submit">
+            {t('dialogs.editMedia.save')}
+          </Button>
+        </FormGroup>
+      </Form>
+    );
+
     return (
-      <Dialog
-        classes={{
-          paper: cx('Dialog', 'EditMediaDialog', contentClassName),
-        }}
-        open={open}
-        onClose={onCloseDialog}
-        aria-labelledby={this.title}
-      >
-        <DialogTitle id={this.title} className={cx('Dialog-title', titleClassName)}>
-          {t('dialogs.editMedia.title')}
-        </DialogTitle>
-        <DialogContent className={cx('Dialog-body', bodyClassName)}>
-          {content}
-        </DialogContent>
-      </Dialog>
+      <DialogCloseAnimation delay={450}>
+        <Dialog
+          classes={{
+            paper: cx('Dialog', 'EditMediaDialog', contentClassName),
+          }}
+          open={open}
+          onClose={onCloseDialog}
+          aria-labelledby={this.title}
+        >
+          <DialogTitle id={this.title} className={cx('Dialog-title', titleClassName)}>
+            {t('dialogs.editMedia.title')}
+          </DialogTitle>
+          <DialogContent className={cx('Dialog-body', bodyClassName)}>
+            {form}
+          </DialogContent>
+        </Dialog>
+      </DialogCloseAnimation>
     );
   }
 }

--- a/src/components/Dialogs/EditMediaDialog/index.js
+++ b/src/components/Dialogs/EditMediaDialog/index.js
@@ -26,6 +26,8 @@ const parseDuration = str => str.split(':')
 
 const enhance = translate();
 
+const BASE_TAB_INDEX = 1000;
+
 class EditMediaDialog extends React.Component {
   static propTypes = {
     t: PropTypes.func.isRequired,
@@ -112,16 +114,10 @@ class EditMediaDialog extends React.Component {
     });
   };
 
-  render() {
+  renderForm() {
     const {
       t,
-      open,
       media,
-      onCloseDialog,
-
-      bodyClassName,
-      contentClassName,
-      titleClassName,
     } = this.props;
     const {
       errors,
@@ -130,11 +126,6 @@ class EditMediaDialog extends React.Component {
       start,
       end,
     } = this.state;
-    const baseTabIndex = 1000;
-
-    if (!open) {
-      return <DialogCloseAnimation delay={450} />;
-    }
 
     const artistInput = (
       <TextField
@@ -143,7 +134,7 @@ class EditMediaDialog extends React.Component {
         value={artist}
         onChange={this.handleChangeArtist}
         icon={<ArtistIcon nativeColor="#9f9d9e" />}
-        tabIndex={baseTabIndex}
+        tabIndex={BASE_TAB_INDEX}
         autoFocus
       />
     );
@@ -161,7 +152,7 @@ class EditMediaDialog extends React.Component {
         value={title}
         onChange={this.handleChangeTitle}
         icon={<TitleIcon nativeColor="#9f9d9e" />}
-        tabIndex={baseTabIndex + 1}
+        tabIndex={BASE_TAB_INDEX + 1}
       />
     );
 
@@ -179,7 +170,7 @@ class EditMediaDialog extends React.Component {
         value={start}
         onChange={this.handleChangeStart}
         icon={<StartIcon nativeColor="#9f9d9e" />}
-        tabIndex={baseTabIndex + 2}
+        tabIndex={BASE_TAB_INDEX + 2}
       />
     );
     const toLabel = (
@@ -196,11 +187,11 @@ class EditMediaDialog extends React.Component {
         value={end}
         onChange={this.handleChangeEnd}
         icon={<EndIcon nativeColor="#9f9d9e" />}
-        tabIndex={baseTabIndex + 3}
+        tabIndex={BASE_TAB_INDEX + 3}
       />
     );
 
-    const form = (
+    return (
       <Form onSubmit={this.handleSubmit}>
         {errors && errors.length > 0 && (
           <FormGroup>
@@ -243,24 +234,37 @@ class EditMediaDialog extends React.Component {
         </FormGroup>
       </Form>
     );
+  }
+
+  render() {
+    const {
+      t,
+      open,
+      onCloseDialog,
+      bodyClassName,
+      contentClassName,
+      titleClassName,
+    } = this.props;
 
     return (
       <DialogCloseAnimation delay={450}>
-        <Dialog
-          classes={{
-            paper: cx('Dialog', 'EditMediaDialog', contentClassName),
-          }}
-          open={open}
-          onClose={onCloseDialog}
-          aria-labelledby={this.title}
-        >
-          <DialogTitle id={this.title} className={cx('Dialog-title', titleClassName)}>
-            {t('dialogs.editMedia.title')}
-          </DialogTitle>
-          <DialogContent className={cx('Dialog-body', bodyClassName)}>
-            {form}
-          </DialogContent>
-        </Dialog>
+        {open ? (
+          <Dialog
+            classes={{
+              paper: cx('Dialog', 'EditMediaDialog', contentClassName),
+            }}
+            open={open}
+            onClose={onCloseDialog}
+            aria-labelledby={this.title}
+          >
+            <DialogTitle id={this.title} className={cx('Dialog-title', titleClassName)}>
+              {t('dialogs.editMedia.title')}
+            </DialogTitle>
+            <DialogContent className={cx('Dialog-body', bodyClassName)}>
+              {this.renderForm()}
+            </DialogContent>
+          </Dialog>
+        ) : null}
       </DialogCloseAnimation>
     );
   }

--- a/src/components/Dialogs/LoginDialog/index.js
+++ b/src/components/Dialogs/LoginDialog/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/aria-proptypes */
 import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/src/components/Dialogs/LoginDialog/index.js
+++ b/src/components/Dialogs/LoginDialog/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/aria-proptypes */
 import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -9,6 +10,7 @@ import DialogContent from '@material-ui/core/DialogContent';
 import withMobileDialog from '@material-ui/core/withMobileDialog';
 import IconButton from '@material-ui/core/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
+import DialogCloseAnimation from '../../DialogCloseAnimation';
 import LoginForm from './LoginForm';
 import RegisterForm from './RegisterForm';
 import ResetPasswordForm from './ResetPasswordForm';
@@ -39,27 +41,31 @@ const LoginDialog = (props) => {
     form = <LoginForm {...props} />;
   }
   return (
-    <Dialog
-      classes={{
-        paper: cx('Dialog', 'LoginDialog', fullScreen && 'LoginDialog--mobile'),
-      }}
-      open={open}
-      fullScreen={fullScreen}
-      onClose={onCloseDialog}
-      aria-labelledby="uw-login-title"
-    >
-      <DialogTitle className="Dialog-title" id="uw-login-title">
-        {title}
-        {fullScreen && (
-          <IconButton className="Dialog-close" onClick={onCloseDialog}>
-            <CloseIcon />
-          </IconButton>
-        )}
-      </DialogTitle>
-      <DialogContent className="Dialog-body">
-        {form}
-      </DialogContent>
-    </Dialog>
+    <DialogCloseAnimation delay={450}>
+      {open ? (
+        <Dialog
+          classes={{
+            paper: cx('Dialog', 'LoginDialog', fullScreen && 'LoginDialog--mobile'),
+          }}
+          fullScreen={fullScreen}
+          onClose={onCloseDialog}
+          aria-labelledby="uw-login-title"
+          open
+        >
+          <DialogTitle className="Dialog-title" id="uw-login-title">
+            {title}
+            {fullScreen && (
+              <IconButton className="Dialog-close" onClick={onCloseDialog}>
+                <CloseIcon />
+              </IconButton>
+            )}
+          </DialogTitle>
+          <DialogContent className="Dialog-body">
+            {form}
+          </DialogContent>
+        </Dialog>
+      ) : null}
+    </DialogCloseAnimation>
   );
 };
 

--- a/src/components/Dialogs/PreviewMediaDialog/index.js
+++ b/src/components/Dialogs/PreviewMediaDialog/index.js
@@ -1,12 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import withProps from 'recompose/withProps';
 import Dialog from '@material-ui/core/Dialog';
 import DialogContent from '@material-ui/core/DialogContent';
+import DialogCloseAnimation from '../../DialogCloseAnimation';
 import PreviewPlayer from '../../Video/Player';
 
 function getTitle(media) {
   return `${media.artist} – ${media.title}`;
 }
+
+const PreviewDialogWrapper = withProps({
+  disableEnforceFocus: true,
+  maxWidth: false,
+  classes: {
+    root: 'AppColumn AppColumn--left',
+    paper: 'Dialog PreviewMediaDialog',
+  },
+  BackdropProps: {
+    className: 'AppColumn AppColumn--full',
+  },
+})(Dialog);
 
 const PreviewMediaDialog = ({
   open,
@@ -14,30 +28,25 @@ const PreviewMediaDialog = ({
   volume,
   onCloseDialog,
 }) => (
-  <Dialog
-    classes={{
-      root: 'AppColumn AppColumn--left',
-      paper: 'Dialog PreviewMediaDialog',
-    }}
-    BackdropProps={{
-      className: 'AppColumn AppColumn--full',
-    }}
-    open={open}
-    onClose={onCloseDialog}
-    disableEnforceFocus
-    maxWidth={false}
-    aria-label={open ? getTitle(media) : null}
-  >
-    <DialogContent className="Dialog-body PreviewMediaDialog-content">
-      {open && (
-        <PreviewPlayer
-          mode="preview"
-          media={media}
-          volume={volume}
-        />
-      )}
-    </DialogContent>
-  </Dialog>
+  <DialogCloseAnimation delay={450}>
+    {open ? (
+      <PreviewDialogWrapper
+        onClose={onCloseDialog}
+        aria-label={getTitle(media)}
+        open
+      >
+        <DialogContent className="Dialog-body PreviewMediaDialog-content">
+          {open && (
+            <PreviewPlayer
+              mode="preview"
+              media={media}
+              volume={volume}
+            />
+          )}
+        </DialogContent>
+      </PreviewDialogWrapper>
+    ) : null}
+  </DialogCloseAnimation>
 );
 
 PreviewMediaDialog.propTypes = {


### PR DESCRIPTION
They now use `DialogCloseAnimation` instead of material-ui's `open` prop.

The DialogCloseAnimation allows the contained Dialog to unmount completely, while animating out in its final state. This is especially useful for the login, edit, and preview dialogs, which are managed using Redux—their internal state is reset when they animate out. Previously, this would cause some jerkiness. The login dialog reverted to the Login form, even if you were on the Register or Password Forgot form; the edit and preview dialogs unmounted their contents without animating before fading out. Now, the most recent state is kept for the duration of the animation and then discarded.