### PR TITLE
ci: only run on default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [default]
+  pull_request:
+    branches: [default]
 
 permissions:
   contents: read


### PR DESCRIPTION
Because I mostly use PRs from branches on this repo, running it on all pushes duplicates work, costing a lot of resource.