### PR TITLE
Fix initialising current song on load

### DIFF
--- a/src/reducers/booth.js
+++ b/src/reducers/booth.js
@@ -38,7 +38,10 @@ export default function reduce(state = initialState, action = {}) {
         return {
           ...state,
           historyID: payload.booth.historyID,
-          media: payload.booth.media,
+          media: {
+            ...payload.booth.media,
+            ...payload.booth.media.media,
+          },
           djID: payload.booth.userID,
           startTime: payload.booth.playedAt,
         };


### PR DESCRIPTION
Regression introduced by #1128, didn't test it well enough.
Now merges the media object from /now in the same way that it's merged on the `advance` socket event.

This is a bit messy tbh but it's a very breaking bug and this fixes it
so it'll have to do.