### PR TITLE
Use CSS grids for media lists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,7 @@
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^12.0.0",
         "@testing-library/user-event": "^13.1.9",
-        "autoprefixer": "^10.3.1",
+        "autoprefixer": "^10.4.0",
         "babel-loader": "^8.1.0",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",
     "@testing-library/user-event": "^13.1.9",
-    "autoprefixer": "^10.3.1",
+    "autoprefixer": "^10.4.0",
     "babel-loader": "^8.1.0",
     "babel-plugin-dynamic-import-node": "^2.3.3",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -3,6 +3,7 @@
 module.exports = {
   plugins: [
     // TODO replace by postcss-preset-env when its next release is out
+    'autoprefixer',
     'postcss-nesting',
     'postcss-logical',
     'postcss-dir-pseudo-class',

--- a/src/components/MediaList/Row.css
+++ b/src/components/MediaList/Row.css
@@ -1,12 +1,19 @@
 :root {
-  --media-list-row-height: 56px;
-  --media-list-row-icon-width: 50px;
-  --unpadded-media-list-row-height: calc(var(--media-list-row-height) - 14px);
+  --media-row-height: 56px;
+  --media-row-thumb-width: 55px;
+  --media-row-duration-width: 70px;
+  --media-row-icon-width: 50px;
+  --unpadded-media-row-height: calc(var(--media-row-height) - 14px);
 }
 
 .MediaListRow {
-  height: var(--media-list-row-height);
-  line-height: var(--media-list-row-height);
+  display: grid;
+  grid-template-columns: var(--media-row-thumb-width) auto var(--media-row-duration-width) var(--media-row-icon-width);
+  grid-template-rows: var(--media-row-height);
+  grid-gap: 15px;
+  padding: 0 15px;
+  height: var(--media-row-height);
+  line-height: var(--media-row-height);
   position: relative;
   background: var(--media-list-color);
   border-bottom: 1px solid var(--divider-color);
@@ -26,15 +33,11 @@
 }
 
 .MediaListRow-loader {
-  margin: 0 15px;
 }
 
 .MediaListRow-thumb {
   height: 100%;
-  width: 55px;
-  margin: 0 15px;
   padding: 7px 0;
-  float: inline-start;
 }
 
 .MediaListRow-image {
@@ -44,15 +47,8 @@
 }
 
 .MediaListRow-data {
-  height: 100%;
   padding: 7px 0;
-  line-height: var(--unpadded-media-list-row-height);
-  width:
-    calc(
-      100% - var(--media-list-thumb-width) - var(--media-list-row-icon-width)
-      - var(--media-list-duration-width)
-    );
-  float: inline-start;
+  line-height: var(--unpadded-media-row-height);
 }
 
 .MediaListRow-artist {
@@ -77,8 +73,8 @@
 }
 
 .MediaListRow-note {
-  height: calc(var(--unpadded-media-list-row-height) / 3);
-  line-height: calc(var(--unpadded-media-list-row-height) / 3);
+  height: calc(var(--unpadded-media-row-height) / 3);
+  line-height: calc(var(--unpadded-media-row-height) / 3);
   width: calc(100% - var(--media-list-spacing));
   margin-inline-end: var(--media-list-spacing);
   overflow: hidden;
@@ -89,14 +85,10 @@
 
 .MediaListRow-duration {
   height: 100%;
-  float: inline-start;
-  width: var(--media-list-duration-width);
 }
 
 .MediaListRow-icon {
   height: 100%;
-  width: var(--media-list-row-icon-width);
-  float: inline-start;
   display: flex;
   align-items: center;
 }

--- a/src/components/PlaylistManager/SearchResults/SearchResultRow.js
+++ b/src/components/PlaylistManager/SearchResults/SearchResultRow.js
@@ -25,7 +25,7 @@ function SearchResultRow({
   return (
     <MediaRowBase
       media={media}
-      className={className}
+      className={cx(className, 'SearchResultRow')}
       style={style}
       onClick={onClick}
     >

--- a/src/components/PlaylistManager/SearchResults/index.css
+++ b/src/components/PlaylistManager/SearchResults/index.css
@@ -27,8 +27,11 @@
   font-weight: bold;
 }
 
+.SearchResultRow {
+  grid-template-columns: var(--media-row-thumb-width) auto var(--media-row-duration-width);
+}
+
 .SearchResultRow-data {
-  width: calc(100% - var(--media-list-thumb-width) - var(--media-list-duration-width));
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
@@ -49,7 +52,7 @@
 
 .SearchResultRow-inPlaylists {
   width: 100%;
-  line-height: calc(56px / 3);
+  line-height: calc(var(--media-row-height) / 3);
   height: 34%;
   font-size: 80%;
 }

--- a/src/components/PlaylistManager/index.css
+++ b/src/components/PlaylistManager/index.css
@@ -14,11 +14,6 @@
 .PlaylistManager-menu {
   width: 33%; /* 25% of total screen width */
   float: inline-start;
-
-  /* menu would be larger than 300px */
-  @media (min-width: 1200px) {
-    width: 300px;
-  }
 }
 
 .PlaylistManager-panel {
@@ -26,9 +21,14 @@
   inset-inline-start: 33%;
   inset-inline-end: 0;
   height: 100%;
+}
 
-  /* menu would be larger than 300px */
-  @media (min-width: 1200px) {
+/* menu would be larger than 300px */
+@media (min-width: 1200px) {
+  .PlaylistManager-menu {
+    width: 300px;
+  }
+  .PlaylistManager-panel {
     inset-inline-start: 300px;
   }
 }

--- a/src/components/RoomHistory/Row.css
+++ b/src/components/RoomHistory/Row.css
@@ -1,58 +1,40 @@
 :root {
-  --history-list-thumb-width: 85px;
-  --history-list-user-width: 130px;
-  --history-list-time-width: 170px;
-  --history-list-votes-width: 250px;
-  --history-list-not-song-width:
-    calc(
-      var(--history-list-thumb-width) +
-      var(--history-list-time-width) +
-      var(--history-list-user-width) +
-      var(--history-list-votes-width) +
-      var(--media-list-row-icon-width)
-    );
+  --history-row-user-width: 115px;
+  --history-row-time-width: 155px;
+  --history-row-votes-width: 220px;
+}
+
+.HistoryRow {
+  grid-template-columns:
+    var(--media-row-thumb-width)
+    auto
+    var(--history-row-votes-width)
+    var(--history-row-user-width)
+    var(--history-row-time-width)
+    var(--media-row-icon-width);
 }
 
 .HistoryRow-song {
   font-size: 1em;
-  height: 100%;
-  float: inline-start;
-  width: calc(100% - var(--media-list-spacing) - var(--history-list-not-song-width));
-  margin-inline-end: var(--media-list-spacing);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.HistoryRow-votes {
-  height: 100%;
-  float: inline-start;
-  width: var(--history-list-votes-width);
-}
-
 .HistoryRow-icon {
-  height: 100%;
-  width: var(--media-list-row-icon-width);
-  float: inline-start;
   display: flex;
   align-items: center;
+  justify-content: center;
 }
 
 .HistoryRow-user {
-  height: 100%;
-  float: inline-start;
-  width: var(--history-list-user-width);
-  text-align: right;
+  text-align: end;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .HistoryRow-time {
-  height: 100%;
-  float: inline-start;
   text-align: end;
-  padding-right: 20px;
   color: var(--muted-text-color);
-  width: var(--history-list-time-width);
 }

--- a/src/sources/youtube/PlaylistRow.css
+++ b/src/sources/youtube/PlaylistRow.css
@@ -2,12 +2,12 @@
   --yt-import-button-width: 54px;
 }
 
+.src-youtube-PlaylistRow {
+  grid-template-columns: var(--media-row-thumb-width) auto var(--yt-import-button-width);
+}
+
 .src-youtube-PlaylistRow-info {
-  height: 100%;
   line-height: 1.4;
-  float: left;
-  width: calc(100% - var(--media-list-thumb-width) - var(--media-list-spacing) - var(--yt-import-button-width));
-  margin-right: var(--media-list-spacing);
 }
 
 .src-youtube-PlaylistRow-name {
@@ -20,12 +20,9 @@
 .src-youtube-PlaylistRow-size {
   font-size: 85%;
   color: #777;
-  float: left;
 }
 
 .src-youtube-PlaylistRow-import {
   height: 100%;
   line-height: 1; /* .MediaListRow sets this to 54px but we don't need that */
-  float: left;
-  width: var(--yt-import-button-width);
 }

--- a/src/vars.css
+++ b/src/vars.css
@@ -37,8 +37,6 @@
 
   /* Playlist colours & sizing */
   --media-list-spacing: 3%;
-  --media-list-thumb-width: 85px;
-  --media-list-duration-width: 70px;
   --media-list-color: transparent;
 
   /* TODO Name this in some other way. It's used as the menu item focus colour


### PR DESCRIPTION
This saves a lot of calculating widths that we used to do with flexbox.

The history used to use floats while most other lists were using flexbox. Now the base MediaList sets up a grid that works for multiple uses, and the columns can be overridden by specific implementations. There is less duplicated flexbox work now and the lists are more consistent.

playlist
![image](https://user-images.githubusercontent.com/1006268/141632344-8cb25874-4538-4b8a-83d4-8ad37ebf58b8.png)

play history
![image](https://user-images.githubusercontent.com/1006268/141632206-fae4e278-2f32-4e3c-96f4-e5dfe3ec382a.png)

search results
![image](https://user-images.githubusercontent.com/1006268/141632053-ad3916ae-2314-4397-a0b9-6e0812bcb4e8.png)

importing from a youtube channel
![image](https://user-images.githubusercontent.com/1006268/141631815-dedb1450-b50f-4618-993e-f121cec79078.png)

importing from a youtube playlist
![image](https://user-images.githubusercontent.com/1006268/141631515-6bb7afad-9f0d-4d66-b47e-e3605d1347ae.png)
