### PR TITLE
Reimplement media Progress bar in JS

### DIFF
--- a/src/components/HeaderBar/Progress.css
+++ b/src/components/HeaderBar/Progress.css
@@ -1,12 +1,5 @@
 .Progress-fill {
   background: var(--highlight-color);
   height: 100%;
-  width: 100%;
-  transform: scaleX(0);
-  transform-origin: top left;
-  transition: transform 0s linear;
-}
-
-.Progress-fill:dir(rtl) {
-  transform-origin: top right;
+  width: 0;
 }

--- a/src/components/HeaderBar/index.js
+++ b/src/components/HeaderBar/index.js
@@ -13,8 +13,7 @@ const HeaderBar = ({
   title,
   dj,
   media,
-  mediaProgress,
-  mediaTimeRemaining,
+  mediaStartTime,
   volume,
   muted,
   onVolumeChange,
@@ -41,8 +40,8 @@ const HeaderBar = ({
     {media && (
       <Progress
         className="HeaderBar-progress"
-        currentProgress={mediaProgress}
-        timeRemaining={mediaTimeRemaining}
+        duration={media.duration}
+        startTime={mediaStartTime}
       />
     )}
     <div className="HeaderBar-volume">
@@ -66,8 +65,7 @@ HeaderBar.propTypes = {
 
   dj: PropTypes.object,
   media: PropTypes.object,
-  mediaProgress: PropTypes.number.isRequired,
-  mediaTimeRemaining: PropTypes.number.isRequired,
+  mediaStartTime: PropTypes.number,
   volume: PropTypes.number,
   muted: PropTypes.bool,
 

--- a/src/containers/HeaderBar.js
+++ b/src/containers/HeaderBar.js
@@ -2,18 +2,12 @@ import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { setVolume, mute, unmute } from '../actions/PlaybackActionCreators';
 import { toggleRoomHistory, toggleAbout } from '../actions/OverlayActionCreators';
-import {
-  djSelector,
-  mediaSelector,
-  mediaProgressSelector,
-  timeRemainingSelector,
-} from '../selectors/boothSelectors';
+import { djSelector, mediaSelector, startTimeSelector } from '../selectors/boothSelectors';
 import { volumeSelector, isMutedSelector } from '../selectors/settingSelectors';
 import HeaderBar from '../components/HeaderBar';
 
 const mapStateToProps = createStructuredSelector({
-  mediaProgress: mediaProgressSelector,
-  mediaTimeRemaining: timeRemainingSelector,
+  mediaStartTime: startTimeSelector,
   media: mediaSelector,
   dj: djSelector,
   volume: volumeSelector,

--- a/src/selectors/boothSelectors.js
+++ b/src/selectors/boothSelectors.js
@@ -39,19 +39,6 @@ export const timeRemainingSelector = createSelector(
   (duration, elapsed) => (duration > 0 ? duration - elapsed : 0),
 );
 
-export const mediaProgressSelector = createSelector(
-  mediaDurationSelector,
-  timeElapsedSelector,
-  (duration, elapsed) => (
-    duration
-      // Ensure that the result is between 0 and 1
-      // It can be outside this range if a network or server hiccup
-      // results in an advance event getting delayed.
-      ? Math.max(0, Math.min(1, elapsed / duration))
-      : 0
-  ),
-);
-
 export const djSelector = createSelector(
   baseSelector,
   usersSelector,


### PR DESCRIPTION
The CSS animation approach was paused by browsers when the tab is not
visible, and didn't catch up correctly when the tab is refocused. With
`requestAnimationFrame` we can still be efficient but also be very
accurate by recalculating the exact elapsed percentage on each render.

closes #2135