### PR TITLE
Hide elements that may overlay embedded players.

### DIFF
--- a/src/components/Video/index.js
+++ b/src/components/Video/index.js
@@ -9,6 +9,11 @@ import VideoToolbar from './VideoToolbar';
 import MouseMoveCapture from './VideoMouseMoveCapture';
 import Player from '../Player';
 
+// Overlays over the video (even tiny in the corner like ours) violate TOS,
+// so we can not show them. Toggling it off with a conditional for now until
+// we find a good place for the fullscreen control (if we do).
+const OVERLAY_ALLOWED = false;
+
 const {
   useCallback,
   useEffect,
@@ -110,26 +115,30 @@ function Video(props) {
         seek={seek}
       />
 
-      {isFullscreen && (
-        <MouseMoveCapture
-          active={shouldShowToolbar}
-          onMouseMove={handleMouseMove}
-        />
-      )}
-      {isFullscreen && (
-        <VideoProgressBar
-          media={media}
-          seek={seek}
-        />
-      )}
-      {(!isFullscreen || shouldShowToolbar) && (
-        <VideoToolbar
-          isFullscreen={isFullscreen}
-          onFullscreenEnter={handleRequestFullscreenEnter}
-          onFullscreenExit={onFullscreenExit}
-        >
-          <MediaSourceTools media={media} />
-        </VideoToolbar>
+      {OVERLAY_ALLOWED && (
+        <>
+          {isFullscreen && (
+            <MouseMoveCapture
+              active={shouldShowToolbar}
+              onMouseMove={handleMouseMove}
+            />
+          )}
+          {isFullscreen && (
+            <VideoProgressBar
+              media={media}
+              seek={seek}
+            />
+          )}
+          {(!isFullscreen || shouldShowToolbar) && (
+            <VideoToolbar
+              isFullscreen={isFullscreen}
+              onFullscreenEnter={handleRequestFullscreenEnter}
+              onFullscreenExit={onFullscreenExit}
+            >
+              <MediaSourceTools media={media} />
+            </VideoToolbar>
+          )}
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
The terms of service for embeddable players usually disallow showing stuff on top of the embed, in case it obscures part of the embed's own UI. We had buttons to control the size of the player on top of the embed; this PR removes them.

The player size can still be toggled in the settings panel.
The fullscreen player is not available anymore with this change. The code is still there but we should maybe remove it entirely.