### PR TITLE
Revert "Change "modern" `@mui` usage to default mui (#3053)"

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -16,6 +16,16 @@ export default defineConfig({
     // For the prerender plugin
     proxySsrExternalModules: true,
   },
+  resolve: {
+    alias: {
+      '@mui/base': '@mui/base/modern',
+      '@mui/icons-material': '@mui/icons-material/esm',
+      '@mui/material': '@mui/material/modern',
+      '@mui/styled-engine': '@mui/styled-engine/modern',
+      '@mui/system': '@mui/system/modern',
+      '@mui/utils': '@mui/utils/modern',
+    },
+  },
   build: {
     outDir: 'npm/public/',
     assetsDir: 'static',


### PR DESCRIPTION
This reverts commit 5d48b7eb2433d23ca296984f8f976a2c090bb45d.
