### PR TITLE
Remove react-i18next from greenkeeper ignore list

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,10 +183,5 @@
     "serve": "gulp serve",
     "start": "gulp start",
     "prerelease": "npm run clean && npm test && npm run prod"
-  },
-  "greenkeeper": {
-    "ignore": [
-      "react-i18next"
-    ]
   }
 }


### PR DESCRIPTION
Since we don't depend on it anymore anyway.