### PR TITLE
Fix props from previous media lingering in edit media dialog

### DIFF
--- a/src/containers/EditMediaDialog.jsx
+++ b/src/containers/EditMediaDialog.jsx
@@ -17,6 +17,7 @@ function EditMediaDialogContainer() {
     <DialogCloseAnimation delay={DIALOG_ANIMATION_DURATION}>
       {media && (
         <EditMediaDialog
+          key={media._id}
           open={open}
           media={media}
           onEditedMedia={onEditedMedia}


### PR DESCRIPTION
The first thing you edited would continue to show up. Now the whole thing is blown away when you click a different media.
