### PR TITLE
Set scrollbar colour in Firefox

### DIFF
--- a/src/components/App/index.css
+++ b/src/components/App/index.css
@@ -6,6 +6,13 @@
   box-sizing: border-box;
 }
 
+/* Custom scrollbars for Firefox: */
+html {
+  scrollbar-color: var(--scrollbar-color) transparent;
+  scrollbar-width: 7px;
+}
+
+/* Custom scrollbars for Chrome: */
 ::-webkit-scrollbar {
   width: 7px;
 }


### PR DESCRIPTION
This has been possible since late 2018!

Now both firefox and chromium-based browsers will show a grey scrollbar
with a transparent track.