### PR TITLE
Fix default message for forced DJ skips.

### DIFF
--- a/src/utils/commands/waitlist.js
+++ b/src/utils/commands/waitlist.js
@@ -23,7 +23,7 @@ import {
 
 register('skip', 'Skip the current DJ.', {
   guard: isModeratorSelector,
-  action: (...args) => skipCurrentDJ(args ? args.join(' ') : '[No reason given]'),
+  action: (...args) => skipCurrentDJ(args.length > 0 ? args.join(' ') : '[No reason given]'),
 });
 
 register(


### PR DESCRIPTION
`args` is an array so would always evaluate to true. We want to use the
default message if no message parameters were given.