### PR TITLE
Anticipate supporting RTL text direction

### DIFF
--- a/src/components/App/index.css
+++ b/src/components/App/index.css
@@ -105,3 +105,8 @@ html:not([dir="rtl"]) .u-rtl-only {
 .AppRow--bottom {
   height: var(--footer-height);
 }
+
+/* Make App-level overlays fit in an AppColumn--left */
+.Overlays .Overlay {
+  width: 75%;
+}

--- a/src/components/App/index.css
+++ b/src/components/App/index.css
@@ -49,24 +49,19 @@ textarea {
 }
 
 .App {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  display: flex;
+  width: 100%;
+  height: 100vh;
 }
 
 .App-middle {
-  position: absolute;
-  top: var(--header-height);
-  bottom: var(--footer-height);
-  left: 0;
-  right: 0;
+  flex-grow: 1;
 }
 
 .AppColumn {
-  position: absolute;
   height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .AppColumn--full {
@@ -75,32 +70,24 @@ textarea {
 
 .AppColumn--left {
   width: 75%;
-  left: 0;
 }
 
 .AppColumn--right {
   width: 25%;
-  right: 0;
 }
 
 .AppRow {
-  position: absolute;
-  left: 0;
-  right: 0;
-  clear: both;
+  width: 100%;
 }
 
 .AppRow--top {
   height: var(--header-height);
-  top: 0;
 }
 
 .AppRow--middle {
-  top: var(--header-height);
-  bottom: var(--footer-height);
+  flex-grow: 1;
 }
 
 .AppRow--bottom {
   height: var(--footer-height);
-  bottom: 0;
 }

--- a/src/components/App/index.css
+++ b/src/components/App/index.css
@@ -48,6 +48,20 @@ textarea {
   font: inherit;
 }
 
+/* utility classes */
+
+/* hide element only if the text direction is right-to-left */
+html[dir="rtl"] .u-rtl-hidden {
+  display: none;
+}
+
+/* show element only if the text direction is right-to-left */
+html:not([dir="rtl"]) .u-rtl-only {
+  display: none;
+}
+
+/* the actual app component */
+
 .App {
   display: flex;
   width: 100%;

--- a/src/components/Chat/Message.css
+++ b/src/components/Chat/Message.css
@@ -15,7 +15,7 @@
   background: var(--background-color);
   position: absolute;
   top: 0;
-  right: 0;
+  inset-inline-end: 0;
   padding: 0 6px;
   display: none;
   font-size: 80%;
@@ -40,14 +40,14 @@
   width: 24px;
   height: 24px;
   top: 0;
-  left: 12px;
+  inset-inline-start: 12px;
   margin: 4px 0;
 }
 
 .ChatMessage-content {
   position: relative;
-  padding-left: 50px;
-  padding-right: 3px;
+  padding-inline-start: 50px;
+  padding-inline-end: 3px;
   width: 100%;
   display: inline-block;
   margin: 6px 0;
@@ -65,7 +65,7 @@
 }
 
 .ChatMessage-text {
-  margin-left: 5px;
+  margin-inline-start: 5px;
 }
 
 .ChatMessage--loading {

--- a/src/components/Chat/index.css
+++ b/src/components/Chat/index.css
@@ -6,6 +6,12 @@
 @import "./Message.css";
 @import "./Motd.css";
 
+.ChatContainer {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
 .ChatContainer-messages {
   position: absolute;
   top: 0;

--- a/src/components/FooterBar/Responses/Button.css
+++ b/src/components/FooterBar/Responses/Button.css
@@ -36,7 +36,9 @@
 .ResponseButton-icon {
   height: 36px;
   width: 36px;
-  padding: 6px 12px 6px 0;
+  padding-top: 6px;
+  padding-bottom: 6px;
+  padding-inline-end: 12px;
 }
 
 .ResponseButton-icon--favorite {

--- a/src/components/HeaderBar/Progress.css
+++ b/src/components/HeaderBar/Progress.css
@@ -8,3 +8,7 @@
   transform-origin: top left;
   transition: transform 0s linear;
 }
+
+.Progress-fill:dir(rtl) {
+  transform-origin: top right;
+}

--- a/src/components/HeaderBar/index.css
+++ b/src/components/HeaderBar/index.css
@@ -5,6 +5,7 @@
 @import "./Volume.css";
 
 .HeaderBar {
+  position: relative;
   display: flex;
   height: 100%;
   width: 100%;

--- a/src/components/List/ListItem.js
+++ b/src/components/List/ListItem.js
@@ -2,7 +2,8 @@ import cx from 'clsx';
 import React from 'react';
 import PropTypes from 'prop-types';
 import MuiListItem from '@material-ui/core/ListItem';
-import SelectedIcon from '@material-ui/icons/ChevronRight';
+import LtrSelectedIcon from '@material-ui/icons/ChevronRight';
+import RtlSelectedIcon from '@material-ui/icons/ChevronLeft';
 
 /**
  * A ListItem component wrapper around material-ui's ListItem,
@@ -21,7 +22,12 @@ const ListItem = ({
     className={cx(className, selected && 'is-selected')}
   >
     {children}
-    {selected && <SelectedIcon />}
+    {selected && (
+      <>
+        <LtrSelectedIcon className="u-rtl-hidden" />
+        <RtlSelectedIcon className="u-rtl-only" />
+      </>
+    )}
   </MuiListItem>
 );
 

--- a/src/components/MediaList/Actions.css
+++ b/src/components/MediaList/Actions.css
@@ -2,7 +2,7 @@
 
 .MediaActions {
   height: 54px;
-  text-align: right;
+  text-align: inline-end;
   background: var(--background-color);
 
   &.is-selected {

--- a/src/components/MediaList/BaseMediaList.js
+++ b/src/components/MediaList/BaseMediaList.js
@@ -7,6 +7,12 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import itemSelection from 'item-selection/immutable';
 import LoadingRow from './LoadingRow';
 
+const {
+  useCallback,
+  useEffect,
+  useState,
+} = React;
+
 /**
  * Check if two media lists are different, taking into account
  * pagination. If the new media list contains items where the previous
@@ -18,89 +24,45 @@ function didMediaChange(prev, next) {
   return prev.some((item, i) => item && next[i] && item._id !== next[i]._id);
 }
 
-export default class BaseMediaList extends React.Component {
-  static propTypes = {
-    className: PropTypes.string,
-    media: PropTypes.array,
-    size: PropTypes.number,
-    onRequestPage: PropTypes.func,
-    listComponent: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.func,
-    ]).isRequired,
-    rowComponent: PropTypes.func.isRequired,
-    rowProps: PropTypes.object,
+const defaultMakeActions = () => null;
 
-    onOpenPreviewMediaDialog: PropTypes.func,
-    makeActions: PropTypes.func,
-  };
+function BaseMediaList({
+  className,
+  media,
+  listComponent: ListComponent,
+  rowComponent: RowComponent,
+  rowProps = {},
+  onRequestPage,
+  onOpenPreviewMediaDialog,
+  // The `size` property is only necessary for lazy loading.
+  size = null,
+  makeActions = defaultMakeActions,
+}) {
+  const [lastMedia, setLastMedia] = useState(media);
+  const [selection, setSelection] = useState(() => itemSelection(media));
 
-  static defaultProps = {
-    // The `size` property is only necessary for lazy loading.
-    size: null,
-    makeActions: () => <span />,
-  };
-
-  static getDerivedStateFromProps(nextProps, prevState) {
-    if (prevState.media !== nextProps.media) {
-      const selectedIndices = prevState.selection.getIndices();
-      const mediaChanged = didMediaChange(prevState.media, nextProps.media);
-      return {
-        media: nextProps.media,
-        selection: mediaChanged
-          ? itemSelection(nextProps.media)
-          : itemSelection(nextProps.media, selectedIndices),
-      };
+  useEffect(() => {
+    if (lastMedia !== media) {
+      setLastMedia(media);
+      const selectedIndices = selection.getIndices();
+      const mediaChanged = didMediaChange(lastMedia, media);
+      setSelection(mediaChanged ? itemSelection(media) : itemSelection(media, selectedIndices));
     }
-    return null;
-  }
+  }, [media]);
 
-  constructor(props) {
-    super(props);
+  const selectItem = useCallback((index, event) => {
+    event.preventDefault();
 
-    const { media } = this.props;
-    this.state = {
-      media,
-      selection: itemSelection(media),
-    };
-  }
-
-  selectItem(index, e) {
-    e.preventDefault();
-
-    let { selection } = this.state;
-
-    if (e.shiftKey) {
-      selection = selection.selectRange(index);
-    } else if (e.ctrlKey) {
-      selection = selection.selectToggle(index);
+    if (event.shiftKey) {
+      setSelection(selection.selectRange(index));
+    } else if (event.ctrlKey) {
+      setSelection(selection.selectToggle(index));
     } else {
-      selection = selection.select(index);
+      setSelection(selection.select(index));
     }
+  }, [selection]);
 
-    this.setState({ selection });
-  }
-
-  renderList = (items, ref) => {
-    const { listComponent: ListComponent } = this.props;
-
-    return (
-      <ListComponent ref={ref}>
-        {items}
-      </ListComponent>
-    );
-  };
-
-  renderRow = ({ index, style }) => {
-    const {
-      makeActions,
-      rowProps: props = {},
-      media,
-      rowComponent: RowComponent,
-      onOpenPreviewMediaDialog,
-    } = this.props;
-    const { selection } = this.state;
-
+  const renderRow = useCallback(({ index, style }) => {
     const selected = selection.isSelectedIndex(index);
     if (!media[index]) {
       return (
@@ -116,85 +78,97 @@ export default class BaseMediaList extends React.Component {
     return (
       <RowComponent
         key={media[index] ? media[index]._id : index}
-        {...props}
+        {...rowProps}
         style={style}
         className="MediaList-row"
         media={media[index]}
         selected={selected}
         selection={selection.get()}
-        onClick={(e) => this.selectItem(index, e)}
+        onClick={(event) => selectItem(index, event)}
         onOpenPreviewMediaDialog={onOpenPreviewMediaDialog}
         makeActions={() => makeActions(media[index], selection, index)}
       />
     );
+  }, [selection, media, RowComponent, rowProps, onOpenPreviewMediaDialog, makeActions]);
+
+  const innerList = ({ height, onItemsRendered, ref }) => (
+    <FixedSizeList
+      itemCount={size || media.length}
+      itemSize={56}
+      height={height}
+      onItemsRendered={onItemsRendered}
+      ref={ref}
+      width="100%"
+      rerenderOnUpdate={selection}
+    >
+      {renderRow}
+    </FixedSizeList>
+  );
+
+  // This is not used as a real React component.
+  // eslint-disable-next-line react/prop-types
+  const lazyLoading = (makeList) => ({ height }) => {
+    const isItemLoaded = (index) => media[index] != null;
+    const loadMoreItems = (start) => {
+      const page = Math.floor(start / 50);
+      onRequestPage(page);
+    };
+
+    const inner = ({ onItemsRendered, ref }) => makeList({ onItemsRendered, ref, height });
+    return (
+      <InfiniteLoader
+        isItemLoaded={isItemLoaded}
+        itemCount={size || media.length}
+        loadMoreItems={loadMoreItems}
+      >
+        {inner}
+      </InfiniteLoader>
+    );
   };
 
-  render() {
-    const {
-      className, media, size, onRequestPage,
-    } = this.props;
-    const { listComponent: ListComponent } = this.props;
-    const { selection } = this.state;
+  const customWrapper = (makeList) => (props) => (
+    <ListComponent>
+      {makeList(props)}
+    </ListComponent>
+  );
 
-    const innerList = ({ height, onItemsRendered, ref }) => (
-      <FixedSizeList
-        itemCount={size || media.length}
-        itemSize={56}
-        height={height}
-        onItemsRendered={onItemsRendered}
-        ref={ref}
-        width="100%"
-        rerenderOnUpdate={selection}
-      >
-        {this.renderRow}
-      </FixedSizeList>
-    );
-
-    const lazyLoading = (makeList) => ({ height }) => {
-      const isItemLoaded = (index) => media[index] != null;
-      const loadMoreItems = (start) => {
-        const page = Math.floor(start / 50);
-        onRequestPage(page);
-      };
-
-      const inner = ({ onItemsRendered, ref }) => makeList({ onItemsRendered, ref, height });
-      return (
-        <InfiniteLoader
-          isItemLoaded={isItemLoaded}
-          itemCount={size || media.length}
-          loadMoreItems={loadMoreItems}
-        >
-          {inner}
-        </InfiniteLoader>
-      );
-    };
-
-    const customWrapper = (makeList) => (props) => (
-      <ListComponent>
-        {makeList(props)}
-      </ListComponent>
-    );
-
-    const autoSizing = (makeList) => () => {
-      const inner = ({ height }) => makeList({ height });
-      return (
-        <AutoSizer disableWidth>
-          {inner}
-        </AutoSizer>
-      );
-    };
-
-    let listRenderer = innerList;
-    if (onRequestPage) {
-      listRenderer = lazyLoading(listRenderer);
-    }
-    listRenderer = customWrapper(listRenderer);
-    listRenderer = autoSizing(listRenderer);
-
+  const autoSizing = (makeList) => () => {
+    const inner = ({ height }) => makeList({ height });
     return (
-      <div className={cx('MediaList', className)}>
-        {listRenderer()}
-      </div>
+      <AutoSizer disableWidth>
+        {inner}
+      </AutoSizer>
     );
+  };
+
+  let listRenderer = innerList;
+  if (onRequestPage) {
+    listRenderer = lazyLoading(listRenderer);
   }
+  listRenderer = customWrapper(listRenderer);
+  listRenderer = autoSizing(listRenderer);
+
+  return (
+    <div className={cx('MediaList', className)}>
+      {listRenderer()}
+    </div>
+  );
 }
+
+BaseMediaList.propTypes = {
+  className: PropTypes.string,
+  media: PropTypes.array,
+  size: PropTypes.number,
+  onRequestPage: PropTypes.func,
+  listComponent: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func,
+  ]).isRequired,
+  rowComponent: PropTypes.func.isRequired,
+  rowProps: PropTypes.object,
+
+  onOpenPreviewMediaDialog: PropTypes.func,
+  makeActions: PropTypes.func,
+};
+
+export default BaseMediaList;

--- a/src/components/MediaList/BaseMediaList.js
+++ b/src/components/MediaList/BaseMediaList.js
@@ -5,6 +5,7 @@ import { FixedSizeList } from 'react-window';
 import InfiniteLoader from 'react-window-infinite-loader';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import itemSelection from 'item-selection/immutable';
+import useDirection from '../../hooks/useDirection';
 import LoadingRow from './LoadingRow';
 
 const {
@@ -40,6 +41,7 @@ function BaseMediaList({
 }) {
   const [lastMedia, setLastMedia] = useState(media);
   const [selection, setSelection] = useState(() => itemSelection(media));
+  const direction = useDirection();
 
   useEffect(() => {
     if (lastMedia !== media) {
@@ -99,6 +101,7 @@ function BaseMediaList({
       onItemsRendered={onItemsRendered}
       ref={ref}
       width="100%"
+      direction={direction}
       rerenderOnUpdate={selection}
     >
       {renderRow}

--- a/src/components/MediaList/Row.css
+++ b/src/components/MediaList/Row.css
@@ -30,7 +30,7 @@
   width: 55px;
   margin: 0 15px;
   padding: 7px 0;
-  float: left;
+  float: inline-start;
 }
 
 .MediaListRow-image {
@@ -43,14 +43,14 @@
   padding: 7px 0;
   line-height: var(--unpadded-media-list-row-height);
   width: calc(100% - var(--media-list-spacing) - var(--media-list-thumb-width) - var(--media-list-duration-width));
-  float: left;
+  float: inline-start;
 }
 
 .MediaListRow-artist {
   height: 100%;
-  float: left;
+  float: inline-start;
   width: calc(40% - var(--media-list-spacing));
-  margin-right: var(--media-list-spacing);
+  margin-inline-end: var(--media-list-spacing);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -58,9 +58,9 @@
 
 .MediaListRow-title {
   height: 100%;
-  float: left;
+  float: inline-start;
   width: calc(60% - var(--media-list-spacing));
-  margin-right: var(--media-list-spacing);
+  margin-inline-end: var(--media-list-spacing);
   overflow: hidden;
   color: var(--secondary-text-color);
   text-overflow: ellipsis;
@@ -71,7 +71,7 @@
   height: calc(var(--unpadded-media-list-row-height) / 3);
   line-height: calc(var(--unpadded-media-list-row-height) / 3);
   width: calc(100% - var(--media-list-spacing));
-  margin-right: var(--media-list-spacing);
+  margin-inline-end: var(--media-list-spacing);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -86,14 +86,14 @@
 
 .MediaListRow-duration {
   height: 100%;
-  float: left;
+  float: inline-start;
   width: var(--media-list-duration-width);
 }
 
 .MediaListRow-actions {
   height: 100%;
   position: absolute;
-  right: 0;
+  inset-inline-end: 0;
   display: none;
 }
 

--- a/src/components/PlaylistManager/Header/SearchBar.css
+++ b/src/components/PlaylistManager/Header/SearchBar.css
@@ -1,5 +1,5 @@
 .SearchBar-source {
-  float: right;
+  float: inline-end;
   margin: 0 5px;
   height: 100%;
 }

--- a/src/components/PlaylistManager/Header/SourcePickerElement.css
+++ b/src/components/PlaylistManager/Header/SourcePickerElement.css
@@ -8,5 +8,5 @@
 
 .SourcePickerElement--active {
   width: 48px;
-  float: left;
+  float: inline-start;
 }

--- a/src/components/PlaylistManager/Menu/Row.css
+++ b/src/components/PlaylistManager/Menu/Row.css
@@ -29,16 +29,16 @@
 
 .PlaylistMenuRow-active-icon {
   display: block;
-  float: left;
+  float: inline-start;
   height: var(--playlist-row-height);
-  margin-right: 7px;
+  margin-inline-end: 7px;
   padding-top: 5px;
 }
 
 .PlaylistMenuRow-loading {
   width: 24px;
   height: 24px;
-  float: left;
+  float: inline-start;
   margin: 10px 7px 10px 0;
 }
 
@@ -54,15 +54,15 @@
 .PlaylistMenuRow-count {
   align-self: flex-end;
   color: var(--highlight-color);
-  margin-right: 5px;
-  margin-left: 7px;
+  margin-inline-end: 5px;
+  margin-inline-start: 7px;
 }
 
 .PlaylistMenuRow-closeButton {
   width: var(--playlist-row-height);
   height: var(--playlist-row-height);
   padding: 10px;
-  margin-right: -10px;
+  margin-inline-end: -10px;
 }
 
 .PlaylistMenuRow--create {
@@ -78,7 +78,7 @@
 }
 
 .PlaylistMenuRow--search .PlaylistMenuRow-count {
-  margin-right: 0;
+  margin-inline-end: 0;
 }
 
 .PlaylistMenuRow--search .PlaylistMenuRow-title {

--- a/src/components/PlaylistManager/Panel/Meta.css
+++ b/src/components/PlaylistManager/Panel/Meta.css
@@ -9,7 +9,7 @@
 
 .PlaylistMeta-name {
   flex-grow: 1;
-  padding-left: 15px;
+  padding-inline-start: 15px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -19,7 +19,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  padding-right: 20px;
+  padding-inline-end: 20px;
   height: 100%;
   cursor: pointer;
 

--- a/src/components/PlaylistManager/SearchResults/index.css
+++ b/src/components/PlaylistManager/SearchResults/index.css
@@ -2,7 +2,7 @@
   height: 54px;
   line-height: 54px;
   font-size: 14pt;
-  padding-left: 15px;
+  padding-inline-start: 15px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -43,7 +43,7 @@
 .SearchResultRow-data .MediaListRow-title {
   height: 66%;
   width: calc(60% - var(--media-list-spacing));
-  margin-right: 0;
+  margin-inline-end: 0;
   line-height: calc(56px / 3 * 2);
 }
 

--- a/src/components/PlaylistManager/index.css
+++ b/src/components/PlaylistManager/index.css
@@ -13,7 +13,7 @@
 
 .PlaylistManager-menu {
   width: 33%; /* 25% of total screen width */
-  float: left;
+  float: inline-start;
 
   /* menu would be larger than 300px */
   @media (min-width: 1200px) {
@@ -23,12 +23,12 @@
 
 .PlaylistManager-panel {
   position: absolute;
-  left: 33%;
-  right: 0;
+  inset-inline-start: 33%;
+  inset-inline-end: 0;
   height: 100%;
 
   /* menu would be larger than 300px */
   @media (min-width: 1200px) {
-    left: 300px;
+    inset-inline-start: 300px;
   }
 }

--- a/src/components/RoomUserList/index.js
+++ b/src/components/RoomUserList/index.js
@@ -3,10 +3,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FixedSizeList } from 'react-window';
 import AutoSizer from 'react-virtualized-auto-sizer';
+import useDirection from '../../hooks/useDirection';
 import RoomUserRow from './Row';
 import GuestsRow from './GuestsRow';
 
 const RoomUserList = ({ className, users, guests }) => {
+  const direction = useDirection();
+
   const showGuests = guests > 0;
   // The "and X guests" row is implemented somewhat hackily as an extra user
   // row. To render properly at the end of the list, it needs to be rendered as
@@ -48,6 +51,7 @@ const RoomUserList = ({ className, users, guests }) => {
         height={height}
         itemCount={length}
         itemSize={40}
+        direction={direction}
       >
         {itemRenderer}
       </FixedSizeList>

--- a/src/components/SearchBar/index.css
+++ b/src/components/SearchBar/index.css
@@ -17,7 +17,7 @@
 .SearchBar-icon {
   width: 80px;
   height: 100%;
-  float: left;
+  float: inline-start;
   text-align: center;
   font-size: 32px;
   line-height: 38px;
@@ -25,8 +25,8 @@
 
 .SearchBar-query {
   height: 100%;
-  margin-left: 80px;
-  margin-right: 100px;
+  margin-inline-start: 80px;
+  margin-inline-end: 100px;
 }
 
 .SearchBar-input {

--- a/src/components/SettingsManager/Links.css
+++ b/src/components/SettingsManager/Links.css
@@ -5,7 +5,6 @@
   height: 24px;
   line-height: 24px;
   margin-bottom: 16px;
-  text-align: left;
   color: var(--text-color);
 
   &:visited {
@@ -14,6 +13,6 @@
 }
 
 .SettingsPanel-linkIcon {
-  margin-right: 8px;
+  margin-inline-end: 8px;
   vertical-align: top;
 }

--- a/src/components/SettingsManager/Profile.css
+++ b/src/components/SettingsManager/Profile.css
@@ -12,7 +12,7 @@
 
 .SettingsPanelProfile-textblock {
   display: inline-block;
-  padding-left: 20px;
+  padding-inline-start: 20px;
   vertical-align: top;
 }
 

--- a/src/components/SettingsManager/SettingsPanel.css
+++ b/src/components/SettingsManager/SettingsPanel.css
@@ -32,13 +32,13 @@
 
 .SettingsPanel-column {
   width: 50%;
-  float: left;
+  float: inline-start;
 }
 
 .SettingsPanel-column--left {
-  padding-right: 50px;
+  padding-inline-end: 50px;
 }
 
 .SettingsPanel-column--right {
-  padding-left: 50px;
+  padding-inline-start: 50px;
 }

--- a/src/components/SidePanels/PanelContainer.js
+++ b/src/components/SidePanels/PanelContainer.js
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const PanelContainer = ({ selected, children }) => (
-  <div className={cx('SidePanel-panel', selected && 'is-selected')} hidden={!selected}>
+  <div className={cx('SidePanel-panel', 'AppRow--middle', selected && 'is-selected')} hidden={!selected}>
     {children}
   </div>
 );

--- a/src/components/SidePanels/index.css
+++ b/src/components/SidePanels/index.css
@@ -17,11 +17,6 @@
 }
 
 .SidePanel-panel {
-  position: absolute;
-  top: var(--header-height);
-  bottom: 0;
-  left: 0;
-  right: 0;
   visibility: hidden;
   opacity: 0;
 

--- a/src/components/SidePanels/index.js
+++ b/src/components/SidePanels/index.js
@@ -64,7 +64,7 @@ function SidePanels() {
         onChange={handleChange}
         variant="fullWidth"
         classes={{
-          root: 'SidePanel-tabs',
+          root: 'AppRow--top SidePanel-tabs',
           indicator: 'SidePanel-indicator',
         }}
       >

--- a/src/components/UserCard/UserRoles.css
+++ b/src/components/UserCard/UserRoles.css
@@ -5,5 +5,5 @@
 
 .UserRoles-role {
   display: inline-block;
-  margin-right: 1em;
+  margin-inline-end: 1em;
 }

--- a/src/components/WaitList/index.js
+++ b/src/components/WaitList/index.js
@@ -3,16 +3,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FixedSizeList } from 'react-window';
 import AutoSizer from 'react-virtualized-auto-sizer';
+import useDirection from '../../hooks/useDirection';
 import ModRow from './ModRow';
 import SimpleRow from './SimpleRow';
 
-const WaitList = ({
+function WaitList({
   className,
   users,
   onMoveUser,
   onRemoveUser,
   canMoveUsers,
-}) => {
+}) {
+  const direction = useDirection();
   const Row = canMoveUsers ? ModRow : SimpleRow;
 
   // these are not components
@@ -34,6 +36,7 @@ const WaitList = ({
       height={height}
       itemCount={users.length}
       itemSize={40}
+      direction={direction}
     >
       {renderRow}
     </FixedSizeList>
@@ -54,7 +57,7 @@ const WaitList = ({
       </AutoSizer>
     </div>
   );
-};
+}
 
 WaitList.propTypes = {
   className: PropTypes.string,

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -64,8 +64,10 @@ function AppContainer({ uwave, mediaSources }) {
   const onCloseOverlay = useCallback(() => dispatch(closeAll()));
 
   useEffect(() => {
-    const root = document.body;
+    const html = document.documentElement;
+    html.dir = theme.direction;
 
+    const root = document.body;
     Object.keys(theme.cssProperties).forEach((prop) => {
       root.style.setProperty(prop, theme.cssProperties[prop]);
     });

--- a/src/hooks/useDirection.js
+++ b/src/hooks/useDirection.js
@@ -1,0 +1,5 @@
+import { useTheme } from '@material-ui/core/styles';
+
+export default function useDirection() {
+  return useTheme().direction;
+}

--- a/src/index.html
+++ b/src/index.html
@@ -3,8 +3,8 @@
     await htmlWebpackPlugin.options.loadingScreen(compilation);
 %>
 <!DOCTYPE html>
-<!-- lang will be overwritten with user configuration at runtime. -->
-<html lang="en">
+<!-- lang/dir will be overwritten with user configuration at runtime. -->
+<html lang="en" dir="ltr">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">

--- a/src/sources/youtube/ChannelPanel.js
+++ b/src/sources/youtube/ChannelPanel.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FixedSizeList } from 'react-window';
 import AutoSizer from 'react-virtualized-auto-sizer';
+import useDirection from '../../hooks/useDirection';
 import ImportPanelHeader from '../../components/PlaylistManager/Import/ImportPanelHeader';
 import PlaylistRow from './PlaylistRow';
 
@@ -11,6 +12,8 @@ function ChannelPanel({
   onImportPlaylist,
   onClosePanel,
 }) {
+  const direction = useDirection();
+
   const body = (
     <AutoSizer disableWidth>
       {({ height }) => (
@@ -18,6 +21,7 @@ function ChannelPanel({
           height={height}
           itemCount={importablePlaylists.length}
           itemSize={56}
+          direction={direction}
         >
           {({ index, style }) => {
             const playlist = importablePlaylists[index];


### PR DESCRIPTION
This PR flips the layout of lots of stuff if the text direction is right-to-left. It mostly uses the direction-aware CSS property variants `inline-start` and `inline-end` to do that.

There are probably lots of places I missed but it's a good start I think.