### PR TITLE
Use server-default artist/title when adding search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+This release requires a server using üWave Core 0.5.0-alpha.8 or higher.
+
+Features:
+ * **Breaking:** Use the server-default artist/title when adding search results. (#2359)
+
 ## 2.0.0-alpha.8 / 23 May 2022
 While this is an alpha release, new servers should use this rather than an older "stable" version.
 

--- a/src/actions/PlaylistActionCreators.js
+++ b/src/actions/PlaylistActionCreators.js
@@ -372,6 +372,10 @@ export function deletePlaylist(playlistID) {
   };
 }
 
+/**
+ * @param {PlaylistItemDesc[]} items - The items to add.
+ * @param {{ x: number, y: number }} position - Where to show the menu.
+ */
 export function addMediaMenu(items, position) {
   return (dispatch, getState) => {
     const playlists = playlistsSelector(getState());
@@ -413,10 +417,22 @@ export function addMediaComplete(playlistID, newSize, insert) {
 }
 
 /**
- * Keep only the playlist item properties that are necessary to add an item to
- * a playlist. The rest ("thumbnail" etc) is left out for smaller payloads.
+ * @typedef {{
+ *   sourceType: string,
+ *   sourceID: string,
+ *   artist?: string,
+ *   title?: string,
+ *   start?: number,
+ *   end?: number,
+ * }} PlaylistItemDesc
  */
 
+/**
+ * Keep only the playlist item properties that are necessary to add an item to
+ * a playlist. The rest ("thumbnail" etc) is left out for smaller payloads.
+ *
+ * @param {PlaylistItemDesc} item
+ */
 function minimizePlaylistItem(item) {
   return {
     sourceType: item.sourceType,
@@ -428,6 +444,11 @@ function minimizePlaylistItem(item) {
   };
 }
 
+/**
+ * @param {{ _id: string }} playlist
+ * @param {PlaylistItemDesc[]} items
+ * @param {string|null} [afterID]
+ */
 export function addMedia(playlist, items, afterID = null) {
   const payload = {
     items: items.map(minimizePlaylistItem),

--- a/src/components/MediaList/AddToPlaylistAction.js
+++ b/src/components/MediaList/AddToPlaylistAction.js
@@ -1,3 +1,4 @@
+import omit from 'just-omit';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
@@ -10,19 +11,29 @@ const {
   useCallback,
 } = React;
 
-function AddToPlaylistAction({ media }) {
+/**
+ * @param {object} props
+ * @param {object} props.media
+ * @param {boolean} [props.withCustomMeta] - Use the artist/title that is stored on this item.
+ *   Set to false when dealing with eg. search results, to make the server look up a default
+ *   artist/title for this media.
+ */
+function AddToPlaylistAction({ media, withCustomMeta = true }) {
   const { selection } = useMediaListContext();
 
   const dispatch = useDispatch();
   const handleClick = useCallback((event) => {
-    const selectedItems = selection.isSelected(media) ? selection.get() : [media];
+    let selectedItems = selection.isSelected(media) ? selection.get() : [media];
+    if (!withCustomMeta) {
+      selectedItems = selectedItems.map((item) => omit(item, ['artist', 'title']));
+    }
     const rect = event.target.getBoundingClientRect();
 
     dispatch(addMediaMenu(selectedItems, {
       x: rect.left,
       y: rect.top,
     }));
-  }, [dispatch, selection, media]);
+  }, [dispatch, selection, media, withCustomMeta]);
 
   return (
     <MediaAction onClick={handleClick}>
@@ -33,6 +44,7 @@ function AddToPlaylistAction({ media }) {
 
 AddToPlaylistAction.propTypes = {
   media: PropTypes.object.isRequired,
+  withCustomMeta: PropTypes.bool,
 };
 
 export default AddToPlaylistAction;

--- a/src/components/MediaList/MediaRowBase.js
+++ b/src/components/MediaList/MediaRowBase.js
@@ -31,6 +31,7 @@ function MediaRowBase({
   const [, drag, connectDragPreview] = useDrag({
     type: dragType,
     item: () => ({
+      type: dragType,
       media: selected ? selection.get() : [media],
     }),
   });

--- a/src/components/PlaylistManager/Menu/Row.js
+++ b/src/components/PlaylistManager/Menu/Row.js
@@ -1,11 +1,12 @@
 import cx from 'clsx';
+import omit from 'just-omit';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useDrop } from 'react-dnd';
 import CircularProgress from '@mui/material/CircularProgress';
 import MenuItem from '@mui/material/MenuItem';
 import ActiveIcon from '@mui/icons-material/Check';
-import { MEDIA } from '../../../constants/DDItemTypes';
+import { MEDIA, SEARCH_RESULT } from '../../../constants/DDItemTypes';
 
 const itemClasses = {
   root: 'PlaylistMenuRow',
@@ -20,10 +21,14 @@ function PlaylistRow({
   onAddToPlaylist,
 }) {
   const [{ isOver }, drop] = useDrop(() => ({
-    accept: MEDIA,
-    drop(item, monitor) {
-      const { media } = monitor.getItem();
-      onAddToPlaylist(playlist, media);
+    accept: [MEDIA, SEARCH_RESULT],
+    drop(_item, monitor) {
+      const { media, type } = monitor.getItem();
+      if (type === SEARCH_RESULT) {
+        onAddToPlaylist(playlist, media.map((item) => omit(item, ['artist', 'title'])));
+      } else {
+        onAddToPlaylist(playlist, media);
+      }
     },
     collect(monitor) {
       return { isOver: monitor.isOver() };

--- a/src/components/PlaylistManager/SearchResults/SearchResultActions.js
+++ b/src/components/PlaylistManager/SearchResults/SearchResultActions.js
@@ -17,7 +17,7 @@ function SearchResultActions({ className, media }) {
       onClick={dontBubble}
     >
       <PreviewMediaAction media={media} />
-      <AddToPlaylistAction media={media} />
+      <AddToPlaylistAction media={media} withCustomMeta={false} />
     </div>
   );
 }

--- a/src/components/PlaylistManager/SearchResults/SearchResultRow.js
+++ b/src/components/PlaylistManager/SearchResults/SearchResultRow.js
@@ -1,6 +1,7 @@
 import cx from 'clsx';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { SEARCH_RESULT } from '../../../constants/DDItemTypes';
 import MediaRowBase from '../../MediaList/MediaRowBase';
 import MediaDuration from '../../MediaList/MediaDuration';
 import MediaThumbnail from '../../MediaList/MediaThumbnail';
@@ -28,6 +29,7 @@ function SearchResultRow({
       className={cx(className, 'SearchResultRow')}
       style={style}
       onClick={onClick}
+      dragType={SEARCH_RESULT}
     >
       <MediaThumbnail url={media.thumbnail} />
       <div className={cx('MediaListRow-data', 'SearchResultRow-data', note && 'has-note')}>

--- a/src/constants/DDItemTypes.js
+++ b/src/constants/DDItemTypes.js
@@ -1,3 +1,4 @@
 export const MEDIA = 'dd/MEDIA';
+export const SEARCH_RESULT = 'dd/SEARCH_RESULT';
 export const HISTORY_ENTRY = 'dd/HISTORY_ENTRY';
 export const WAITLIST_USER = 'dd/WAITLIST_USER';

--- a/src/containers/DragLayer.js
+++ b/src/containers/DragLayer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useDragLayer } from 'react-dnd';
-import { MEDIA, WAITLIST_USER } from '../constants/DDItemTypes';
+import { MEDIA, SEARCH_RESULT, WAITLIST_USER } from '../constants/DDItemTypes';
 import MediaDragPreview from '../components/MediaList/MediaDragPreview';
 
 function DragLayerContainer() {
@@ -20,6 +20,7 @@ function DragLayerContainer() {
   function renderPreview() {
     switch (type) {
       case MEDIA:
+      case SEARCH_RESULT:
         return <MediaDragPreview items={items} currentOffset={currentOffset} />;
       case WAITLIST_USER:
         return null;

--- a/src/sources/youtube/ImportRow.js
+++ b/src/sources/youtube/ImportRow.js
@@ -50,4 +50,3 @@ ImportRow.propTypes = {
 };
 
 export default ImportRow;
-

--- a/src/sources/youtube/ImportRow.js
+++ b/src/sources/youtube/ImportRow.js
@@ -1,0 +1,53 @@
+import cx from 'clsx';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { SEARCH_RESULT } from '../../constants/DDItemTypes';
+import MediaRowBase from '../../components/MediaList/MediaRowBase';
+import MediaDuration from '../../components/MediaList/MediaDuration';
+import MediaThumbnail from '../../components/MediaList/MediaThumbnail';
+import AddToPlaylistAction from '../../components/MediaList/AddToPlaylistAction';
+import PreviewMediaAction from '../../components/MediaList/PreviewMediaAction';
+
+function ImportRow({
+  className,
+  media,
+  style,
+  onClick,
+}) {
+  return (
+    <MediaRowBase
+      media={media}
+      className={cx(className, 'ImportRow')}
+      style={style}
+      onClick={onClick}
+      dragType={SEARCH_RESULT}
+    >
+      <MediaThumbnail url={media.thumbnail} />
+      <div className={cx('MediaListRow-data')}>
+        <div className="MediaListRow-artist" title={media.artist}>
+          {media.artist}
+        </div>
+        <div className="MediaListRow-title" title={media.title}>
+          {media.title}
+        </div>
+      </div>
+      <div className="MediaListRow-duration">
+        <MediaDuration media={media} />
+      </div>
+      <div className="MediaActions MediaListRow-actions">
+        <PreviewMediaAction media={media} />
+        <AddToPlaylistAction media={media} withCustomMeta={false} />
+      </div>
+    </MediaRowBase>
+  );
+}
+
+ImportRow.propTypes = {
+  className: PropTypes.string,
+  style: PropTypes.object, // from virtual list positioning
+  media: PropTypes.object,
+  onClick: PropTypes.func,
+};
+
+export default ImportRow;
+

--- a/src/sources/youtube/PlaylistPanel.js
+++ b/src/sources/youtube/PlaylistPanel.js
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import Tooltip from '@mui/material/Tooltip';
 import IconButton from '@mui/material/IconButton';
 import ImportIcon from '@mui/icons-material/PlaylistAdd';
-import MediaList from '../../components/MediaList';
+import MediaListBase from '../../components/MediaList/BaseMediaList';
 import ImportPanelHeader from '../../components/PlaylistManager/Import/ImportPanelHeader';
+import ImportRow from './ImportRow';
 
 function YouTubeImportPlaylistPanel({
   importingPlaylist,
@@ -30,9 +31,11 @@ function YouTubeImportPlaylistPanel({
           </Tooltip>
         </div>
       </ImportPanelHeader>
-      <MediaList
+      <MediaListBase
         className="ImportPanel-body"
         media={importingPlaylistItems}
+        listComponent="div"
+        rowComponent={ImportRow}
       />
     </div>
   );

--- a/src/sources/youtube/index.css
+++ b/src/sources/youtube/index.css
@@ -1,3 +1,8 @@
 @import "./Player.css";
 @import "./PlaylistPanel.css";
 @import "./PlaylistRow.css";
+
+/* TODO this should be a shared style */
+.ImportRow {
+  grid-template-columns: var(--media-row-thumb-width) auto var(--media-row-duration-width);
+}


### PR DESCRIPTION
Closes #1855

When adding media from search we no longer submit the artist and title
to the server. This lets search implementations reply with original
metadata, and then we can derive an appropriate artist+title from that
when the media is actually added.

This will require an updated server.