### PR TITLE
Change "modern" `@mui` usage to default mui

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -16,16 +16,6 @@ export default defineConfig({
     // For the prerender plugin
     proxySsrExternalModules: true,
   },
-  resolve: {
-    alias: {
-      '@mui/base': '@mui/base/modern',
-      '@mui/icons-material': '@mui/icons-material/esm',
-      '@mui/material': '@mui/material/modern',
-      '@mui/styled-engine': '@mui/styled-engine/modern',
-      '@mui/system': '@mui/system/modern',
-      '@mui/utils': '@mui/utils/modern',
-    },
-  },
   build: {
     outDir: 'npm/public/',
     assetsDir: 'static',


### PR DESCRIPTION
AFAICT the content of these modules is now identical!

And where it's not, I don't think the difference will be as substantial now with the baseline support in MUI already being modern browsers. It's not worth the potential weirdness of changing resolution.
