### PR TITLE
Clear filter when selecting a different playlist.

### DIFF
--- a/src/reducers/playlists.js
+++ b/src/reducers/playlists.js
@@ -208,9 +208,12 @@ export default function reduce(state = initialState, action = {}) {
         })),
         activePlaylistID: payload.playlistID,
       };
-    case SELECT_PLAYLIST:
+    case SELECT_PLAYLIST: {
+      const { currentFilter } = state;
+      const shouldClearFilter = currentFilter && currentFilter.playlistID !== payload.playlistID;
       return {
         ...state,
+        currentFilter: shouldClearFilter ? {} : currentFilter,
         // set `selected` property on playlists
         playlists: mapValues(state.playlists, playlist => ({
           ...playlist,
@@ -218,6 +221,7 @@ export default function reduce(state = initialState, action = {}) {
         })),
         selectedPlaylistID: payload.playlistID,
       };
+    }
     case SEARCH_START:
     // We deselect playlists when doing a search, so the UI can switch to the
     // search results view instead.


### PR DESCRIPTION
Previously, switching between playlists would result in the filter menu being hidden and the filter applying. However the playlist item count used for scrolling was the unfiltered amount. Scrolling down would show loading icons for all non matching items.

There is still a bug where clicking the selected playlist will keep the filter menu open while showing unfiltered items, but that's not as bad.