### PR TITLE
Fix Array.find* polyfills, fixes #1081

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1597,21 +1597,11 @@
       "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
       "dev": true
     },
-    "array-find": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
-      "integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg="
-    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
-    },
-    "array-findindex": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/array-findindex/-/array-findindex-0.1.0.tgz",
-      "integrity": "sha1-aK2coUi2QF0tG/Odpk1d4U7w4/A="
     },
     "array-flatten": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,6 @@
     "@u-wave/react-mq": "^1.0.0",
     "@u-wave/react-server-list": "^2.0.1",
     "@u-wave/react-youtube": "^0.6.0",
-    "array-find": "^1.0.0",
-    "array-findindex": "^0.1.0",
     "classnames": "^2.2.6",
     "connect-gzip-static": "^2.1.1",
     "debug": "^3.1.0",

--- a/src/actions/ChatActionCreators.js
+++ b/src/actions/ChatActionCreators.js
@@ -109,7 +109,7 @@ export function inputMessage(text) {
 }
 
 function isMuted(state, userID) {
-  return mutedUserIDsSelector(state).indexOf(userID) !== -1;
+  return mutedUserIDsSelector(state).includes(userID);
 }
 
 export function receive(message) {

--- a/src/components/Chat/Markup/compile.js
+++ b/src/components/Chat/Markup/compile.js
@@ -28,7 +28,7 @@ export default function compile(tree, opts = {}) {
       case 'link':
         return <Link key={i} href={node.href}>{node.text}</Link>;
       case 'emoji':
-        if (availableEmoji.indexOf(node.name) !== -1 && node.name in emojiImages) {
+        if (availableEmoji.includes(node.name) && node.name in emojiImages) {
           return (
             <Emoji
               key={i}

--- a/src/containers/RoomUserList.js
+++ b/src/containers/RoomUserList.js
@@ -14,9 +14,9 @@ const userListWithVotesSelector = createSelector(
   (users, votes) => users.map(user => ({
     ...user,
     votes: {
-      upvote: votes.upvotes.indexOf(user._id) !== -1,
-      downvote: votes.downvotes.indexOf(user._id) !== -1,
-      favorite: votes.favorites.indexOf(user._id) !== -1,
+      upvote: votes.upvotes.includes(user._id),
+      downvote: votes.downvotes.includes(user._id),
+      favorite: votes.favorites.includes(user._id),
     },
   })),
 );

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -3,8 +3,6 @@
 import 'lie/polyfill';
 import 'whatwg-fetch';
 import pFinally from 'p-finally';
-import arrayFind from 'array-find';
-import arrayFindIndex from 'array-findindex';
 import objectAssign from 'object-assign';
 import objectValues from 'object-values';
 
@@ -17,15 +15,57 @@ if (!Promise.prototype.finally) {
 
 if (!Array.prototype.find) {
   // eslint-disable-next-line no-extend-native
-  Array.prototype.find = function find_(predicate) {
-    return arrayFind(this, predicate);
+  Array.prototype.find = function find(predicate, ctx = undefined) {
+    const l = this.length;
+    for (let i = 0; i < l; i += 1) {
+      const v = this[i];
+      if (predicate.call(ctx, v, i, this)) {
+        return v;
+      }
+    }
+    return undefined;
   };
 }
 
 if (!Array.prototype.findIndex) {
   // eslint-disable-next-line no-extend-native
-  Array.prototype.findIndex = function findIndex_(predicate) {
-    return arrayFindIndex(this, predicate);
+  Array.prototype.findIndex = function findIndex(predicate, ctx = undefined) {
+    const l = this.length;
+    for (let i = 0; i < l; i += 1) {
+      if (predicate.call(ctx, this[i], i, this)) {
+        return i;
+      }
+    }
+    return -1;
+  };
+}
+
+if (!Array.prototype.includes) {
+  // eslint-disable-next-line no-extend-native
+  Array.prototype.includes = function includes(value) {
+    for (let i = 0; i < this.length; i += 1) {
+      if (Object.is(this[i], value)) {
+        return true;
+      }
+    }
+    return false;
+  };
+}
+
+if (!String.prototype.includes) {
+  // eslint-disable-next-line no-extend-native
+  String.prototype.includes = function includes(substring) {
+    return this.indexOf(substring) !== -1;
+  };
+}
+
+if (!Object.is) {
+  // eslint-disable-next-line no-extend-native
+  Object.is = function is(x, y) {
+    if (x === y) {
+      return x !== 0 || 1 / x === 1 / y;
+    }
+    return x !== x && y !== y; // eslint-disable-line no-self-compare
   };
 }
 

--- a/src/reducers/users.js
+++ b/src/reducers/users.js
@@ -66,7 +66,7 @@ function usersReducer(state = {}, action = {}) {
     case USER_REMOVE_ROLES:
       return updateUser(state, payload.userID, user => ({
         ...user,
-        roles: user.roles.filter(role => payload.roles.indexOf(role) === -1),
+        roles: user.roles.filter(role => !payload.roles.includes(role)),
       }));
     default:
       return state;

--- a/src/reducers/votes.js
+++ b/src/reducers/votes.js
@@ -47,7 +47,7 @@ export default function reduce(state = initialState, action = {}) {
         downvotes: [...state.downvotes, payload.userID],
       };
     case FAVORITE:
-      if (state.favorites.indexOf(payload.userID) === -1) {
+      if (!state.favorites.includes(payload.userID)) {
         return {
           ...state,
           favorites: [...state.favorites, payload.userID],

--- a/src/selectors/roomHistorySelectors.js
+++ b/src/selectors/roomHistorySelectors.js
@@ -19,9 +19,9 @@ const addOwnVoteProps = id => entry => ({
   stats: {
     ...entry.stats,
     // No ID is provided for guest users.
-    isDownvote: !!id && entry.stats.downvotes.indexOf(id) > -1,
-    isFavorite: !!id && entry.stats.favorites.indexOf(id) > -1,
-    isUpvote: !!id && entry.stats.upvotes.indexOf(id) > -1,
+    isDownvote: !!id && entry.stats.downvotes.includes(id),
+    isFavorite: !!id && entry.stats.favorites.includes(id),
+    isUpvote: !!id && entry.stats.upvotes.includes(id),
   },
 });
 

--- a/src/selectors/settingSelectors.js
+++ b/src/selectors/settingSelectors.js
@@ -5,7 +5,7 @@ import createTheme from '../utils/createTheme';
 
 function getAvailableLanguage(languages) {
   return languages.find(lang => (
-    availableLanguages.indexOf(lang) !== -1
+    availableLanguages.includes(lang)
   ));
 }
 

--- a/src/selectors/userSelectors.js
+++ b/src/selectors/userSelectors.js
@@ -22,7 +22,7 @@ export const isLoggedInSelector = createSelector(currentUserSelector, Boolean);
 export const tokenSelector = createSelector(authSelector, auth => auth.token);
 export const authStrategiesSelector = createSelector(authSelector, auth => auth.strategies);
 export function supportsAuthStrategy(name) {
-  return createSelector(authStrategiesSelector, strategies => strategies.indexOf(name) !== -1);
+  return createSelector(authStrategiesSelector, strategies => strategies.includes(name));
 }
 export const supportsSocialAuthSelector = createSelector(
   supportsAuthStrategy('google'),
@@ -50,10 +50,10 @@ function compareUsers(roles, superuser) {
     const aRoles = getAllUserRoles(roles, a);
     const bRoles = getAllUserRoles(roles, b);
     // Sort superusers to the top,
-    if (aRoles.indexOf(superuser) !== -1) {
+    if (aRoles.includes(superuser)) {
       return -1;
     }
-    if (bRoles.indexOf(superuser) !== -1) {
+    if (bRoles.includes(superuser)) {
       return 1;
     }
     // other users by the amount of permissions they have,
@@ -102,11 +102,11 @@ export const userHasRoleSelector = createSelector(
 
     const userRoles = getAllUserRoles(roles, user);
     // If this is a super user, we always return true.
-    if (userRoles.indexOf(superUserRole) !== -1) {
+    if (userRoles.includes(superUserRole)) {
       return () => true;
     }
 
-    return role => userRoles.indexOf(role) !== -1;
+    return role => userRoles.includes(role);
   },
 );
 

--- a/src/selectors/voteSelectors.js
+++ b/src/selectors/voteSelectors.js
@@ -7,7 +7,7 @@ const createPropSelector = (base, prop) => createSelector(base, obj => obj[prop]
 const createIsSelector = type => createSelector(
   type,
   currentUserSelector,
-  (users, me) => !!me && users.indexOf(me._id) > -1,
+  (users, me) => !!me && users.includes(me._id),
 );
 const createCountSelector = type => createSelector(
   type,

--- a/src/store/request.js
+++ b/src/store/request.js
@@ -16,7 +16,7 @@ function makeUrl(path, params = {}) {
 
   if (!isEmpty(params)) {
     // heh…
-    uri += (uri.indexOf('?') !== -1 ? '&' : '?') + qsStringify(params);
+    uri += (uri.includes('?') ? '&' : '?') + qsStringify(params);
   }
 
   return uri;

--- a/src/utils/commands/staff.js
+++ b/src/utils/commands/staff.js
@@ -19,8 +19,8 @@ register(
   {
     action: () => (dispatch, getState) => {
       const allRoles = Object.keys(rolesSelector(getState()));
-      const roles = allRoles.filter(role => role.indexOf('.') === -1);
-      const permissions = allRoles.filter(role => role.indexOf('.') !== -1);
+      const roles = allRoles.filter(role => !role.includes('.'));
+      const permissions = allRoles.filter(role => role.includes('.'));
 
       dispatch(log(`Roles: ${roles.join(', ')}`));
       return dispatch(log(`Permissions: ${permissions.join(', ')}`));


### PR DESCRIPTION
And use Array#includes and String#includes methods.

The polyfills used previously would check for `Array.prototype.find*`
and use them if available, but when polyfilled, that meant they would
just call themselves over and over. I've just inlined them here,
hopefully they work