### PR TITLE
build: get rid of fast-async

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2472,12 +2472,6 @@
       "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
-    "acorn-es7-plugin": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/acorn-es7-plugin/-/acorn-es7-plugin-1.1.7.tgz",
-      "integrity": "sha1-8u4fMiipDurRJF+asZIusucdM2s=",
-      "dev": true
-    },
     "acorn-globals": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
@@ -8955,16 +8949,6 @@
         "time-stamp": "^1.0.0"
       }
     },
-    "fast-async": {
-      "version": "6.3.8",
-      "resolved": "https://registry.npmjs.org/fast-async/-/fast-async-6.3.8.tgz",
-      "integrity": "sha512-TjlooyqrYm/gOXjD2UHNwfrWkvTbzU105Nk4bvcRTeRoL+wIeK6rqbqDg3CN9z5p37cE2iXhP6SxQFz8OVIaUg==",
-      "dev": true,
-      "requires": {
-        "nodent-compiler": "^3.2.10",
-        "nodent-runtime": ">=3.2.1"
-      }
-    },
     "fast-deep-equal": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
@@ -14749,44 +14733,6 @@
           }
         }
       }
-    },
-    "nodent-compiler": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/nodent-compiler/-/nodent-compiler-3.2.11.tgz",
-      "integrity": "sha512-rfDrGWdgIJYomPUzR8nXiWNuIhJ7cVodPeZP3Ho65LEycuaX2uVNZ0ytpcfrmUKzdFeLRtye9+pHe8OynPZuPQ==",
-      "dev": true,
-      "requires": {
-        "acorn": ">= 2.5.2 <= 5.7.3",
-        "acorn-es7-plugin": "^1.1.7",
-        "nodent-transform": "^3.2.9",
-        "source-map": "^0.5.7"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
-      }
-    },
-    "nodent-runtime": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/nodent-runtime/-/nodent-runtime-3.2.1.tgz",
-      "integrity": "sha512-7Ws63oC+215smeKJQCxzrK21VFVlCFBkwl0MOObt0HOpVQXs3u483sAmtkF33nNqZ5rSOQjB76fgyPBmAUrtCA==",
-      "dev": true
-    },
-    "nodent-transform": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/nodent-transform/-/nodent-transform-3.2.9.tgz",
-      "integrity": "sha512-4a5FH4WLi+daH/CGD5o/JWRR8W5tlCkd3nrDSkxbOzscJTyTUITltvOJeQjg3HJ1YgEuNyiPhQbvbtRjkQBByQ==",
-      "dev": true
     },
     "nopt": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "express": "^4.17.1",
     "extract-loader": "^5.0.1",
     "fancy-log": "^1.3.2",
-    "fast-async": "^6.3.8",
     "fetch-mock": "^9.0.0",
     "file-loader": "^6.0.0",
     "gulp": "^4.0.0",

--- a/tasks/webpack/compileDependencies.js
+++ b/tasks/webpack/compileDependencies.js
@@ -22,17 +22,6 @@ export default function compileDependencies() {
           // Don't assume dependencies are OK with being run in loose mode
           loose: false,
           forceAllTransforms: true,
-          exclude: [
-            '@babel/plugin-transform-async-to-generator',
-            '@babel/plugin-transform-regenerator',
-          ],
-        }],
-      ],
-      plugins: [
-        ['module:fast-async', {
-          compiler: {
-            noRuntime: true,
-          },
         }],
       ],
     },

--- a/tasks/webpack/compileDependencies.js
+++ b/tasks/webpack/compileDependencies.js
@@ -2,10 +2,7 @@
 const es2015Deps = [
   /\/abortcontroller-polyfill\/src\//,
   /\/format-duration\//,
-  /\/object-values\//,
-  /\/p-finally\//,
   /\/strip-indent\//,
-  /\/debug\//,
   /\/escape-string-regex\//,
   /\/@material-ui\/core\/es\//,
   /\/@material-ui\/icons\/es\//,


### PR DESCRIPTION
It was using an old acorn version. We can rely on Babel for async functions, I think, and also start using them in üWave code. After #1287 we might go for dual module/nomodule builds and save a lot of bytes again.