### PR TITLE
Keep playlist items after /api/now refetch, fixes #2768

### DIFF
--- a/src/reducers/playlists.ts
+++ b/src/reducers/playlists.ts
@@ -312,9 +312,8 @@ const slice = createSlice({
             const activePlaylist = state.playlists[payload.activePlaylist];
             // Probably overly defensive, but avoid a crash if we got inconsistent data
             const size = activePlaylist ? activePlaylist.size : 1;
-            const playlistItems = Array(size).fill(null);
-            playlistItems[0] = item;
-            state.playlistItems[payload.activePlaylist] = playlistItems;
+            state.playlistItems[payload.activePlaylist] ??= Array(size).fill(null);
+            state.playlistItems[payload.activePlaylist]![0] = item;
           }
           state.activePlaylistID = payload.activePlaylist;
           // Select the first playlist by default if there is no active playlist.


### PR DESCRIPTION
After fetching /api/now, this code unconditionally overwrote the active playlist's items with only the first one.

/api/now is now re-fetched if you were inactive for a bit to address inconsistency. This causes the playlist items to be cleared and then immediately re-fetched if you have the playlist manager open.

I think it's probably a good idea to refetch playlist items in this case, as they may be out of date, especially if you made modifications on another device. But the flicker is no good. So first fix that, and the rest can be done later.