### PR TITLE
Build static hashed filenames into a /static/ folder.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,8 +97,8 @@ if (nodeEnv === 'production') {
 
   plugins.push(
     new ExtractCssPlugin({
-      filename: '[name]_[contenthash:7].css',
-      chunkFilename: '[name]_[contenthash:7].css',
+      filename: 'static/[name]_[contenthash:7].css',
+      chunkFilename: 'static/[name]_[contenthash:7].css',
     }),
     new SriPlugin({
       hashFuncNames: ['sha512'],
@@ -124,8 +124,8 @@ const base = {
   output: {
     publicPath: '/',
     path: path.join(__dirname, 'public'),
-    filename: nodeEnv === 'production' ? '[name]_[chunkhash:7].js' : '[name]_dev.js',
-    chunkFilename: nodeEnv === 'production' ? '[name]_[chunkhash:7].js' : '[name]_dev.js',
+    filename: nodeEnv === 'production' ? 'static/[name]_[chunkhash:7].js' : '[name]_dev.js',
+    chunkFilename: nodeEnv === 'production' ? 'static/[name]_[chunkhash:7].js' : '[name]_dev.js',
     crossOriginLoading: 'anonymous',
   },
 
@@ -138,13 +138,13 @@ const base = {
       {
         test: /\.mp3$/,
         use: [
-          { loader: 'file-loader', query: { name: '[name]_[hash:7].[ext]' } },
+          { loader: 'file-loader', query: { name: 'static/[name]_[hash:7].[ext]' } },
         ],
       },
       {
         test: /\.(gif|jpe?g|png|svg)$/,
         use: [
-          { loader: 'file-loader', query: { name: '[name]_[hash:7].[ext]' } },
+          { loader: 'file-loader', query: { name: 'static/[name]_[hash:7].[ext]' } },
           { loader: 'image-webpack-loader', query: { bypassOnDebug: true } },
         ],
       },


### PR DESCRIPTION
This way nginx can be configured to serve it, so static files don't have
to be served by node.