### PR TITLE
stop propagation of events for PromptDialog

### DIFF
--- a/src/components/Dialogs/PromptDialog/index.js
+++ b/src/components/Dialogs/PromptDialog/index.js
@@ -123,6 +123,7 @@ export default class PromptDialog extends React.Component {
                 icon={icon}
                 value={value}
                 onChange={this.handleInputChange}
+                onKeyDown={(e) => e.stopPropagation()}
               />
             </FormGroup>
             <FormGroup>


### PR DESCRIPTION
There is an issue with PromptDialog that has to do with the standard handling of the onKeyDown event in material-ui for navigating the list of MenuItem. If you click the option to create a new playlist and try to enter its name, pressing the first letter of each MenuItem will trigger an event to focus on that item, which removes focus from the text box so no letter is entered. So, for example, if you have a playlist named "Playlist", pressing "p" in the textfield will not work. 
stopPropogation for onKeyDown shoud fix it.