### PR TITLE
Close login dialog after login, fixes #2771

### DIFF
--- a/src/actions/LoginActionCreators.js
+++ b/src/actions/LoginActionCreators.js
@@ -71,7 +71,7 @@ export function register({
         type: REGISTER_COMPLETE,
         payload: { user },
       });
-      dispatch(login({ email, password }));
+      return dispatch(login({ email, password }));
     },
     onError: registerCompleteError,
   });

--- a/src/components/Dialogs/LoginDialog/LoginForm.jsx
+++ b/src/components/Dialogs/LoginDialog/LoginForm.jsx
@@ -17,6 +17,7 @@ const { useCallback, useState } = React;
 
 function LoginForm({
   supportsSocialAuth,
+  onCloseDialog,
   onLogin,
   onOpenResetPasswordDialog,
 }) {
@@ -26,7 +27,10 @@ function LoginForm({
 
   const handleSubmit = useAsyncCallback(async (event) => {
     event.preventDefault();
-    await onLogin({ email, password });
+    const result = await onLogin({ email, password });
+    if (!result.error) {
+      onCloseDialog();
+    }
   }, [onLogin, email, password]);
 
   const handleResetPassword = useCallback((event) => {
@@ -115,6 +119,7 @@ function LoginForm({
 
 LoginForm.propTypes = {
   supportsSocialAuth: PropTypes.bool,
+  onCloseDialog: PropTypes.func,
   onLogin: PropTypes.func,
   onOpenResetPasswordDialog: PropTypes.func,
 };

--- a/src/components/Dialogs/LoginDialog/RegisterForm.jsx
+++ b/src/components/Dialogs/LoginDialog/RegisterForm.jsx
@@ -24,6 +24,7 @@ function RegisterForm({
   useReCaptcha,
   reCaptchaSiteKey,
   supportsSocialAuth,
+  onCloseDialog,
   onRegister,
 }) {
   const { t } = useTranslator();
@@ -47,8 +48,9 @@ function RegisterForm({
       password,
       grecaptcha: captchaResponse,
     });
+    onCloseDialog();
   }, [
-    t, onRegister,
+    t, onRegister, onCloseDialog,
     username, email, password, passwordConfirmation, captchaResponse,
   ]);
 
@@ -181,6 +183,7 @@ RegisterForm.propTypes = {
   useReCaptcha: PropTypes.bool,
   reCaptchaSiteKey: PropTypes.string,
   supportsSocialAuth: PropTypes.bool,
+  onCloseDialog: PropTypes.func,
   onRegister: PropTypes.func,
 };
 


### PR DESCRIPTION
The error happened because the dialog state is kept in redux, and it's not closed by the action creators now.

I think it makes sense for the dialog to close itself, and probably eventually I would move dialog state out of redux.

This is a little bit clunky because login was already ported to an async thunk and `onLogin` doesn't throw an error on failure.