### PR TITLE
[Hotfix] Throttling requests sent from infinite scrolling behavior

### DIFF
--- a/src/components/MediaList/BaseMediaList.js
+++ b/src/components/MediaList/BaseMediaList.js
@@ -125,7 +125,10 @@ function BaseMediaList({
       inFlightPageRequests.current[page] = 1;
 
       return onRequestPage(page).finally(() => {
-        // an attempt to throttle since cached requests are too fast
+        // Without the timeout we can still get duplicate requests.
+        // That is *probably* because a rerender is triggered by some
+        // redux action on request completion, just *before* the new
+        // playlist items are actually stored in state.
         setTimeout(() => {
           delete inFlightPageRequests.current[page];
         }, 200);

--- a/src/components/MediaList/BaseMediaList.js
+++ b/src/components/MediaList/BaseMediaList.js
@@ -13,7 +13,6 @@ const {
   useEffect,
   useRef,
   useState,
-  useRef,
 } = React;
 
 /**


### PR DESCRIPTION
Hi, Burkes here.

I was trying to work around with the library used for infinite scrolling, that didn't help.

Tried debouncing the call, didn't work too well either when you scrolled too quickly (ends up loading only where you stop scrolling at). Thought throttling would make more sense, but then I saw the suggestion in the issue to control it with a in-flight request state.

Almost worked, since cached requests responded within milliseconds and still sent out duplicate requests, I added some of type of throttling with the in-flight state and it works consistently, but I don't know if it "looks bad".

<img width="160" alt="Screen Shot 2021-02-15 at 3 57 42 PM" src="https://user-images.githubusercontent.com/39530115/108648904-09e9c400-749b-11eb-8e90-2999b2a37adb.png">


fixes #1709 