### PR TITLE
New reconnect logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15166,11 +15166,6 @@
         }
       }
     },
-    "reconnecting-websocket": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/reconnecting-websocket/-/reconnecting-websocket-3.2.2.tgz",
-      "integrity": "sha512-SWSfoXiaHVOqXuPWFgGWeUxKnb5HIY7I/Fh5C/hy4wUOgeOh7YIMXEiv5/eHBlNs4tNzCrO5YDR9AH62NWle0Q=="
-    },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "react-redux": "^5.0.7",
     "react-transition-group": "^2.4.0",
     "recompose": "^0.28.2",
-    "reconnecting-websocket": "^3.2.2",
     "redux": "^4.0.0",
     "redux-batched-subscribe": "^0.1.6",
     "redux-logger": "^3.0.0",

--- a/src/actions/LoginActionCreators.js
+++ b/src/actions/LoginActionCreators.js
@@ -86,6 +86,7 @@ export function initState() {
       dispatch(syncTimestamps(beforeTime, state.time));
       dispatch(loadedState(state));
       dispatch(loadHistory());
+      return state;
     },
   });
 }


### PR DESCRIPTION
Replaces reconnecting-websocket with custom logic. Now, when reconnecting, we first hit /now to get the socket token. This also syncs state, which should fix the crashes we get after reconnecting after a long time—usually because a user left in the mean time, but local out-of-date state still had them in the waitlist, or because someone joined in the mean time and sent a chat message, but local state doesn't know who they are.