### PR TITLE
build: remove eslint-plugin-import

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,12 +1,9 @@
 import js from '@eslint/js';
-// FIXME: not sure why this happens
-// eslint-disable-next-line import/no-unresolved
 import ts from 'typescript-eslint';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
 import jsxA11y from 'eslint-plugin-jsx-a11y';
 import compat from 'eslint-plugin-compat';
-import importPlugin from 'eslint-plugin-import';
 import vitest from '@vitest/eslint-plugin';
 import jestDom from 'eslint-plugin-jest-dom';
 import testingLibrary from 'eslint-plugin-testing-library';
@@ -550,8 +547,6 @@ export default [
     },
   },
 
-  importPlugin.flatConfigs.recommended,
-  importPlugin.flatConfigs.typescript,
   compat.configs['flat/recommended'],
 
   {
@@ -634,25 +629,6 @@ export default [
     languageOptions: {
       sourceType: 'script',
       globals: globals.commonjs,
-    },
-  },
-
-  {
-    files: ['src/**/*.{mjs,cjs,js,ts,mts,cts,jsx,tsx}'],
-    rules: {
-      'import/no-extraneous-dependencies': ['error', { devDependencies: true }],
-      'import/extensions': ['error', 'ignorePackages', {
-        js: 'never',
-        mjs: 'never',
-        jsx: 'never',
-        ts: 'never',
-        tsx: 'never',
-      }],
-    },
-    settings: {
-      'import/core-modules': [
-        'virtual:emoji-shortcodes',
-      ],
     },
   },
 

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -2,7 +2,7 @@
 /// <reference types="vitest">
 import { readFile, writeFile } from 'node:fs/promises';
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react'; // eslint-disable-line import/no-unresolved
+import react from '@vitejs/plugin-react';
 import yaml from '@rollup/plugin-yaml';
 import emoji from './tasks/emoji.mjs';
 import prerender from './tasks/prerender.mjs';


### PR DESCRIPTION
TypeScript basically takes care of this...

The like only thing this loses is extraneous dependencies checking. Not a huge deal in my opinion.