### PR TITLE
Lazy load user list and waitlist.

### DIFF
--- a/src/components/SidePanels/PanelContainer.js
+++ b/src/components/SidePanels/PanelContainer.js
@@ -2,15 +2,16 @@ import cx from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const PanelContainer = ({ selected, children }) => (
+const PanelContainer = ({ selected, children, keepMounted }) => (
   <div className={cx('SidePanel-panel', selected && 'is-selected')}>
-    {children}
+    {(keepMounted || selected) ? children : null}
   </div>
 );
 
 PanelContainer.propTypes = {
   children: PropTypes.node.isRequired,
   selected: PropTypes.bool.isRequired,
+  keepMounted: PropTypes.bool,
 };
 
 export default PanelContainer;

--- a/src/components/SidePanels/index.js
+++ b/src/components/SidePanels/index.js
@@ -1,15 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { translate } from 'react-i18next';
+import loadable from 'react-loadable';
 import compose from 'recompose/compose';
 import pure from 'recompose/pure';
 import withState from 'recompose/withState';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 import Chat from '../Chat';
-import RoomUserList from '../../containers/RoomUserList';
-import WaitList from '../../containers/WaitList';
 import PanelContainer from './PanelContainer';
+
+const RoomUserList = loadable({
+  loader: () => import('../../containers/RoomUserList' /* webpackChunkName: "roomUserList" */),
+  loading: () => null,
+});
+
+const WaitList = loadable({
+  loader: () => import('../../containers/WaitList' /* webpackChunkName: "waitList" */),
+  loading: () => null,
+});
 
 const enhance = compose(
   translate(),
@@ -29,7 +38,7 @@ const tabClasses = {
 const getUsersLabel = (t, listenerCount) => (
   <React.Fragment>
     {t('users.title')}
-    <span key="sub" style={subHeaderStyle}>
+    <span style={subHeaderStyle}>
       {listenerCount}
     </span>
   </React.Fragment>
@@ -44,7 +53,7 @@ const getWaitlistLabel = (t, size, position) => {
     return (
       <React.Fragment>
         {t('waitlist.title')}
-        <span key="sub" style={subHeaderStyle}>{posText}</span>
+        <span style={subHeaderStyle}>{posText}</span>
       </React.Fragment>
     );
   }
@@ -83,7 +92,7 @@ const SidePanels = ({
       />
     </Tabs>
     <div>
-      <PanelContainer selected={selected === 0}>
+      <PanelContainer selected={selected === 0} keepMounted>
         <Chat />
       </PanelContainer>
       <PanelContainer selected={selected === 1}>


### PR DESCRIPTION
Not sure if this is worth the trouble but PRing just in case. The deploy preview will show the performance difference.

This also changes the user and wait lists to mount/unmount when they are shown/hidden, which may help with some of the occasional crashes we see when users leave(?). it's not really a fix though, just hides the problem.