### PR TITLE
Hide the room history `+` when logged out

### DIFF
--- a/src/components/RoomHistory/HistoryList.js
+++ b/src/components/RoomHistory/HistoryList.js
@@ -6,9 +6,13 @@ import HistoryRow from './Row';
 
 const { useMemo } = React;
 
-function HistoryList({ onOpenAddMediaMenu, ...props }) {
+function HistoryList({
+  onOpenAddMediaMenu,
+  isLoggedIn = false,
+  ...props
+}) {
   const makeActions = useMemo(() => {
-    if (onOpenAddMediaMenu) {
+    if (onOpenAddMediaMenu && isLoggedIn) {
       return (media, selection) => (
         <AddToPlaylistAction
           onAdd={(position) => onOpenAddMediaMenu(position, media, selection)}
@@ -31,6 +35,7 @@ function HistoryList({ onOpenAddMediaMenu, ...props }) {
 
 HistoryList.propTypes = {
   onOpenAddMediaMenu: PropTypes.func.isRequired,
+  isLoggedIn: PropTypes.bool,
 };
 
 export default HistoryList;

--- a/src/containers/RoomHistory.js
+++ b/src/containers/RoomHistory.js
@@ -4,6 +4,7 @@ import { createStructuredSelector } from 'reselect';
 import { openPreviewMediaDialog } from '../actions/DialogActionCreators';
 import { addMediaMenu } from '../actions/PlaylistActionCreators';
 import { roomHistoryWithVotesSelector } from '../selectors/roomHistorySelectors';
+import { isLoggedInSelector } from '../selectors/userSelectors';
 import Overlay from '../components/Overlay';
 import createLazyOverlay from '../components/LazyOverlay';
 
@@ -17,6 +18,7 @@ const selectionOrOne = (media, selection) => {
 
 const mapStateToProps = createStructuredSelector({
   media: roomHistoryWithVotesSelector,
+  isLoggedIn: isLoggedInSelector,
 });
 
 const onOpenAddMediaMenu = (position, media, selection) => (


### PR DESCRIPTION
You could access the "Create Playlist" dialog while logged out, but
nothing can actually happen there.

Perhaps we could show the login dialog when you click the + icon in the
future, but for now let's just hide it entirely.