### PR TITLE
set flex-basis for .AppRow--middle to fill up all free space in Safari

### DIFF
--- a/src/components/App/index.css
+++ b/src/components/App/index.css
@@ -97,6 +97,7 @@ html:not([dir="rtl"]) .u-rtl-only {
 }
 
 .AppRow--middle {
+  flex-basis: 0;
   flex-grow: 1;
 }
 


### PR DESCRIPTION
Hi, I found the easiest solution to fix height problem in Safari by filling up available space. Basically it helps to go from this https://ibb.co/XCv7vNc to this https://ibb.co/y4FFYVN. Also I have not found this to affect how it works in other browsers.