### PR TITLE
Keep login dialog open until new state is loaded

### DIFF
--- a/src/actions/LoginActionCreators.js
+++ b/src/actions/LoginActionCreators.js
@@ -102,7 +102,7 @@ export function login({ email, password }) {
     onComplete: (res) => (dispatch) => {
       Session.set(res.meta.jwt);
       dispatch(setSessionToken(res.meta.jwt));
-      dispatch(initState());
+      return dispatch(initState());
     },
     onError: (error) => ({
       type: LOGIN_COMPLETE,


### PR DESCRIPTION
Currently, when you log in the dialog closes and then a little later the footer updates with your user info. It feels a bit janky. This PR waits for the /now request (which is responsible for the UI updates) to complete before finishing the login process (and thus closing the dialog).