### PR TITLE
deps: update react-abstract-autocomplete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "prop-types": "^15.6.2",
         "qs-stringify": "^1.2.0",
         "react": "^19.2.0",
-        "react-abstract-autocomplete": "^2.0.4",
+        "react-abstract-autocomplete": "^2.0.5",
         "react-async-hook": "^4.0.0",
         "react-bus": "^4.0.1",
         "react-dom": "^19.2.0",
@@ -10734,9 +10734,9 @@
       }
     },
     "node_modules/react-abstract-autocomplete": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/react-abstract-autocomplete/-/react-abstract-autocomplete-2.0.4.tgz",
-      "integrity": "sha512-/qscBlTYqLHBe2g2BGlkzHyl2ET6NgTgnGLQZZi1UsXeOXiSJVO0yhChrFxTVRNyp6NGfKv/OAIi2UtACaagkw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/react-abstract-autocomplete/-/react-abstract-autocomplete-2.0.5.tgz",
+      "integrity": "sha512-yjHwF0TOBEpr/eG1ig2VwWZBNbSjJwby21RSowfW4/JZsdc1S2YUkVY4j4GQQ7/Qq15qEfrgdUQtQR4A04KT9A==",
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "prop-types": "^15.6.2",
     "qs-stringify": "^1.2.0",
     "react": "^19.2.0",
-    "react-abstract-autocomplete": "^2.0.4",
+    "react-abstract-autocomplete": "^2.0.5",
     "react-async-hook": "^4.0.0",
     "react-bus": "^4.0.1",
     "react-dom": "^19.2.0",


### PR DESCRIPTION
Fixes a React 19 incompatibility that crashed on `@`-completions and
silently did nothing for emoji completions.
