### PR TITLE
Initialize votes on load

### DIFF
--- a/src/reducers/votes.js
+++ b/src/reducers/votes.js
@@ -1,5 +1,5 @@
 import {
-  ADVANCE,
+  INIT_STATE,
   LOAD_VOTES,
   FAVORITE,
   UPVOTE,
@@ -17,16 +17,18 @@ const initialState = {
 export default function reduce(state = initialState, action = {}) {
   const { type, payload } = action;
   switch (type) {
-    case ADVANCE:
-      if (payload && payload.stats) {
+    case INIT_STATE: {
+      const { stats } = payload.booth || {};
+      if (stats) {
         return {
           ...state,
-          upvotes: payload.stats.upvotes,
-          downvotes: payload.stats.downvotes,
-          favorites: payload.stats.favorites,
+          upvotes: stats.upvotes,
+          downvotes: stats.downvotes,
+          favorites: stats.favorites,
         };
       }
       return initialState;
+    }
     case LOAD_VOTES:
       return {
         ...state,


### PR DESCRIPTION
Fixes the vote counters always being 0 on load, even if people already
voted.

Previously this was handled via the ADVANCE action, but the stats were
removed from it a while ago. That was because the stats were only
available on the initial ADVANCE, not subsequent ones, which was
inconsistent.

Now it uses the INIT_STATE action which is more appropriate.