### PR TITLE
Tweak widths of things in media list rows

### DIFF
--- a/src/components/MediaList/Row.css
+++ b/src/components/MediaList/Row.css
@@ -1,6 +1,6 @@
 :root {
   --media-list-row-height: 56px;
-  --media-list-row-icon-offset: 8px;
+  --media-list-row-icon-width: 50px;
   --unpadded-media-list-row-height: calc(var(--media-list-row-height) - 14px);
 }
 
@@ -41,7 +41,7 @@
   height: 100%;
   padding: 7px 0;
   line-height: var(--unpadded-media-list-row-height);
-  width: calc(100% - var(--media-list-spacing) - var(--media-list-thumb-width) - var(--media-list-row-icon-offset) - var(--media-list-duration-width));
+  width: calc(100% - var(--media-list-thumb-width) - var(--media-list-row-icon-width) - var(--media-list-duration-width));
   float: inline-start;
 }
 
@@ -91,7 +91,8 @@
 
 .MediaListRow-icon {
   height: 100%;
-  float: left;
+  width: var(--media-list-row-icon-width);
+  float: inline-start;
   display: flex;
   align-items: center;
 }
@@ -105,8 +106,4 @@
 
 .MediaListRow:hover .MediaListRow-actions {
   display: block;
-}
-
-.MediaListRow:hover .MediaListRow-icon {
-  display: none;
 }

--- a/src/components/RoomHistory/Row.css
+++ b/src/components/RoomHistory/Row.css
@@ -1,6 +1,5 @@
 :root {
   --history-list-thumb-width: 85px;
-  --history-list-icon-width: 50px;
   --history-list-user-width: 130px;
   --history-list-time-width: 170px;
   --history-list-votes-width: 250px;
@@ -10,16 +9,16 @@
       var(--history-list-time-width) +
       var(--history-list-user-width) +
       var(--history-list-votes-width) +
-      var(--history-list-icon-width)
+      var(--media-list-row-icon-width)
     );
 }
 
 .HistoryRow-song {
   font-size: 1em;
   height: 100%;
-  float: left;
+  float: inline-start;
   width: calc(100% - var(--media-list-spacing) - var(--history-list-not-song-width));
-  margin-right: var(--media-list-spacing);
+  margin-inline-end: var(--media-list-spacing);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -27,20 +26,21 @@
 
 .HistoryRow-votes {
   height: 100%;
-  float: left;
+  float: inline-start;
   width: var(--history-list-votes-width);
 }
 
 .HistoryRow-icon {
   height: 100%;
-  float: left;
+  width: var(--media-list-row-icon-width);
+  float: inline-start;
   display: flex;
   align-items: center;
 }
 
 .HistoryRow-user {
   height: 100%;
-  float: left;
+  float: inline-start;
   width: var(--history-list-user-width);
   text-align: right;
   overflow: hidden;
@@ -50,8 +50,8 @@
 
 .HistoryRow-time {
   height: 100%;
-  float: left;
-  text-align: right;
+  float: inline-start;
+  text-align: end;
   padding-right: 20px;
   color: var(--muted-text-color);
   width: var(--history-list-time-width);

--- a/src/components/RoomHistory/Row.js
+++ b/src/components/RoomHistory/Row.js
@@ -109,7 +109,7 @@ function HistoryRow({
       <div className="HistoryRow-time" dateTime={timestamp}>
         <TimeAgo timestamp={timestamp} />
       </div>
-      <div className="HistoryRow-icon">
+      <div className="MediaListRow-icon HistoryRow-icon">
         {sourceIcon}
       </div>
 


### PR DESCRIPTION
This should fix the media source icon jumping between rows on narrow
screens. It also fixes some RTL text support and removes excessive
padding from Way Back When™.