### PR TITLE
pkg: remove `npm run clean` script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -121,7 +121,6 @@
         "jsonapi-typescript": "^0.1.3",
         "lightningcss": "^1.28.1",
         "p-map": "^7.0.0",
-        "rimraf": "^5.0.0",
         "stylelint": "^16.11.0",
         "stylelint-config-standard": "^36.0.1",
         "twemoji-emojis": "^14.1.0",
@@ -10734,22 +10733,6 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
-      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^10.3.7"
-      },
-      "bin": {
-        "rimraf": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rollup": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "jsonapi-typescript": "^0.1.3",
     "lightningcss": "^1.28.1",
     "p-map": "^7.0.0",
-    "rimraf": "^5.0.0",
     "stylelint": "^16.11.0",
     "stylelint-config-standard": "^36.0.1",
     "twemoji-emojis": "^14.1.0",
@@ -138,11 +137,10 @@
     "url": "git+https://github.com/u-wave/web.git"
   },
   "scripts": {
-    "clean": "rimraf npm/public",
     "dev": "vite",
     "lint": "eslint --cache . && stylelint --cache src/**/*.css",
     "postpublish": "npm publish -w ./npm",
-    "prerelease": "npm run clean && npm test && npm run prod",
+    "prerelease": "npm test && npm run prod",
     "prod": "vite build",
     "serve": "u-wave-web",
     "start": "npm run dev",


### PR DESCRIPTION
`vite build` does this already, so it's really not been needed for a
long time.
