### PR TITLE
Mobile fixes

### DIFF
--- a/locale/en.yaml
+++ b/locale/en.yaml
@@ -156,6 +156,7 @@ uwave:
 
   users:
     title: Room
+    listeners: Listeners
     guests: "and {{count}} guest"
     guests_plural: "and {{count}} guests"
 

--- a/src/components/LoadingScreen/index.css
+++ b/src/components/LoadingScreen/index.css
@@ -29,4 +29,5 @@
 .LoadingIndicator-notice {
   animation: 1s linear 0s 1 initiallyHide;
   color: var(--text-color);
+  text-align: center;
 }

--- a/src/components/MediaList/Row.css
+++ b/src/components/MediaList/Row.css
@@ -46,23 +46,6 @@
   float: left;
 }
 
-.MediaListRow-data.has-note .MediaListRow-artist,
-.MediaListRow-data.has-note .MediaListRow-title {
-  height: calc(var(--unpadded-media-list-row-height) / 3 * 2);
-  line-height: calc(var(--unpadded-media-list-row-height) / 3 * 2);
-}
-
-.MediaListRow-note {
-  height: calc(var(--unpadded-media-list-row-height) / 3);
-  line-height: calc(var(--unpadded-media-list-row-height) / 3);
-  width: calc(100% - var(--media-list-spacing));
-  margin-right: var(--media-list-spacing);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 75%;
-}
-
 .MediaListRow-artist {
   height: 100%;
   float: left;
@@ -82,6 +65,23 @@
   color: var(--secondary-text-color);
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.MediaListRow-note {
+  height: calc(var(--unpadded-media-list-row-height) / 3);
+  line-height: calc(var(--unpadded-media-list-row-height) / 3);
+  width: calc(100% - var(--media-list-spacing));
+  margin-right: var(--media-list-spacing);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 75%;
+}
+
+.MediaListRow-data.has-note .MediaListRow-artist,
+.MediaListRow-data.has-note .MediaListRow-title {
+  height: calc(var(--unpadded-media-list-row-height) / 3 * 2);
+  line-height: calc(var(--unpadded-media-list-row-height) / 3 * 2);
 }
 
 .MediaListRow-duration {

--- a/src/components/Overlay/Header/index.css
+++ b/src/components/Overlay/Header/index.css
@@ -3,38 +3,35 @@
 .OverlayHeader {
   background: var(--background-color);
   height: var(--header-height);
+  display: flex;
+  justify-content: space-between;
 }
 
 .OverlayHeader-title {
-  float: left;
   height: 100%;
   font-size: 10pt;
   display: flex;
   justify-content: center;
   align-items: center;
-
-  /* max width = 300px */
+  flex-grow: 1;
+  text-transform: uppercase;
   width: 33%;
 
   @media (min-width: 1200px) {
     width: 300px;
+    flex-grow: 0;
   }
 }
 
 .OverlayHeader-content {
-  float: left;
+  flex-grow: 1;
   height: 100%;
-  width: calc(100% - 33% - var(--overlay-header-close-size));
-
-  @media (min-width: 1200px) {
-    width: calc(100% - 300px - var(--overlay-header-close-size));
-  }
 }
 
 .OverlayHeader-close {
+  flex-shrink: 0;
   height: 100%;
   width: var(--overlay-header-close-size);
-  float: left;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/Overlay/Header/index.js
+++ b/src/components/Overlay/Header/index.js
@@ -12,11 +12,13 @@ const Header = ({
 }) => (
   <div className={cx('OverlayHeader', className)}>
     <div className="OverlayHeader-title">
-      {title.toUpperCase()}
+      {title}
     </div>
-    <div className="OverlayHeader-content">
-      {children}
-    </div>
+    {children && (
+      <div className="OverlayHeader-content">
+        {children}
+      </div>
+    )}
     <div className="OverlayHeader-close">
       <CloseButton
         direction={direction}

--- a/src/components/PlaylistManager/SearchResults/index.css
+++ b/src/components/PlaylistManager/SearchResults/index.css
@@ -39,6 +39,7 @@
   width: calc(40% - var(--media-list-spacing));
   line-height: calc(56px / 3 * 2);
 }
+
 .SearchResultRow-data .MediaListRow-title {
   height: 66%;
   width: calc(60% - var(--media-list-spacing));

--- a/src/components/ServerList/index.css
+++ b/src/components/ServerList/index.css
@@ -1,3 +1,7 @@
+.ServerList {
+  width: 100%;
+}
+
 .ServerList--loading {
   display: flex;
   align-items: center;

--- a/src/components/SettingsManager/SettingsPanel.css
+++ b/src/components/SettingsManager/SettingsPanel.css
@@ -1,14 +1,15 @@
 @import "../../vars.css";
 
 .SettingsPanel {
+  display: flex;
+  flex-direction: column;
   padding: 20px 50px;
 }
 
-.SettingsPanel-divider {
-  height: 1px;
-  border: none;
-  background: var(--muted-text-color);
-  margin: 20px 0;
+.SettingsPanel-section {
+  padding-bottom: 20px;
+  border-bottom: 1px solid var(--muted-text-color);
+  margin-bottom: 20px;
 }
 
 .SettingsPanel-header {
@@ -25,23 +26,19 @@
   margin: 0 0 20px 0;
 }
 
-@media (min-width: 768px) {
-  .SettingsPanel-column {
-    width: 50%;
-    float: left;
-  }
-
-  .SettingsPanel-column--left {
-    padding-right: 50px;
-  }
-
-  .SettingsPanel-column--right {
-    padding-left: 50px;
-  }
+.SettingsPanel.is-wide {
+  display: block;
 }
 
-@media (max-width: 768px) {
-  .SettinsPanel-column--left {
-    margin-bottom: 25px;
-  }
+.SettingsPanel-column {
+  width: 50%;
+  float: left;
+}
+
+.SettingsPanel-column--left {
+  padding-right: 50px;
+}
+
+.SettingsPanel-column--right {
+  padding-left: 50px;
 }

--- a/src/components/SettingsManager/SettingsPanel.js
+++ b/src/components/SettingsManager/SettingsPanel.js
@@ -1,6 +1,7 @@
 import cx from 'clsx';
 import React from 'react';
 import PropTypes from 'prop-types';
+import useMediaQuery from 'use-mediaquery';
 import { useTranslator } from '@u-wave/react-translate';
 import FormGroup from '@material-ui/core/FormGroup';
 import Switch from '@material-ui/core/Switch';
@@ -21,6 +22,7 @@ function SettingsPanel({
   onLogout,
 }) {
   const { t } = useTranslator();
+  const isWide = useMediaQuery('(min-width: 1280px)');
 
   const handleVideoEnabledChange = (event, value) => {
     onSettingChange('videoEnabled', value);
@@ -35,65 +37,93 @@ function SettingsPanel({
     onChangeLanguage(event.target.value);
   };
 
+  const profileSection = user && (
+    <div key="profile" className="SettingsPanel-section SettingsPanel-user">
+      <Profile user={user} onChangeUsername={onChangeUsername} />
+    </div>
+  );
+
+  const settingsSection = (
+    <div key="settings" className="SettingsPanel-section SettingsPanel-settings">
+      <h2 className="SettingsPanel-header">{t('settings.title')}</h2>
+      <FormGroup>
+        <SettingControl
+          label={t('settings.videoEnabled')}
+          helpText={t('settings.videoEnabledHelp')}
+        >
+          <Switch
+            color="primary"
+            checked={settings.videoEnabled}
+            onChange={handleVideoEnabledChange}
+          />
+        </SettingControl>
+        <SettingControl label={t('settings.videoSize')}>
+          <Switch
+            color="primary"
+            checked={settings.videoSize === 'large'}
+            onChange={handleVideoSizeChange}
+          />
+        </SettingControl>
+        <SettingControl label={t('settings.mentionSound')}>
+          <Switch
+            color="primary"
+            checked={settings.mentionSound}
+            onChange={handleMentionSoundChange}
+          />
+        </SettingControl>
+        <SettingControl label={t('settings.language')}>
+          <LanguagePicker
+            value={settings.language}
+            onChange={handleLanguageChange}
+          />
+        </SettingControl>
+      </FormGroup>
+    </div>
+  );
+
+  const linksSection = (
+    <div key="links" className="SettingsPanel-section SettingsPanel-links">
+      <Links />
+    </div>
+  );
+
+  const signoutSection = user && (
+    <div key="signout" className="SettingsPanel-section SettingsPanel-signout">
+      <LogoutButton onLogout={onLogout} />
+    </div>
+  );
+
+  const notificationsSection = (
+    <div key="notifications" className="SettingsPanel-section SettingsPanel-notificationSettings">
+      <NotificationSettings settings={settings} onSettingChange={onSettingChange} />
+    </div>
+  );
+
   return (
-    <div className={cx('SettingsPanel', className)}>
-      {user && (
-        <Profile
-          user={user}
-          onChangeUsername={onChangeUsername}
-        />
+    <div className={cx('SettingsPanel', isWide && 'is-wide', className)}>
+      {isWide ? (
+        // On wider screens, use two columns
+        <>
+          {profileSection}
+          <div className="SettingsPanel-column SettingsPanel-column--left">
+            {settingsSection}
+            {linksSection}
+            {signoutSection}
+          </div>
+          <div className="SettingsPanel-column SettingsPanel-column--right">
+            {notificationsSection}
+          </div>
+        </>
+      ) : (
+        // On narrower screens, use a single-column layout
+        <>
+          {profileSection}
+          {settingsSection}
+          {notificationsSection}
+          {linksSection}
+          {signoutSection}
+        </>
       )}
-      {user && <hr className="SettingsPanel-divider" />}
-      <div className="SettingsPanel-column SettingsPanel-column--left">
-        <h2 className="SettingsPanel-header">{t('settings.title')}</h2>
-        <FormGroup>
-          <SettingControl
-            label={t('settings.videoEnabled')}
-            helpText={t('settings.videoEnabledHelp')}
-          >
-            <Switch
-              color="primary"
-              checked={settings.videoEnabled}
-              onChange={handleVideoEnabledChange}
-            />
-          </SettingControl>
-          <SettingControl label={t('settings.videoSize')}>
-            <Switch
-              color="primary"
-              checked={settings.videoSize === 'large'}
-              onChange={handleVideoSizeChange}
-            />
-          </SettingControl>
-          <SettingControl label={t('settings.mentionSound')}>
-            <Switch
-              color="primary"
-              checked={settings.mentionSound}
-              onChange={handleMentionSoundChange}
-            />
-          </SettingControl>
-          <SettingControl label={t('settings.language')}>
-            <LanguagePicker
-              value={settings.language}
-              onChange={handleLanguageChange}
-            />
-          </SettingControl>
-        </FormGroup>
-        <hr className="SettingsPanel-divider" />
-        <Links />
-        {user && (
-          <>
-            <hr className="SettingsPanel-divider" />
-            <LogoutButton onLogout={onLogout} />
-          </>
-        )}
-      </div>
-      <div className="SettingsPanel-column SettingsPanel-column--right">
-        <NotificationSettings
-          settings={settings}
-          onSettingChange={onSettingChange}
-        />
-        <hr className="SettingsPanel-divider" />
-      </div>
     </div>
   );
 }

--- a/src/components/SettingsManager/SettingsPanel.js
+++ b/src/components/SettingsManager/SettingsPanel.js
@@ -1,7 +1,7 @@
 import cx from 'clsx';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { translate } from '@u-wave/react-translate';
+import { useTranslator } from '@u-wave/react-translate';
 import FormGroup from '@material-ui/core/FormGroup';
 import Switch from '@material-ui/core/Switch';
 import Profile from './Profile';
@@ -11,113 +11,101 @@ import LogoutButton from './LogoutButton';
 import NotificationSettings from './NotificationSettings';
 import Links from './Links';
 
-const enhance = translate();
+function SettingsPanel({
+  className,
+  settings,
+  user,
+  onSettingChange,
+  onChangeUsername,
+  onChangeLanguage,
+  onLogout,
+}) {
+  const { t } = useTranslator();
 
-class SettingsPanel extends React.Component {
-  static propTypes = {
-    t: PropTypes.func.isRequired,
-    className: PropTypes.string,
-    settings: PropTypes.object.isRequired,
-    user: PropTypes.object,
-    onSettingChange: PropTypes.func.isRequired,
-    onChangeUsername: PropTypes.func.isRequired,
-    onChangeLanguage: PropTypes.func.isRequired,
-    onLogout: PropTypes.func.isRequired,
-  };
-
-  handleVideoEnabledChange = (e, value) => {
-    const { onSettingChange } = this.props;
+  const handleVideoEnabledChange = (event, value) => {
     onSettingChange('videoEnabled', value);
   };
-
-  handleVideoSizeChange = (e, value) => {
-    const { onSettingChange } = this.props;
+  const handleVideoSizeChange = (event, value) => {
     onSettingChange('videoSize', value ? 'large' : 'small');
   };
-
-  handleMentionSoundChange = (e, value) => {
-    const { onSettingChange } = this.props;
+  const handleMentionSoundChange = (event, value) => {
     onSettingChange('mentionSound', value);
   };
-
-  handleLanguageChange = (event) => {
-    const { onChangeLanguage } = this.props;
+  const handleLanguageChange = (event) => {
     onChangeLanguage(event.target.value);
   };
 
-  render() {
-    const {
-      t,
-      className,
-      settings,
-      user,
-      onSettingChange,
-      onChangeUsername,
-      onLogout,
-    } = this.props;
-
-    return (
-      <div className={cx('SettingsPanel', className)}>
+  return (
+    <div className={cx('SettingsPanel', className)}>
+      {user && (
+        <Profile
+          user={user}
+          onChangeUsername={onChangeUsername}
+        />
+      )}
+      {user && <hr className="SettingsPanel-divider" />}
+      <div className="SettingsPanel-column SettingsPanel-column--left">
+        <h2 className="SettingsPanel-header">{t('settings.title')}</h2>
+        <FormGroup>
+          <SettingControl
+            label={t('settings.videoEnabled')}
+            helpText={t('settings.videoEnabledHelp')}
+          >
+            <Switch
+              color="primary"
+              checked={settings.videoEnabled}
+              onChange={handleVideoEnabledChange}
+            />
+          </SettingControl>
+          <SettingControl label={t('settings.videoSize')}>
+            <Switch
+              color="primary"
+              checked={settings.videoSize === 'large'}
+              onChange={handleVideoSizeChange}
+            />
+          </SettingControl>
+          <SettingControl label={t('settings.mentionSound')}>
+            <Switch
+              color="primary"
+              checked={settings.mentionSound}
+              onChange={handleMentionSoundChange}
+            />
+          </SettingControl>
+          <SettingControl label={t('settings.language')}>
+            <LanguagePicker
+              value={settings.language}
+              onChange={handleLanguageChange}
+            />
+          </SettingControl>
+        </FormGroup>
+        <hr className="SettingsPanel-divider" />
+        <Links />
         {user && (
-          <Profile
-            user={user}
-            onChangeUsername={onChangeUsername}
-          />
+          <>
+            <hr className="SettingsPanel-divider" />
+            <LogoutButton onLogout={onLogout} />
+          </>
         )}
-        {user && <hr className="SettingsPanel-divider" />}
-        <div className="SettingsPanel-column SettingsPanel-column--left">
-          <h2 className="SettingsPanel-header">{t('settings.title')}</h2>
-          <FormGroup>
-            <SettingControl
-              label={t('settings.videoEnabled')}
-              helpText={t('settings.videoEnabledHelp')}
-            >
-              <Switch
-                color="primary"
-                checked={settings.videoEnabled}
-                onChange={this.handleVideoEnabledChange}
-              />
-            </SettingControl>
-            <SettingControl label={t('settings.videoSize')}>
-              <Switch
-                color="primary"
-                checked={settings.videoSize === 'large'}
-                onChange={this.handleVideoSizeChange}
-              />
-            </SettingControl>
-            <SettingControl label={t('settings.mentionSound')}>
-              <Switch
-                color="primary"
-                checked={settings.mentionSound}
-                onChange={this.handleMentionSoundChange}
-              />
-            </SettingControl>
-            <SettingControl label={t('settings.language')}>
-              <LanguagePicker
-                value={settings.language}
-                onChange={this.handleLanguageChange}
-              />
-            </SettingControl>
-          </FormGroup>
-          <hr className="SettingsPanel-divider" />
-          <Links />
-          {user && (
-            <>
-              <hr className="SettingsPanel-divider" />
-              <LogoutButton onLogout={onLogout} />
-            </>
-          )}
-        </div>
-        <div className="SettingsPanel-column SettingsPanel-column--right">
-          <NotificationSettings
-            settings={settings}
-            onSettingChange={onSettingChange}
-          />
-          <hr className="SettingsPanel-divider" />
-        </div>
       </div>
-    );
-  }
+      <div className="SettingsPanel-column SettingsPanel-column--right">
+        <NotificationSettings
+          settings={settings}
+          onSettingChange={onSettingChange}
+        />
+        <hr className="SettingsPanel-divider" />
+      </div>
+    </div>
+  );
 }
 
-export default enhance(SettingsPanel);
+SettingsPanel.propTypes = {
+  className: PropTypes.string,
+  settings: PropTypes.object.isRequired,
+  user: PropTypes.object,
+  onSettingChange: PropTypes.func.isRequired,
+  onChangeUsername: PropTypes.func.isRequired,
+  onChangeLanguage: PropTypes.func.isRequired,
+  onLogout: PropTypes.func.isRequired,
+};
+
+export default SettingsPanel;

--- a/src/loadingUI.js
+++ b/src/loadingUI.js
@@ -1,5 +1,12 @@
+// We use `querySelectorAll` in this file because there are typically _two_
+// loading indicators, even if only one is visible: one for the desktop loading
+// screen and one for the mobile loading screen.
+
 function setLoadingText(text) {
-  document.querySelector('.LoadingIndicator-notice').textContent = text;
+  Array.from(document.querySelectorAll('.LoadingIndicator-notice')).forEach((notice) => {
+    // eslint-disable-next-line no-param-reassign
+    notice.textContent = text;
+  });
 }
 
 export default function load(uw) {
@@ -15,9 +22,17 @@ export default function load(uw) {
     document.querySelector('#app-loading').innerHTML = '';
     document.querySelector('#jss').textContent = '';
   }).catch((err) => {
+    clearTimeout(longBuildTimer);
+
     setLoadingText(`Error: ${err.message}`);
-    document.querySelector('.LoadingIndicator-loader').hidden = true;
-    document.querySelector('.LoadingIndicator-warning').hidden = false;
+    Array.from(document.querySelectorAll('.LoadingIndicator-loader')).forEach((el) => {
+      // eslint-disable-next-line no-param-reassign
+      el.hidden = true;
+    });
+    Array.from(document.querySelectorAll('.LoadingIndicator-warning')).forEach((el) => {
+      // eslint-disable-next-line no-param-reassign
+      el.hidden = false;
+    });
 
     throw err;
   });

--- a/src/mobile/components/DrawerMenu/index.js
+++ b/src/mobile/components/DrawerMenu/index.js
@@ -20,6 +20,49 @@ const classes = {
   paper: 'DrawerMenu',
 };
 
+function Playlists({
+  title,
+  playlists,
+  onShowPlaylist,
+}) {
+  const header = (
+    <ListSubheader>
+      {title}
+    </ListSubheader>
+  );
+
+  return (
+    <MenuList subheader={header}>
+      {playlists.map((playlist) => (
+        <MenuItem
+          key={playlist._id}
+          onClick={(event) => {
+            event.preventDefault();
+            onShowPlaylist(playlist._id);
+          }}
+        >
+          {playlist.active && (
+            <ListItemIcon>
+              <ActiveIcon />
+            </ListItemIcon>
+          )}
+          <ListItemText disableTypography>
+            <Typography noWrap variant="body1">
+              {playlist.name}
+            </Typography>
+          </ListItemText>
+        </MenuItem>
+      ))}
+    </MenuList>
+  );
+}
+
+Playlists.propTypes = {
+  title: PropTypes.string.isRequired,
+  playlists: PropTypes.arrayOf(PropTypes.shape({ name: PropTypes.string.isRequired })).isRequired,
+  onShowPlaylist: PropTypes.func.isRequired,
+};
+
 function DrawerMenu({
   user,
   playlists,
@@ -45,39 +88,37 @@ function DrawerMenu({
     onShowSettings();
     onDrawerClose();
   }, [onShowSettings, onDrawerClose]);
+  const handleShowPlaylist = useCallback((id) => {
+    onShowPlaylist(id);
+    onDrawerClose();
+  }, [onShowPlaylist, onDrawerClose]);
 
   return (
     <Drawer open={open} onClose={onDrawerClose} classes={classes}>
       {user && <UserCard className="DrawerMenu-user" user={user} />}
       <MenuList>
-        {hasAboutPage && <MenuItem onClick={handleShowAbout}>{t('about.about')}</MenuItem>}
-        <MenuItem onClick={handleShowServerList}>{t('about.servers')}</MenuItem>
-        <MenuItem onClick={handleShowSettings}>{t('settings.title')}</MenuItem>
-      </MenuList>
-      <Divider />
-      <MenuList
-        subheader={<ListSubheader>{t('playlists.title')}</ListSubheader>}
-      >
-        {playlists.map((playlist) => (
-          <MenuItem
-            key={playlist._id}
-            onClick={(event) => {
-              event.preventDefault();
-              onShowPlaylist(playlist._id);
-              onDrawerClose();
-            }}
-          >
-            {playlist.active && (
-              <ListItemIcon>
-                <ActiveIcon />
-              </ListItemIcon>
-            )}
-            <ListItemText disableTypography>
-              <Typography noWrap variant="body1">{playlist.name}</Typography>
-            </ListItemText>
+        {hasAboutPage && (
+          <MenuItem onClick={handleShowAbout}>
+            {t('about.about')}
           </MenuItem>
-        ))}
+        )}
+        <MenuItem onClick={handleShowServerList}>
+          {t('about.servers')}
+        </MenuItem>
+        <MenuItem onClick={handleShowSettings}>
+          {t('settings.title')}
+        </MenuItem>
       </MenuList>
+      {user && (
+        <>
+          <Divider />
+          <Playlists
+            title={t('playlists.title')}
+            playlists={playlists}
+            onShowPlaylist={handleShowPlaylist}
+          />
+        </>
+      )}
     </Drawer>
   );
 }

--- a/src/mobile/components/DrawerMenu/index.js
+++ b/src/mobile/components/DrawerMenu/index.js
@@ -8,7 +8,6 @@ import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import ListSubheader from '@material-ui/core/ListSubheader';
 import Divider from '@material-ui/core/Divider';
-import Typography from '@material-ui/core/Typography';
 import ActiveIcon from '@material-ui/icons/Check';
 import UserCard from '../../../components/UserCard/UserCard';
 
@@ -46,10 +45,8 @@ function Playlists({
               <ActiveIcon />
             </ListItemIcon>
           )}
-          <ListItemText disableTypography>
-            <Typography noWrap variant="body1">
-              {playlist.name}
-            </Typography>
+          <ListItemText primaryTypographyProps={{ noWrap: true }}>
+            {playlist.name}
           </ListItemText>
         </MenuItem>
       ))}

--- a/src/mobile/components/DrawerMenu/index.js
+++ b/src/mobile/components/DrawerMenu/index.js
@@ -73,7 +73,7 @@ function DrawerMenu({
               </ListItemIcon>
             )}
             <ListItemText disableTypography>
-              <Typography noWrap variant="subheading">{playlist.name}</Typography>
+              <Typography noWrap variant="body1">{playlist.name}</Typography>
             </ListItemText>
           </MenuItem>
         ))}

--- a/src/mobile/components/MainView/index.css
+++ b/src/mobile/components/MainView/index.css
@@ -1,13 +1,15 @@
 @import "./VideoDisabledMessage.css";
 
 .MainView {
+  --app-bar-height: 56px;
+
   height: 100%;
   position: relative;
 }
 
 .MainView-appBar {
   z-index: 5;
-  height: 56px;
+  height: var(--app-bar-height);
 }
 
 .MainView-title {
@@ -16,5 +18,11 @@
 }
 
 .MainView-content {
-  height: calc(100% - 56px);
+  height: calc(100% - var(--app-bar-height));
+}
+
+@media (min-width: 600px) {
+  .MainView {
+    --app-bar-height: 64px;
+  }
 }

--- a/src/mobile/components/MainView/index.js
+++ b/src/mobile/components/MainView/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useTranslator } from '@u-wave/react-translate';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
@@ -29,7 +30,7 @@ const getWaitlistLabel = (size, position) => {
   return '0';
 };
 
-const MainView = ({
+function MainView({
   media,
   videoEnabled,
   waitlistPosition,
@@ -38,48 +39,53 @@ const MainView = ({
   onOpenDrawer,
   onOpenWaitlist,
   onEnableVideo,
-}) => (
-  <div className="MainView">
-    <AppBar position="static" className="MainView-appBar">
-      <Toolbar>
-        <IconButton aria-label="Menu" onClick={onOpenDrawer}>
-          <MenuIcon />
-        </IconButton>
-        <Typography variant="h6" className="MainView-title">
-          {media ? (
-            <SongTitle artist={media.artist} title={media.title} />
-          ) : (
-            'Nobody is DJing!'
+}) {
+  const { t } = useTranslator();
+
+  let title = t('booth.empty');
+  if (media) {
+    title = <SongTitle artist={media.artist} title={media.title} />;
+  }
+
+  return (
+    <div className="MainView">
+      <AppBar position="static" className="MainView-appBar">
+        <Toolbar>
+          <IconButton aria-label="Menu" onClick={onOpenDrawer}>
+            <MenuIcon />
+          </IconButton>
+          <Typography variant="h6" className="MainView-title">
+            {title}
+          </Typography>
+          <IconButton onClick={onOpenRoomHistory}>
+            <HistoryIcon />
+          </IconButton>
+          <IconButton style={waitlistIconStyle} onClick={onOpenWaitlist}>
+            {getWaitlistLabel(waitlistSize, waitlistPosition)}
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+
+      <div className="MainView-content">
+        <div className="MobileApp-video">
+          <Video
+            enabled={videoEnabled}
+            size="large"
+          />
+          {!videoEnabled && (
+            <VideoDisabledMessage onEnableVideo={onEnableVideo} />
           )}
-        </Typography>
-        <IconButton onClick={onOpenRoomHistory}>
-          <HistoryIcon />
-        </IconButton>
-        <IconButton style={waitlistIconStyle} onClick={onOpenWaitlist}>
-          {getWaitlistLabel(waitlistSize, waitlistPosition)}
-        </IconButton>
-      </Toolbar>
-    </AppBar>
+        </div>
+        <div className="MobileApp-chat">
+          <Chat />
+        </div>
+      </div>
 
-    <div className="MainView-content">
-      <div className="MobileApp-video">
-        <Video
-          enabled={videoEnabled}
-          size="large"
-        />
-        {!videoEnabled && (
-          <VideoDisabledMessage onEnableVideo={onEnableVideo} />
-        )}
-      </div>
-      <div className="MobileApp-chat">
-        <Chat />
-      </div>
+      <DrawerMenu />
+      <UsersDrawer />
     </div>
-
-    <DrawerMenu />
-    <UsersDrawer />
-  </div>
-);
+  );
+}
 
 MainView.propTypes = {
   media: PropTypes.object,

--- a/src/mobile/components/MediaList/Row.js
+++ b/src/mobile/components/MediaList/Row.js
@@ -2,14 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Avatar from '@material-ui/core/Avatar';
 import ListItem from '@material-ui/core/ListItem';
+import ListItemAvatar from '@material-ui/core/ListItemAvatar';
 import ListItemText from '@material-ui/core/ListItemText';
 
 const MediaRow = ({ media }) => (
   <ListItem className="MobileMediaRow">
-    <Avatar
-      src={media.thumbnail}
-      style={{ borderRadius: 0 }}
-    />
+    <ListItemAvatar>
+      <Avatar
+        src={media.thumbnail}
+        variant="square"
+      />
+    </ListItemAvatar>
     <ListItemText
       primary={media.title}
       secondary={media.artist}

--- a/src/mobile/components/MediaList/Row.js
+++ b/src/mobile/components/MediaList/Row.js
@@ -5,6 +5,8 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemAvatar from '@material-ui/core/ListItemAvatar';
 import ListItemText from '@material-ui/core/ListItemText';
 
+const noWrap = { noWrap: true };
+
 const MediaRow = ({ media }) => (
   <ListItem className="MobileMediaRow">
     <ListItemAvatar>
@@ -14,6 +16,8 @@ const MediaRow = ({ media }) => (
       />
     </ListItemAvatar>
     <ListItemText
+      primaryTypographyProps={noWrap}
+      secondaryTypographyProps={noWrap}
       primary={media.title}
       secondary={media.artist}
     />

--- a/src/mobile/components/RoomHistory/Row.js
+++ b/src/mobile/components/RoomHistory/Row.js
@@ -6,22 +6,20 @@ import ListItemAvatar from '@material-ui/core/ListItemAvatar';
 import ListItemText from '@material-ui/core/ListItemText';
 import Votes from './Votes';
 
-const wrapTitle = (title) => (
-  <span className="MobileMediaRow-title">
-    {title}
-  </span>
-);
+const noWrap = { noWrap: true };
 
 const HistoryRow = ({ media }) => (
   <ListItem className="MobileMediaRow">
     <ListItemAvatar>
       <Avatar
         src={media.media.thumbnail}
-        style={{ borderRadius: 0 }}
+        variant="square"
       />
     </ListItemAvatar>
     <ListItemText
-      primary={wrapTitle(media.media.title)}
+      primaryTypographyProps={noWrap}
+      secondaryTypographyProps={noWrap}
+      primary={media.media.title}
       secondary={media.media.artist}
     />
     <Votes {...media.stats} />

--- a/src/mobile/components/RoomHistory/Votes.css
+++ b/src/mobile/components/RoomHistory/Votes.css
@@ -1,18 +1,20 @@
 .MobileHistoryVotes {
-  float: right;
-  height: 16px;
-  display: inline-flex;
-  flex-direction: row;
-  justify-content: center;
+  height: 100%;
+  display: flex;
+  flex-shrink: 0;
 }
 
 .MobileHistoryVotes-vote {
   margin-right: 5px;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  justify-content: space-around;
 }
 
 .MobileHistoryVotes-icon {
+  order: 1;
   height: 16px;
   width: 22px;
   padding: 0 4px 0 2px;
-  vertical-align: top;
 }

--- a/src/mobile/components/UsersDrawer/UserList.js
+++ b/src/mobile/components/UsersDrawer/UserList.js
@@ -64,7 +64,7 @@ function UserList({
       <Divider />
 
       <List
-        subheader={<ListSubheader>{t('users.title')}</ListSubheader>}
+        subheader={<ListSubheader>{t('users.listeners')}</ListSubheader>}
       >
         {users.map((user) => (
           <UserRow key={user._id} user={user} />

--- a/src/mobile/containers/DrawerMenu.js
+++ b/src/mobile/containers/DrawerMenu.js
@@ -16,7 +16,7 @@ const {
 
 function DrawerMenuContainer() {
   const uwave = useContext(UwaveContext);
-  const hasAboutPage = uwave && uwave.getAboutPageComponent();
+  const hasAboutPage = !!(uwave && uwave.getAboutPageComponent());
   const user = useSelector(currentUserSelector);
   const playlists = useSelector(playlistsSelector);
   const open = useSelector(drawerIsOpenSelector);

--- a/src/mobile/containers/PlaylistManager.js
+++ b/src/mobile/containers/PlaylistManager.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import {
   selectedPlaylistSelector,
   filteredSelectedPlaylistItemsSelector,
@@ -7,6 +7,11 @@ import {
 import { showSearchResultsSelector } from '../../selectors/searchSelectors';
 import { showImportPanelSelector } from '../../selectors/importSelectors';
 import createLazyOverlay from '../../components/LazyOverlay';
+import { closeAll } from '../../actions/OverlayActionCreators';
+
+const {
+  useCallback,
+} = React;
 
 const PlaylistManager = createLazyOverlay({
   loader: () => import('../components/PlaylistManager' /* webpackChunkName: "playlistsMobile" */),
@@ -18,6 +23,8 @@ function PlaylistManagerContainer() {
   const selectedItems = useSelector(filteredSelectedPlaylistItemsSelector);
   const showImportPanel = useSelector(showImportPanelSelector);
   const showSearchResults = useSelector(showSearchResultsSelector);
+  const dispatch = useDispatch();
+  const onCloseOverlay = useCallback(() => dispatch(closeAll()), [dispatch]);
 
   return (
     <PlaylistManager
@@ -25,6 +32,7 @@ function PlaylistManagerContainer() {
       selectedItems={selectedItems}
       showImportPanel={showImportPanel}
       showSearchResults={showSearchResults}
+      onCloseOverlay={onCloseOverlay}
     />
   );
 }

--- a/src/vars.css
+++ b/src/vars.css
@@ -1,5 +1,5 @@
 :root {
-  --font-family: "Open Sans", Roboto, Arial, sans-serif;
+  --font-family: "Open Sans", roboto, arial, sans-serif;
 
   /* Global colours */
   --text-color: #fff;


### PR DESCRIPTION
- Syncs the mobile components with "recent" material-ui updates (from the past 2 years or so....)
- Fixes issues with overlays not being closable
- Makes the settings panel more responsive, and especially puts the useful things at the top for mobile users as well as desktop users
  <details><summary>Screenshots</summary>

  ## Desktop
  ![image](https://user-images.githubusercontent.com/1006268/91564240-a09c5480-e940-11ea-8240-da3c950409f3.png)

  ## Mobile
  ![image](https://user-images.githubusercontent.com/1006268/91564307-b9a50580-e940-11ea-8bea-4df24cf4d497.png)

  </details>

Still todo:
- [x] Fix the headers for the playlist view
- [x] Alignment in the server listing
- [x] Also vertical alignment in the app bar …
- [ ] Use the current videoDisabled style also when nobody is playing (but with different text)
- [x] Hide the Playlists drawer menu header if not signed in
- [x] The vote icons in the room history don't fit in the slightest…work out a different approach
- [x] The mobile loading screen does not show errors
- [ ] The mobile loading screen has icons that look clickable, maybe hide them