### PR TITLE
ci: lower automatic update frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,14 @@ updates:
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
   open-pull-requests-limit: 10
   commit-message:
     prefix: "ci"
 - package-ecosystem: npm
   directories: ["/", "/npm"]
   schedule:
-    interval: weekly
+    interval: monthly
   open-pull-requests-limit: 10
   commit-message:
     prefix: "deps"
@@ -18,6 +18,8 @@ updates:
     # Minimum node.js version is updated manually
     - dependency-name: "@types/node"
   groups:
+    non-major:
+      update-types: [minor, patch]
     vite:
       patterns:
       - "@vitejs/*"


### PR DESCRIPTION
This isn't being developed actively enough to benefit from a weekly
update cadence. Let's use the slowest available cadence (monthly).

Also combine all non-major version bumps into a single PR.
