### PR TITLE
Use INIT_STATE action for initial booth setup.

### DIFF
--- a/src/actions/LoginActionCreators.js
+++ b/src/actions/LoginActionCreators.js
@@ -16,7 +16,7 @@ import {
 } from '../constants/ActionTypes';
 import * as Session from '../utils/Session';
 import { get, post, del } from './RequestActionCreators';
-import { advance, loadHistory } from './BoothActionCreators';
+import { loadHistory } from './BoothActionCreators';
 import { setPlaylists, loadPlaylist } from './PlaylistActionCreators';
 import { syncTimestamps } from './TickerActionCreators';
 import { closeLoginDialog } from './DialogActionCreators';
@@ -59,10 +59,6 @@ export function loadedState(state) {
       type: INIT_STATE,
       payload: state,
     });
-    if (state.booth && state.booth.historyID) {
-      // TODO don't set this when logging in _after_ entering the page?
-      dispatch(advance(state.booth));
-    }
     if (state.user) {
       const token = tokenSelector(getState());
       dispatch(loginComplete({

--- a/src/reducers/booth.js
+++ b/src/reducers/booth.js
@@ -1,5 +1,6 @@
 import {
   ADVANCE,
+  INIT_STATE,
   ENTER_FULLSCREEN,
   EXIT_FULLSCREEN,
 } from '../constants/ActionTypes';
@@ -22,7 +23,24 @@ export default function reduce(state = initialState, action = {}) {
           historyID: payload.historyID,
           media: payload.media,
           djID: payload.userID,
-          startTime: payload.timestamp,
+          startTime: payload.timestamp, // TODO change this to playedAt
+        };
+      }
+      return {
+        ...state,
+        historyID: null,
+        media: null,
+        djID: null,
+        startTime: null,
+      };
+    case INIT_STATE:
+      if (payload.booth) {
+        return {
+          ...state,
+          historyID: payload.booth.historyID,
+          media: payload.booth.media,
+          djID: payload.booth.userID,
+          startTime: payload.booth.playedAt,
         };
       }
       return {

--- a/src/reducers/votes.js
+++ b/src/reducers/votes.js
@@ -39,25 +39,31 @@ export default function reduce(state = initialState, action = {}) {
     case LOAD_VOTES:
       return setVotes(state, payload);
     case UPVOTE:
+      if (state.upvotes.includes(payload.userID)) {
+        return state;
+      }
       return {
         ...state,
         upvotes: [...state.upvotes, payload.userID],
         downvotes: state.downvotes.filter(vote => vote !== payload.userID),
       };
     case DOWNVOTE:
+      if (state.downvotes.includes(payload.userID)) {
+        return state;
+      }
       return {
         ...state,
         upvotes: state.upvotes.filter(vote => vote !== payload.userID),
         downvotes: [...state.downvotes, payload.userID],
       };
     case FAVORITE:
-      if (!state.favorites.includes(payload.userID)) {
-        return {
-          ...state,
-          favorites: [...state.favorites, payload.userID],
-        };
+      if (state.favorites.includes(payload.userID)) {
+        return state;
       }
-      return state;
+      return {
+        ...state,
+        favorites: [...state.favorites, payload.userID],
+      };
     case DO_FAVORITE_START:
       return state;
     case DO_FAVORITE_COMPLETE:


### PR DESCRIPTION
Fixes some more initial booth vote issues, and reduces the amount of store churn during the initial load.