### PR TITLE
Fix double scrollbar in media lists

### DIFF
--- a/src/components/MediaList/index.css
+++ b/src/components/MediaList/index.css
@@ -2,7 +2,3 @@
 @import "./MediaDragPreview.css";
 @import "./MediaLoadingIndicator.css";
 @import "./Row.css";
-
-.MediaList {
-  overflow-y: auto;
-}


### PR DESCRIPTION
This CSS is no longer necessary since we switched to `react-window`.