### PR TITLE
Fix action names when leaving waitlist

### DIFF
--- a/src/reducers/waitlist.ts
+++ b/src/reducers/waitlist.ts
@@ -25,7 +25,7 @@ export const joinWaitlist = createAsyncThunk('waitlist/join', async (_: void, ap
   }]);
 });
 
-export const leaveWaitlist = createAsyncThunk('waitlist/join', async (_: void, api) => {
+export const leaveWaitlist = createAsyncThunk('waitlist/leave', async (_: void, api) => {
   const userID = currentUserIDSelector(api.getState());
   await uwFetch<{ data: string[] }>([`/waitlist/${userID}`, { method: 'delete' }]);
 });


### PR DESCRIPTION
These are not actually used to respond to anything, so it wasn't a
user-visible bug.
