### PR TITLE
Update material-ui to v1.4.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1249,9 +1249,9 @@
       }
     },
     "@material-ui/core": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-1.3.1.tgz",
-      "integrity": "sha512-h5pVkHgYrKExTdll4Y2Kmvkd5Hr4MxqEQLhRxzGTaXJ8RjOuRd+plfRk5r5ZauAdrIkKEsNcEt75VlEFX9aSGw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-Jymq67Hp9XbtzsENkpSl6DeG99wOdNhUCJnnEGcxSlGGBrERRkZxzVRkt4+2v1OyAD8+9NCK3hOOa7DH4Cl4zA==",
       "requires": {
         "@babel/runtime": "^7.0.0-beta.42",
         "@types/jss": "^9.5.3",
@@ -1263,6 +1263,7 @@
         "deepmerge": "^2.0.1",
         "dom-helpers": "^3.2.1",
         "hoist-non-react-statics": "^2.5.0",
+        "is-plain-object": "^2.0.4",
         "jss": "^9.3.3",
         "jss-camel-case": "^6.0.0",
         "jss-default-unit": "^8.0.2",
@@ -1272,10 +1273,10 @@
         "jss-vendor-prefixer": "^7.0.0",
         "keycode": "^2.1.9",
         "normalize-scroll-left": "^0.1.2",
+        "popper.js": "^1.0.0",
         "prop-types": "^15.6.0",
         "react-event-listener": "^0.6.0",
         "react-jss": "^8.1.0",
-        "react-popper": "^0.10.0",
         "react-transition-group": "^2.2.1",
         "recompose": "^0.27.0",
         "scroll": "^2.0.3",
@@ -1291,9 +1292,9 @@
       }
     },
     "@material-ui/lab": {
-      "version": "1.0.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-1.0.0-alpha.5.tgz",
-      "integrity": "sha512-FqDhtfEB78JG7NKr2v8KRK5rhmQ4PT3fBY9iMCGFI02tIynBALqNB9Z3ahanYIoQxdiYftRbxmP+q7lSqvsIgw=="
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-eHz7Xw0V6YierStjliR+J1hiWpw5Ffz18wnUrOFsuZAj6YXoSDK1dFu08/1Ugt+OADUI5y55epxr0+BawbOXpQ=="
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
@@ -7664,14 +7665,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7691,8 +7690,7 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -7840,7 +7838,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -16396,15 +16393,6 @@
         "unified": "^6.1.5",
         "unist-util-visit": "^1.3.0",
         "xtend": "^4.0.1"
-      }
-    },
-    "react-popper": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.10.4.tgz",
-      "integrity": "sha1-rypBXqIike3VBGeNev2opu4ylao=",
-      "requires": {
-        "popper.js": "^1.14.1",
-        "prop-types": "^15.6.1"
       }
     },
     "react-reconciler": {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   "dependencies": {
     "@babel/runtime": "7.0.0-beta.53",
     "@f/cookies-enabled": "^1.1.1",
-    "@material-ui/core": "^1.3.1",
+    "@material-ui/core": "^1.4.0",
     "@material-ui/icons": "^1.1.0",
-    "@material-ui/lab": "^1.0.0-alpha.4",
+    "@material-ui/lab": "^1.0.0-alpha.6",
     "@u-wave/react-mq": "^1.0.0",
     "@u-wave/react-server-list": "^2.0.1",
     "@u-wave/react-youtube": "^0.6.0",


### PR DESCRIPTION
Includes a ton of tooltip improvements. It now only mounts tooltips in the DOM when they are visible, so it's safe to add hundreds of them (may be useful for media actions or something).