### PR TITLE
Replace MUI `<Switch />` by a simple CSS-styled `<input />`

### DIFF
--- a/src/components/SettingsManager/NotificationSettings.tsx
+++ b/src/components/SettingsManager/NotificationSettings.tsx
@@ -1,7 +1,7 @@
 import { useTranslator } from '@u-wave/react-translate';
 import FormGroup from '@mui/material/FormGroup';
-import Switch from '@mui/material/Switch';
 import { useSelector } from '../../hooks/useRedux';
+import Switch from '../Switch';
 import SettingControl from './SettingControl';
 
 type NotificationSettingsProps = {
@@ -18,37 +18,33 @@ function NotificationSettings({ onSettingChange }: NotificationSettingsProps) {
       <FormGroup>
         <SettingControl label={t('settings.notifications.userJoin')}>
           <Switch
-            color="primary"
             checked={notifications.userJoin}
-            onChange={(_event, checked) => {
-              onSettingChange('notifications.userJoin', checked);
+            onChange={(event) => {
+              onSettingChange('notifications.userJoin', event.target.checked);
             }}
           />
         </SettingControl>
         <SettingControl label={t('settings.notifications.userLeave')}>
           <Switch
-            color="primary"
             checked={notifications.userLeave}
-            onChange={(_event, checked) => {
-              onSettingChange('notifications.userLeave', checked);
+            onChange={(event) => {
+              onSettingChange('notifications.userLeave', event.target.checked);
             }}
           />
         </SettingControl>
         <SettingControl label={t('settings.notifications.userNameChanged')}>
           <Switch
-            color="primary"
             checked={notifications.userNameChanged}
-            onChange={(_event, checked) => {
-              onSettingChange('notifications.userNameChanged', checked);
+            onChange={(event) => {
+              onSettingChange('notifications.userNameChanged', event.target.checked);
             }}
           />
         </SettingControl>
         <SettingControl label={t('settings.notifications.skip')}>
           <Switch
-            color="primary"
             checked={notifications.skip}
-            onChange={(_event, checked) => {
-              onSettingChange('notifications.skip', checked);
+            onChange={(event) => {
+              onSettingChange('notifications.skip', event.target.checked);
             }}
           />
         </SettingControl>

--- a/src/components/SettingsManager/SettingsPanel.tsx
+++ b/src/components/SettingsManager/SettingsPanel.tsx
@@ -3,7 +3,7 @@ import { useTranslator } from '@u-wave/react-translate';
 import type { SelectChangeEvent, Theme } from '@mui/material';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import FormGroup from '@mui/material/FormGroup';
-import Switch from '@mui/material/Switch';
+import Switch from '../Switch';
 import Profile from './Profile';
 import SettingControl from './SettingControl';
 import LanguagePicker from './LanguagePicker';
@@ -71,25 +71,13 @@ function SettingsPanel({
           label={t('settings.videoEnabled')}
           helpText={t('settings.videoEnabledHelp')}
         >
-          <Switch
-            color="primary"
-            checked={videoEnabled}
-            onChange={handleVideoEnabledChange}
-          />
+          <Switch checked={videoEnabled} onChange={handleVideoEnabledChange} />
         </SettingControl>
         <SettingControl label={t('settings.videoSize')}>
-          <Switch
-            color="primary"
-            checked={videoSize === 'large'}
-            onChange={handleVideoSizeChange}
-          />
+          <Switch checked={videoSize === 'large'} onChange={handleVideoSizeChange} />
         </SettingControl>
         <SettingControl label={t('settings.mentionSound')}>
-          <Switch
-            color="primary"
-            checked={mentionSoundEnabled}
-            onChange={handleMentionSoundChange}
-          />
+          <Switch checked={mentionSoundEnabled} onChange={handleMentionSoundChange} />
         </SettingControl>
         <SettingControl label={t('settings.language')}>
           <LanguagePicker value={language} onChange={handleLanguageChange} />

--- a/src/components/Switch/index.css
+++ b/src/components/Switch/index.css
@@ -52,7 +52,16 @@ input.Switch[type="checkbox"] {
     transform: translateX(16px);
   }
 
-  &:not(:checked):hover::after {
-    outline: 9px solid rgba(var(--mui-palette-action-activeChannel) / calc(var(--mui-palette-action-hoverOpacity)));
+  /* Draw a hover ring; :where to lower specificity */
+  &:where(:not(:checked)):hover::after {
+    outline: 9px solid rgb(from currentColor r g b / calc(var(--mui-palette-action-hoverOpacity)));
+  }
+
+  /* Draw a keyboard focus ring on the thumb */
+  &:focus-visible {
+    outline: none;
+  }
+  &:focus-visible::after {
+    outline: 9px solid rgb(from currentColor r g b / 30%);
   }
 }

--- a/src/components/Switch/index.css
+++ b/src/components/Switch/index.css
@@ -1,0 +1,58 @@
+/*
+ * Styles are from:
+ * https://github.com/mui/material-ui/blob/ba12a4c9365051da8673a1b949c306ae2a77f138/packages/mui-material/src/Switch/Switch.js
+ */
+
+input.Switch[type="checkbox"] {
+  appearance: none;
+  display: inline-flex;
+  width: 58px;
+  height: 38px;
+  padding: 12px;
+  box-sizing: border-box;
+  position: relative;
+  cursor: pointer;
+
+  /* Track */
+  &::before {
+    content: ' ';
+    width: 34px;
+    height: 14px;
+    position: absolute;
+    border-radius: 7px;
+    transition: opacity 150ms cubic-bezier(0.4, 0, 0.2, 1),
+      background-color 150ms cubic-bezier(0.4, 0, 0.2, 1);
+    background: #fff;
+    opacity: 30%;
+  }
+
+  &:checked::before {
+    background: var(--mui-palette-primary-main);
+    opacity: 50%;
+  }
+
+  /* Thumb */
+  &::after {
+    content: ' ';
+    box-shadow: var(--mui-shadows-1);
+    background-color: currentColor;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    margin-top: -3px;
+
+    color: var(--mui-palette-Switch-defaultColor);
+    transform: translateX(0px);
+    transition: color 150ms cubic-bezier(0.4, 0, 0.2, 1),
+      transform 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  &:checked::after {
+    color: var(--mui-palette-primary-main);
+    transform: translateX(16px);
+  }
+
+  &:not(:checked):hover::after {
+    outline: 9px solid rgba(var(--mui-palette-action-activeChannel) / calc(var(--mui-palette-action-hoverOpacity)));
+  }
+}

--- a/src/components/Switch/index.tsx
+++ b/src/components/Switch/index.tsx
@@ -1,0 +1,8 @@
+import cx from 'clsx';
+
+type SwitchProps = React.ComponentPropsWithoutRef<'input'>;
+export default function Switch(props: SwitchProps) {
+  return (
+    <input {...props} type="checkbox" className={cx('Switch', props.className)} />
+  );
+}

--- a/src/components/index.css
+++ b/src/components/index.css
@@ -2,6 +2,7 @@
 @import url("./App/index.css");
 @import url("./CircularProgress/index.css");
 @import url("./SvgIcon/index.css");
+@import url("./Switch/index.css");
 @import url("./Form/index.css");
 @import url("./MediaList/index.css");
 @import url("./SongTitle/index.css");


### PR DESCRIPTION
Saves about 4kB in the bundle (🤷🏻‍♀️) and quite some implementation complexity inside a simple element.

There is a small "regression" here: there's no pulsating ripple when toggling the switch.
I don't think that's super important though.