### PR TITLE
Some tweaks to make React Compiler happier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -112,7 +112,7 @@
         "eslint-plugin-jest-dom": "^5.5.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-react-compiler": "19.0.0-beta-714736e-20250131",
+        "eslint-plugin-react-compiler": "^19.1.0-rc.2",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-testing-library": "^7.2.1",
         "get-port": "^7.0.0",
@@ -6002,9 +6002,9 @@
       }
     },
     "node_modules/eslint-plugin-react-compiler": {
-      "version": "19.0.0-beta-714736e-20250131",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-compiler/-/eslint-plugin-react-compiler-19.0.0-beta-714736e-20250131.tgz",
-      "integrity": "sha512-iTPUaHzvBejGqicSwZLCDBgWBxLzU1Dvqjs31loNoOPRnsey5dcOupaZajECKVvXmB1wcbIWNp6/VR5+dM9d6w==",
+      "version": "19.1.0-rc.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-compiler/-/eslint-plugin-react-compiler-19.1.0-rc.2.tgz",
+      "integrity": "sha512-oKalwDGcD+RX9mf3NEO4zOoUMeLvjSvcbbEOpquzmzqEEM2MQdp7/FY/Hx9NzmUwFzH1W9SKTz5fihfMldpEYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "eslint-plugin-jest-dom": "^5.5.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-compiler": "19.0.0-beta-714736e-20250131",
+    "eslint-plugin-react-compiler": "^19.1.0-rc.2",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-testing-library": "^7.2.1",
     "get-port": "^7.0.0",

--- a/src/components/SettingsManager/NotificationSettings.tsx
+++ b/src/components/SettingsManager/NotificationSettings.tsx
@@ -1,9 +1,8 @@
-import { useCallback } from 'react';
 import { useTranslator } from '@u-wave/react-translate';
 import FormGroup from '@mui/material/FormGroup';
 import Switch from '@mui/material/Switch';
-import SettingControl from './SettingControl';
 import { useSelector } from '../../hooks/useRedux';
+import SettingControl from './SettingControl';
 
 type NotificationSettingsProps = {
   onSettingChange: (name: string, value: boolean) => void,
@@ -11,19 +10,6 @@ type NotificationSettingsProps = {
 function NotificationSettings({ onSettingChange }: NotificationSettingsProps) {
   const { t } = useTranslator();
   const notifications = useSelector((state) => state.settings.notifications);
-
-  function useToggleSetting(name: string) {
-    return useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
-      onSettingChange(name, event.target.checked);
-      // `name` is a constant.
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [onSettingChange]);
-  }
-
-  const onToggleUserJoin = useToggleSetting('notifications.userJoin');
-  const onToggleUserLeave = useToggleSetting('notifications.userLeave');
-  const onToggleUserNameChanged = useToggleSetting('notifications.userNameChanged');
-  const onToggleSkip = useToggleSetting('notifications.skip');
 
   return (
     <div>
@@ -34,28 +20,36 @@ function NotificationSettings({ onSettingChange }: NotificationSettingsProps) {
           <Switch
             color="primary"
             checked={notifications.userJoin}
-            onChange={onToggleUserJoin}
+            onChange={(_event, checked) => {
+              onSettingChange('notifications.userJoin', checked);
+            }}
           />
         </SettingControl>
         <SettingControl label={t('settings.notifications.userLeave')}>
           <Switch
             color="primary"
             checked={notifications.userLeave}
-            onChange={onToggleUserLeave}
+            onChange={(_event, checked) => {
+              onSettingChange('notifications.userLeave', checked);
+            }}
           />
         </SettingControl>
         <SettingControl label={t('settings.notifications.userNameChanged')}>
           <Switch
             color="primary"
             checked={notifications.userNameChanged}
-            onChange={onToggleUserNameChanged}
+            onChange={(_event, checked) => {
+              onSettingChange('notifications.userNameChanged', checked);
+            }}
           />
         </SettingControl>
         <SettingControl label={t('settings.notifications.skip')}>
           <Switch
             color="primary"
             checked={notifications.skip}
-            onChange={onToggleSkip}
+            onChange={(_event, checked) => {
+              onSettingChange('notifications.skip', checked);
+            }}
           />
         </SettingControl>
       </FormGroup>

--- a/src/containers/PlaylistManagerMenu.tsx
+++ b/src/containers/PlaylistManagerMenu.tsx
@@ -40,12 +40,11 @@ function PlaylistsMenuContainer({ className }: PlaylistMenuContainerProps) {
   const onSelectSearchResults = useCallback(() => {
     dispatch(showSearchResults());
   }, [dispatch]);
+  const resetSearch = mediaSearch.reset;
   const onCloseSearchResults = useCallback(() => {
-    mediaSearch.reset();
+    resetSearch();
     dispatch(selectActivePlaylist());
-    // The `mediaSearch.reset` reference never changes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dispatch]);
+  }, [resetSearch, dispatch]);
   const onShowImportPanel = useCallback(() => {
     dispatch(showImportPanel());
   }, [dispatch]);

--- a/src/sources/soundcloud/Player.tsx
+++ b/src/sources/soundcloud/Player.tsx
@@ -78,18 +78,21 @@ function SoundCloudPlayer({
     });
   }, []);
 
+  // `seek` / `media.start` should only be taken into account when
+  // the media changes.
+  const computedSeek = useRef(0);
+  computedSeek.current = seek + media.start;
+
   useEffect(() => {
     setError(null);
     if (!audioRef.current || !audioUrl) {
-      return () => {
-        // dummy
-      };
+      return;
     }
     const audio = audioRef.current;
     audio.src = audioUrl;
     audio.play().catch(setError);
     const doSeek = () => {
-      audio.currentTime = seek + (media.start ?? 0);
+      audio.currentTime = computedSeek.current;
       audio.removeEventListener('canplaythrough', doSeek, false);
     };
     audio.addEventListener('canplaythrough', doSeek, false);
@@ -98,10 +101,6 @@ function SoundCloudPlayer({
       audio.pause();
       audio.removeEventListener('canplaythrough', doSeek, false);
     };
-
-    // `seek` / `media.start` should only be taken into account when
-    // the media changes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [audioUrl]);
 
   useEffect(() => {


### PR DESCRIPTION
Particularly, remove some exhaustive-deps exemptions. Instead, use refs
or other strategies to explicitly bypass `useEffect` dependency
tracking.
