### PR TITLE
Support emojis specified as full URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5777,6 +5777,11 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
       "integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ=="
     },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s="
+    },
     "cssdb": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-4.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "array.prototype.find": "^2.1.1",
     "array.prototype.findindex": "^2.1.0",
     "clsx": "^1.0.4",
+    "css.escape": "^1.5.1",
     "deepmerge": "^4.2.2",
     "dlv": "^1.1.3",
     "dset": "^3.0.0",

--- a/src/components/Chat/Input/EmojiSuggestion.js
+++ b/src/components/Chat/Input/EmojiSuggestion.js
@@ -3,23 +3,28 @@ import PropTypes from 'prop-types';
 import ListItemAvatar from '@material-ui/core/ListItemAvatar';
 import ListItemText from '@material-ui/core/ListItemText';
 import Suggestion from './Suggestion';
+import emojiUrl from '../../../utils/emojiUrl';
 
 const shortcode = (emoji) => `:${emoji.shortcode}:`;
 
-const EmojiSuggestion = ({
+function EmojiSuggestion({
   value: emoji,
   ...props
-}) => (
-  <Suggestion {...props}>
-    <ListItemAvatar>
-      <span
-        className="EmojiSuggestion-image"
-        style={{ backgroundImage: `url(/assets/emoji/${emoji.image})` }}
-      />
-    </ListItemAvatar>
-    <ListItemText primary={shortcode(emoji)} />
-  </Suggestion>
-);
+}) {
+  const url = emojiUrl(emoji.image);
+
+  return (
+    <Suggestion {...props}>
+      <ListItemAvatar>
+        <span
+          className="EmojiSuggestion-image"
+          style={{ backgroundImage: `url(${CSS.escape(url)})` }}
+        />
+      </ListItemAvatar>
+      <ListItemText primary={shortcode(emoji)} />
+    </Suggestion>
+  );
+}
 
 EmojiSuggestion.propTypes = {
   value: PropTypes.shape({

--- a/src/components/Chat/Markup/Emoji.js
+++ b/src/components/Chat/Markup/Emoji.js
@@ -1,16 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Tooltip from '@material-ui/core/Tooltip';
+import emojiUrl from '../../../utils/emojiUrl';
 
 const shortcode = (name) => `:${name}:`;
-const url = (filename) => `/assets/emoji/${filename}`;
 
 const Emoji = ({ name, image }) => (
   <Tooltip title={shortcode(name)} placement="top">
     <span className="Emoji" data-emoji={name}>
       <img
         className="Emoji-img"
-        src={url(image)}
+        src={emojiUrl(image)}
         alt={shortcode(name)}
       />
     </span>

--- a/src/polyfills-legacy.js
+++ b/src/polyfills-legacy.js
@@ -10,6 +10,7 @@ import 'is-nan/auto';
 import 'string.prototype.includes/auto';
 import 'es6-promise/auto';
 import 'es6-symbol/implement';
+import 'css.escape';
 import 'url-polyfill';
 import 'whatwg-fetch';
 import 'abortcontroller-polyfill/src/polyfill';

--- a/src/utils/emojiUrl.js
+++ b/src/utils/emojiUrl.js
@@ -1,0 +1,21 @@
+// URL, relative to the web client, where emoji can be found.
+const EMOJI_BASE_PATH = '/assets/emoji/';
+
+/**
+ * Get the full URL for an emoji.
+ *
+ * @example
+ * emojiUrl('smile.png')
+ * // → 'https://demo.u-wave.net/assets/emoji/smile.png'
+ * @example
+ * emojiUrl('https://example.com/my-emote.png')
+ * // → 'https://example.com/my-emote.png'
+ *
+ * @param {string} filenameOrUrl - The file name for a local emoji or a full URL to a remote one.
+ */
+function emojiUrl(filenameOrUrl) {
+  const dirname = new URL(EMOJI_BASE_PATH, window.location.href);
+  return new URL(filenameOrUrl, dirname);
+}
+
+export default emojiUrl;


### PR DESCRIPTION
This way they don't always need to be hosted locally.

It also correctly escapes URLs when they are used in CSS. Previously a creative filename could cause the syntax to be invalid.