### PR TITLE
added pointer-events:none to the .MediaListRow-image

### DIFF
--- a/src/components/MediaList/Row.css
+++ b/src/components/MediaList/Row.css
@@ -40,6 +40,7 @@
 .MediaListRow-image {
   max-width: 100%;
   max-height: 100%;
+  pointer-events: none;
 }
 
 .MediaListRow-data {


### PR DESCRIPTION
If you drag a track by clicking on a preview image, it opens that image in a new tab instead of moving the track. This should fix it.