### PR TITLE
Do not hide playlist items when playlist meta is loading

### DIFF
--- a/src/components/PlaylistManager/Panel/index.tsx
+++ b/src/components/PlaylistManager/Panel/index.tsx
@@ -41,13 +41,13 @@ function PlaylistPanel(props: PlaylistPanelProps) {
   const size = media.length;
 
   let list;
-  if (loading) {
+  if (loading && size > 0 && media.every((item) => item == null)) {
     list = (
       <div className="PlaylistPanel-loading">
         <CircularProgress size="100%" />
       </div>
     );
-  } else if (isFiltered && media.length === 0) {
+  } else if (isFiltered && size === 0) {
     list = <PlaylistFilterEmpty />;
   } else if (size === 0) {
     list = <PlaylistEmpty />;

--- a/src/reducers/playlists.ts
+++ b/src/reducers/playlists.ts
@@ -486,8 +486,6 @@ const slice = createSlice({
         return initialState;
       })
       .addCase(activatePlaylist.pending, (state, action) => {
-        // TODO use a different property here so we can show a loading icon on
-        // the "Active" button only, instead of on top of the entire playlist
         const playlist = state.playlists[action.meta.arg];
         if (playlist != null) {
           playlist.loading = true;
@@ -500,8 +498,6 @@ const slice = createSlice({
         }
       })
       .addCase(activatePlaylist.fulfilled, (state, action) => {
-        // TODO use a different property here so we can show a loading icon on
-        // the "Active" button only, instead of on top of the entire playlist
         const playlist = state.playlists[action.meta.arg];
         if (playlist != null) {
           playlist.loading = false;


### PR DESCRIPTION
I noticed this when playing with #2972 but it actually happens in many situations.

When a playlist is in the loading state, that doesn't actually mean that its items should not be accessible. For example, a playlist is loading while you're activating it. It doesn't make sense to then show a loading spinner covering the whole playlist manager. We already show a loading icon on the playlist name and that's indication enough.

With this change, playlist deletion / activation / selection / adding items don't place a loading spinner on the whole playlist panel. Only when the playlist is in the loading state *and* doesn't have any items loaded yet, do we show the whole-screen spinner.