### PR TITLE
mobile: fix horizontal app and overlay sizings

### DIFF
--- a/src/components/App/index.css
+++ b/src/components/App/index.css
@@ -106,6 +106,8 @@ html:not([dir="rtl"]) .u-rtl-only {
 }
 
 /* Make App-level overlays fit in an AppColumn--left */
-.Overlays .Overlay {
-  width: 75%;
+@media (min-width: 769px) {
+  .Overlays .Overlay {
+    width: 75%;
+  }
 }

--- a/src/mobile/components/App/index.css
+++ b/src/mobile/components/App/index.css
@@ -1,5 +1,15 @@
 @import "./Overlays.css";
 
+.MobileApp {
+  width: 100%;
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+}
+
 .MobileApp-video {
   height: 56px;
   position: relative;


### PR DESCRIPTION
Fixes layout problems introduced by https://github.com/u-wave/web/pull/1708.